### PR TITLE
Perform argument evaluation as calling user unless SETUID.

### DIFF
--- a/bin/ch-run.c
+++ b/bin/ch-run.c
@@ -377,8 +377,9 @@ void privs_verify_invoking()
    TRY (getresuid(&ruid, &euid, &suid));
    TRY (getresgid(&rgid, &egid, &sgid));
 
-   // GIDs should be unprivileged and non-setgid regardless of mode.
-   TRY (egid == 0);
+   // GIDs should be unprivileged unless called by root,
+   // and non-setgid regardless of mode.
+   TRY (!(ruid == 0 && rgid == 0) && egid == 0);
    TRY (egid != rgid || egid != sgid);
 
 #ifdef SETUID

--- a/test/run.bats
+++ b/test/run.bats
@@ -89,6 +89,17 @@ load common
     sudo rm $CH_RUN_TMP
 }
 
+@test 'ch-run (--help|--version) works as privileged user unless setuid mode' {
+    [[ -z $CH_RUN_SETUID ]] || skip 'compiled in setuid mode'
+    [[ -n $CHTEST_HAVE_SUDO ]] || skip 'sudo not available'
+    run sudo $CH_RUN_FILE --version
+    echo "$output"
+    [[ $status -eq 0 ]]
+    run sudo $CH_RUN_FILE --help
+    echo "$output"
+    [[ $status -eq 0 ]]
+}
+
 @test 'ch-run -u and -g refused in setuid mode' {
     [[ -n $CH_RUN_SETUID ]] || skip 'not compiled for setuid'
     run ch-run -u 65534


### PR DESCRIPTION
This is a suggestion for #71 . I am not sure this is the best approach, or which approach would be better... 

If we are SETUID, check invoking privs and drop privs,
if not, perform argument parsing and handling as the
calling user.
Check invoking user's privileges only after that,
before actually taking action.

Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>