### PR TITLE
Use /dev instead of /oldroot for the pivot_root dance.

### DIFF
--- a/bin/ch-run.c
+++ b/bin/ch-run.c
@@ -254,11 +254,13 @@ void enter_udss(char * newroot, bool writable, struct bind * binds,
       }
    }
    // Pivot into the new root
-   TRY (0 > asprintf(&path, "%s/oldroot", newroot));
+   // Directory /dev is used since it is readily available even
+   // in extremely minimal environments.
+   TRY (0 > asprintf(&path, "%s/dev", newroot));
    TRY (chdir(newroot));
    TRY (syscall(SYS_pivot_root, newroot, path));
    TRY (chroot("."));
-   TRY (umount2("/oldroot", MNT_DETACH));
+   TRY (umount2("/dev", MNT_DETACH));
 
 #ifdef SETUID
    privs_drop_temporarily();

--- a/bin/ch-tar2dir
+++ b/bin/ch-tar2dir
@@ -78,8 +78,8 @@ tar x$VERBOSE -I $GZIP_CMD -C "$NEWROOT" -f "$TARBALL" --exclude='dev/*'
 # Make all directories writeable so we can delete image later (hello, Red Hat).
 find "$NEWROOT" -type d -a ! -perm /200 -exec chmod u+w {} +
 
-# Make directories that ch-run will need.
-mkdir -p "$NEWROOT/oldroot"
+# Ensure directories that ch-run needs exist.
+mkdir -p "$NEWROOT/dev"
 for i in $(seq 0 9); do mkdir -p "$NEWROOT/mnt/$i"; done
 
 echo "$NEWROOT unpacked ok"

--- a/test/chtest/Build
+++ b/test/chtest/Build
@@ -40,7 +40,7 @@ wget $MIRROR/main/x86_64/$APK_TOOLS
 
 # Bootstrap directories.
 mkdir img
-mkdir img/{dev,etc,oldroot,proc,sys,tmp}
+mkdir img/{dev,etc,proc,sys,tmp}
 touch img/etc/{group,hosts,passwd,resolv.conf}
 
 # Bootstrap static apk.

--- a/test/run_uidgid.bats
+++ b/test/run_uidgid.bats
@@ -93,7 +93,7 @@ setup () {
     type=$(fgrep ' / ' /proc/mounts | cut -d' ' -f3)
     opts=$(fgrep ' / ' /proc/mounts | cut -d' ' -f4)
     run ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- \
-               /bin/mount -n -o $opts -t $type $dev /oldroot
+               /bin/mount -n -o $opts -t $type $dev /dev
     echo "$output"
     # return codes from http://man7.org/linux/man-pages/man8/mount.8.html
     # busybox seems to use the same list


### PR DESCRIPTION
The dance only requires an existing directory in
the image, and /dev is present in any image.
Considered alternatives: /bin might be a symlink to /usr/bin,
other images may miss /usr altogether.

Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>