### PR TITLE
Set path to apk for build_auto test

### DIFF
--- a/test/chtest/Build
+++ b/test/chtest/Build
@@ -73,11 +73,11 @@ fi
 rm img/sbin/apk.static.*
 
 # Install packages we need for our tests.
-$CH_RUN -- apk add gcc make musl-dev python3 || true
+$CH_RUN -- sbin/apk add gcc make musl-dev python3 || true
 
 # Validate the install.
-$CH_RUN -- apk audit --system
-$CH_RUN -- apk stats
+$CH_RUN -- sbin/apk audit --system
+$CH_RUN -- sbin/apk stats
 
 # Fix permissions.
 #


### PR DESCRIPTION
ch-run needs to be told where to find apk, otherwise custom build chtest
test fails thus:
   + ch-run -u0 -g0 -w --no-home /home/debian/cctest/tarballs/chtest.tmp/img -- apk add gcc make musl-dev python3
   ch-run: can't execve(2) user command: No such file or directory
   + true
   + ch-run -u0 -g0 -w --no-home /home/debian/cctest/tarballs/chtest.tmp/img -- apk audit --system
   ch-run: can't execve(2) user command: No such file or directory

This commit patches the script to use sbin/apk (which is where apk is
located inside the image).

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>