### PR TITLE
replace TRY and TRX macros with new macros

### DIFF
--- a/bin/ch-ssh.c
+++ b/bin/ch-ssh.c
@@ -59,8 +59,8 @@ int main(int argc, char * argv[])
 
    // insert ch-run command
    ch_run_args = getenv("CH_RUN_ARGS");
-   if (ch_run_args == NULL)
-      fatal("CH_RUN_ARGS not set\n");
+   Te (ch_run_args != NULL, "CH_RUN_ARGS not set");
+
    args[i] = "ch-run";
    for (j = 1; i + j < ARGS_MAX; j++, ch_run_args = NULL) {
       args[i+j] = strtok(ch_run_args, " ");
@@ -76,5 +76,5 @@ int main(int argc, char * argv[])
    //   printf("%d: %s\n", i, args[i]);
 
    execvp("ssh", args);
-   fatal("can't execute ssh: %s\n", strerror(errno));
+   Tf (0, "can't execute ssh");
 }

--- a/bin/charliecloud.c
+++ b/bin/charliecloud.c
@@ -9,24 +9,31 @@
 
 #include "version.h"
 
-/* Print a formatted error message on stderr, then exit unsuccessfully. */
-void fatal(char * fmt, ...)
+
+/* Print a formatted error message on stderr, followed by the string expansion
+   of errno, source file, line number, errno, and newline; then exit
+   unsuccessfully. If errno is zero, then don't include it, because then it
+   says "success", which is super confusing in an error message. */
+void fatal(char * file, int line, int errno_, char * fmt, ...)
 {
    va_list ap;
 
-   fprintf(stderr, "%s: ", program_invocation_short_name);
-   va_start(ap, fmt);
-   vfprintf(stderr, fmt, ap);
-   va_end(ap);
-   exit(EXIT_FAILURE);
-}
+   fputs(program_invocation_short_name, stderr);
+   fputs(": ", stderr);
 
-/* Report the string expansion of errno on stderr, then exit unsuccessfully. */
-void fatal_errno(char * msg, char * file, int line)
-{
-   if (msg == NULL)
-      msg = "error";
-   fatal("%s: %s (%s:%d:%d)\n", msg, strerror(errno), file, line, errno);
+   if (fmt == NULL)
+      fputs("error", stderr);
+   else {
+      va_start(ap, fmt);
+      vfprintf(stderr, fmt, ap);
+      va_end(ap);
+   }
+
+   if (errno)
+      fprintf(stderr, ": %s (%s:%d %d)\n", strerror(errno), file, line, errno);
+   else
+      fprintf(stderr, " (%s:%d)\n", file, line);
+   exit(EXIT_FAILURE);
 }
 
 /* Report the version number. */

--- a/bin/charliecloud.h
+++ b/bin/charliecloud.h
@@ -1,15 +1,47 @@
 /* Copyright © Los Alamos National Security, LLC, and others. */
 
-/* Test some result: if not zero, exit with an error. This is a macro so we
-   have access to the file and line number.
+/* Test some value, and if it's not what we expect, exit with an error. These
+   are macros so we have access to the file and line number.
 
-   Note: This macro is sometimes used for things other than system calls. If
-   errno is not set when the program aborts, the resulting error message will
-   say "error: Success", which is very confusing. Thus, make sure that users
-   won't see those. */
-#define TRY(x) if (x) fatal_errno(NULL, __FILE__, __LINE__)
-#define TRX(x, msg) if (x) fatal_errno(msg, __FILE__, __LINE__)
+                     verify x is true (non-zero); otherwise print then exit:
+     T_ (x)            default error message including file, line, errno
+     Tf (x, fmt, ...)  printf-style message followed by file, line, errno
+     Te (x, fmt, ...)  same without errno
 
