### PR TITLE
Check if a sys_file could be found

### DIFF
--- a/test/chtest/dev_proc_sys.py
+++ b/test/chtest/dev_proc_sys.py
@@ -14,16 +14,20 @@ for f in ("/sys/devices/cpu/rdpmc",
       sys_file = f
       break
 
+if sys_file is None:
+   print("WARNING\t No sys_file found to test")
+
 problem_ct = 0
 for f in ("/dev/mem", "/proc/kcore", sys_file):
-   try:
-      open(f, "rb").read(1)
-      print("RISK\t%s: read allowed" % f)
-      problem_ct += 1
-   except PermissionError:
-      print("SAFE\t%s: read not allowed" % f)
-   except OSError as x:
-      print("ERROR\t%s: exception: %s" % (f, x))
-      problem_ct += 1
+   if f is not None:
+      try:
+         open(f, "rb").read(1)
+         print("RISK\t%s: read allowed" % f)
+         problem_ct += 1
+      except PermissionError:
+         print("SAFE\t%s: read not allowed" % f)
+      except OSError as x:
+         print("ERROR\t%s: exception: %s" % (f, x))
+         problem_ct += 1
 
 sys.exit(problem_ct != 0)


### PR DESCRIPTION
Previously, if none of the things tried for sys_file exist, it remains
as None, which results in the rather unhelpful error message:

   Traceback (most recent call last):
     File "/test/dev_proc_sys.py", line 20, in <module>
       open(f, "rb").read(1)
   TypeError: expected str, bytes or os.PathLike object, not NoneType

Now we only try non-None paths, and emit a warning if sys_file is None

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>