### PR TITLE
make image specified by relative path (#6) or symlink (#50) work

### DIFF
--- a/bin/ch-run.c
+++ b/bin/ch-run.c
@@ -135,7 +135,8 @@ int main(int argc, char * argv[])
    if (args.user_cmd_start >= argc - 1)
       fatal("NEWROOT and/or CMD not specified\n");
    assert(args.binds[USER_BINDS_MAX].src == NULL);  // overrun in argp_parse?
-   args.newroot = argv[args.user_cmd_start++];
+   args.newroot = realpath(argv[args.user_cmd_start++], NULL);
+   TRX ((args.newroot == NULL), "couldn't resolve image path");
 
    if (args.verbose) {
       fprintf(stderr, "newroot: %s\n", args.newroot);

--- a/test/run.bats
+++ b/test/run.bats
@@ -358,3 +358,15 @@ EOF
     done
 }
 
+@test 'relative path to image' {
+   # bug number 6
+   DIRNAME=$(dirname $CHTEST_IMG)
+   BASEDIR=$(basename $CHTEST_IMG)
+   cd $DIRNAME && ch-run $BASEDIR -- true
+}
+
+@test 'symlink to image' {
+   # bug number 80
+   ln -s $CHTEST_IMG $BATS_TMPDIR/symlink-test
+   ch-run $BATS_TMPDIR/symlink-test -- true
+}


### PR DESCRIPTION
Small patch to resolve relative paths for image directores.  Resolves #6 