### PR TITLE
Add a further path inside /sys to test

### DIFF
--- a/test/chtest/dev_proc_sys.py
+++ b/test/chtest/dev_proc_sys.py
@@ -9,7 +9,8 @@ import sys
 sys_file = None
 for f in ("/sys/devices/cpu/rdpmc",
           "/sys/kernel/mm/page_idle/bitmap",
-          "/sys/kernel/slab/request_sock_TCP/red_zone"):
+          "/sys/kernel/slab/request_sock_TCP/red_zone",
+	  "sys/kernel/debug/kprobes/enabled"):
    if (os.path.exists(f)):
       sys_file = f
       break


### PR DESCRIPTION
On (at least) a Debian "stretch" system, the charliecloud image contains
none of the tested paths inside /sys. This patch adds one that does
exist there.

The error message is also rather confusing, which will be the subject of
another patch.