-void fatal(char * fmt, ...);
-void fatal_errno(char * msg, char * file, int line);
+                     verify x is zero (false); otherwise print as above & exit
+     Z_ (x)
+     Zf (x, fmt, ...)
+     Ze (x, fmt, ...)
+
+   errno is omitted if it's zero.
+
+   Examples:
+
+     Z_ (chdir("/does/not/exist"));
+       -> ch-run: error: No such file or directory (ch-run.c:138 2)
+     Zf (chdir("/does/not/exist"), "foo");
+       -> ch-run: foo: No such file or directory (ch-run.c:138 2)
+     Ze (chdir("/does/not/exist"), "foo");
+       -> ch-run: foo (ch-run.c:138)
+     errno = 0;
+     Zf (0, "foo");
+       -> ch-run: foo (ch-run.c:138)
+
+   Typically, Z_ and Zf are used to check system and standard library calls,
+   while T_ and Tf are used to assert developer-specified conditions.
+
+   errno is not altered by these macros unless they exit the program.
+
+   FIXME: It would be nice if we could collapse these to fewer macros.
+   However, when looking into that I ended up in preprocessor black magic
+   (e.g. https://stackoverflow.com/a/2308651) that I didn't understand. */
+#define T_(x) if (!(x)) fatal(__FILE__, __LINE__, errno, NULL)
+#define Tf(x, ...) if (!(x)) fatal(__FILE__, __LINE__, errno, __VA_ARGS__)
+#define Te(x, ...) if (!(x)) fatal(__FILE__, __LINE__, 0, __VA_ARGS__)
+#define Z_(x) if (x) fatal(__FILE__, __LINE__, errno, NULL)
+#define Zf(x, ...) if (x) fatal(__FILE__, __LINE__, errno, __VA_ARGS__)
+#define Ze(x, ...) if (x) fatal(__FILE__, __LINE__, 0, __VA_ARGS__)
+
+
+void fatal(char * file, int line, int errno_, char * fmt, ...);
 void version(void);

--- a/test/run.bats
+++ b/test/run.bats
@@ -68,7 +68,7 @@ load common
     run $CH_RUN_TMP --version
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'ch-run.setgid: error: Success' ]]
+    [[ $output =~ 'ch-run.setgid: error (' ]]
     rm $CH_RUN_TMP
 }
 
@@ -85,7 +85,7 @@ load common
     run $CH_RUN_TMP --version
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'ch-run.setuid: error: Success' ]]
+    [[ $output =~ 'ch-run.setuid: error (' ]]
     sudo rm $CH_RUN_TMP
 }
 
@@ -115,7 +115,7 @@ load common
     run sudo -u root -g $(id -gn) $CH_RUN_FILE -v --version
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'error: Success' ]]
+    [[ $output =~ 'error (' ]]
 }
 
 @test 'ch-run -u and -g refused in setuid mode' {
@@ -299,7 +299,7 @@ EOF
     run ch-run -b0 -b1 -b2 -b3 -b4 -b5 -b6 -b7 -b8 -b9 -b10 $CHTEST_IMG -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = 'ch-run: --bind can be used at most 10 times' ]]
+    [[ $output =~ 'ch-run: --bind can be used at most 10 times' ]]
 
     # no argument to --bind
     run ch-run $CHTEST_IMG -b
@@ -311,53 +311,53 @@ EOF
     run ch-run -b '' $CHTEST_IMG -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = 'ch-run: --bind: no source provided' ]]
+    [[ $output =~ 'ch-run: --bind: no source provided' ]]
 
     # source not provided
     run ch-run -b :/mnt/9 $CHTEST_IMG -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = 'ch-run: --bind: no source provided' ]]
+    [[ $output =~ 'ch-run: --bind: no source provided' ]]
 
     # destination not provided
     run ch-run -b $IMGDIR/bind1: $CHTEST_IMG -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = 'ch-run: --bind: no destination provided' ]]
+    [[ $output =~ 'ch-run: --bind: no destination provided' ]]
 
     # source does not exist
     run ch-run -b $IMGDIR/hoops $CHTEST_IMG -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    r='^ch-run: could not bind .+/hoops to /mnt/0: No such file or directory$'
+    r='^ch-run: could not bind .+/hoops to /mnt/0: No such file or directory'
     [[ $output =~ $r ]]
 
     # destination does not exist
     run ch-run -b $IMGDIR/bind1:/goops $CHTEST_IMG -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    r='^ch-run: could not bind .+/bind1 to /goops: No such file or directory$'
+    r='^ch-run: could not bind .+/bind1 to /goops: No such file or directory'
     [[ $output =~ $r ]]
 
     # neither source nor destination exist
     run ch-run -b $IMGDIR/hoops:/goops $CHTEST_IMG -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    r='^ch-run: could not bind .+/hoops to /goops: No such file or directory$'
+    r='^ch-run: could not bind .+/hoops to /goops: No such file or directory'
     [[ $output =~ $r ]]
 
     # correct bind followed by source does not exist
     run ch-run -b $IMGDIR/bind1:/mnt/9 -b $IMGDIR/hoops $CHTEST_IMG -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    r='^ch-run: could not bind .+/hoops to /mnt/1: No such file or directory$'
+    r='^ch-run: could not bind .+/hoops to /mnt/1: No such file or directory'
     [[ $output =~ $r ]]
 
     # correct bind followed by destination does not exist
     run ch-run -b $IMGDIR/bind1 -b $IMGDIR/bind2:/goops $CHTEST_IMG -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    r='^ch-run: could not bind .+/bind2 to /goops: No such file or directory$'
+    r='^ch-run: could not bind .+/bind2 to /goops: No such file or directory'
     [[ $output =~ $r ]]
 }
 


### PR DESCRIPTION
This pull request addresses #75 by replacing `TRY` and `TRX` with six new macros. As a side benefit, a few instances of ad-hoc error handling are replaced as well.

@jlowellwofford, @olifre, you've been writing Charliecloud code recently if you'd like to do the review but no obligation of course.