### PR TITLE
Support read-only FS which don't support remounting.

### DIFF
--- a/bin/ch-run.c
+++ b/bin/ch-run.c
@@ -246,7 +246,7 @@ void enter_udss(char * newroot, bool writable, struct bind * binds,
    TRY (chroot("."));
    TRY (0 > asprintf(&newroot, "/%s", base));
 
-   if (!writable) {
+   if (!writable && !(access(newroot, W_OK) == -1 && errno == EROFS)) {
       // Re-mount image read-only
       if (mount(NULL, newroot, NULL, MS_REMOUNT | MS_BIND | MS_RDONLY, NULL)) {
          fatal("can't re-mount image read-only (is it on NFS?): %s\n",


### PR DESCRIPTION
When FS is read-only, we don't need to remount
read-only.
This fixes support e.g. for FUSE filesystems
which are already mounted read-only,
but don't support being remounted.

Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>

Fixes #56 