### PR TITLE
Document the need for perm-test user to be in at least 2 groups; handle the failing case better

### DIFF
--- a/doc-src/install.rst
+++ b/doc-src/install.rst
@@ -313,7 +313,9 @@ Run
 ---
 
 The run tests require the contents of :code:`$CH_TEST_TARDIR` produced by a
-successful, complete build test. Copy this directory to the run system.
+successful, complete build test. Copy this directory to the run
+system. Additionally, the user running the tests needs to be a member
+of at least 2 groups.
 
 File permission enforcement is tested against specially constructed fixture
 directories. These should include every meaningful mounted filesystem, and

--- a/test/make-perms-test
+++ b/test/make-perms-test
@@ -69,6 +69,11 @@ for g in grp.getgrall():
       my_gid2 = g.gr_gid
       break
 
+if my_group2 is None or my_gid2 is None:
+   print("Couldn't find a second group %s is a member of!" % my_user,
+         file=sys.stderr)
+   sys.exit(1)
+
 print('''\
 test directory:     %(testdir)s
 me:                 %(my_user)s %(my_uid)d


### PR DESCRIPTION
Some users (e.g. the default user on a number of "cloud" images) are only in one group. In that case, make-perms-test will fail with the message:

Traceback (most recent call last):
  File "./make-perms-test", line 79, in <module>
    ''' % locals())
TypeError: %d format: a number is required, not NoneType

Which isn't very clear. This PR checks that a second group was found, and errors out if not; it also documents the need to be a member of at least 2 groups

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>