### PR TITLE
Make Charliecloud more friendly for packaging.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,26 @@ export: VERSION.full
 	rm bats.tar
 	ls -lh charliecloud-$$(cat VERSION.full).tar.gz
 
-BIN=$(PREFIX)/bin
-DOC=$(PREFIX)/share/doc/charliecloud
+# PREFIX is the prefix expected at runtime (usually /usr or /usr/local
+#  for system-wide installations).
+#  More at https://www.gnu.org/prep/standards/html_node/Directory-Variables.html
+# DESTDIR is the installation directory using during make install,
+#  which usually coincides for manual installation,
+#  but is chosen to be a temporary directory in packaging
+#  environments. PREFIX needs to be appended.
+#  More at https://www.gnu.org/prep/standards/html_node/DESTDIR.html
+# Reasoning here: Users performing manual install *have* to specify PREFIX,
+# default is to use that also for DESTDIR.
+# If DESTDIR is provided in addition, we use that for installation.
+INSTALL_PREFIX := $(if $(DESTDIR),$(DESTDIR)/$(PREFIX),$(PREFIX))
+BIN=$(INSTALL_PREFIX)/bin
+DOC=$(INSTALL_PREFIX)/share/doc/charliecloud
 TEST=$(DOC)/test
 .PHONY: install
 install: all
 	@test -n "$(PREFIX)" || \
           (echo "No PREFIX specified. Lasciando ogni speranza." && false)
-	@echo Installing in $(PREFIX)
+	@echo Installing in $(INSTALL_PREFIX)
 #       binaries
 	install -d $(BIN)
 	install -pm 755 -t $(BIN) $$(find bin -type f -executable)

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,19 @@ install: all
 #       binaries
 	install -d $(BIN)
 	install -pm 755 -t $(BIN) $$(find bin -type f -executable)
-	if [ -u bin/ch-run ]; then sudo chmod u+s $(BIN)/ch-run; fi
+	# Install ch-run setuid if either SETUID=yes is specified
+	# or the binary in the build directory is setuid.
+	if [ -n "$(SETUID)" ]; then \
+            if [ $$(id -u) -eq 0 ]; then \
+	        chown root $(BIN)/ch-run; \
+	        chmod u+s $(BIN)/ch-run; \
+	    else \
+	        sudo chown root $(BIN)/ch-run; \
+	        sudo chmod u+s $(BIN)/ch-run; \
+	    fi \
+	elif [ -u bin/ch-run ]; then \
+	    sudo chmod u+s $(BIN)/ch-run; \
+	fi
 	install -pm 644 -t $(BIN) bin/base.sh bin/version.h bin/version.sh
 #       misc "documentation"
 	install -d $(DOC)

--- a/bin/Makefile
+++ b/bin/Makefile
@@ -16,6 +16,12 @@ ifdef SETUID
 export CFLAGS += -DSETUID
 all: setuid
 setuid: ch-run
-	sudo chown root $<
-	sudo chmod u+s $<
+	# Use sudo only if not already root.
+	if [ $$(id -u) -eq 0 ]; then \
+	    chown root $<; \
+	    chmod u+s $<; \
+	elif ( command -v sudo >/dev/null 2>&1 && sudo -v >/dev/null 2>&1 ); then \
+	    sudo chown root $<; \
+	    sudo chmod u+s $<; \
+	fi
 endif

--- a/bin/base.sh
+++ b/bin/base.sh
@@ -1,6 +1,7 @@
 CH_BIN="$(cd "$(dirname "$0")" && pwd)"
 
-. "$CH_BIN/version.sh"
+LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
+. ${LIBEXEC}/version.sh
 
 # Do we need sudo to run docker?
 if ( docker info > /dev/null 2>&1 ); then

--- a/bin/ch-build
+++ b/bin/ch-build
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-. $(dirname "$0")/base.sh
+LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
+. ${LIBEXEC}/base.sh
 
 usage () {
     cat 1>&2 <<EOF

--- a/bin/ch-build2dir
+++ b/bin/ch-build2dir
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-. $(dirname "$0")/base.sh
+LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
+. ${LIBEXEC}/base.sh
 
 set -e
 

--- a/bin/ch-docker-run
+++ b/bin/ch-docker-run
@@ -2,7 +2,8 @@
 
 # bash is needed for arrays.
 
-. $(dirname "$0")/base.sh
+LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
+. ${LIBEXEC}/base.sh
 
 usage () {
     cat 1>&2 <<EOF

--- a/bin/ch-docker2tar
+++ b/bin/ch-docker2tar
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-. $(dirname "$0")/base.sh
+LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
+. ${LIBEXEC}/base.sh
 
 set -e
 #set -x

--- a/bin/ch-tar2dir
+++ b/bin/ch-tar2dir
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-. $(dirname "$0")/base.sh
+LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
+. ${LIBEXEC}/base.sh
 
 usage () {
     cat 1>&2 <<EOF


### PR DESCRIPTION
Up to now, Charliecloud is perfect for the main design goal,
which is installation and usage by users.
For system-wide installation or packaging, several issues occur,
which are resolved by this commit.
Default behaviour is unchanged, but packagers
or system maintainers can specify not to install examples,
tests and documentation.
Also, an extra flag allows to disable setting SUID
during build, which usually runs unprivileged,
but only during install, which runs privileged
(in common packaging environments). 

Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>