### PR TITLE
Add -c|--cd to specify container's initial working directory.

### DIFF
--- a/bin/ch-run.c
+++ b/bin/ch-run.c
@@ -68,6 +68,7 @@ const struct argp_option options[] = {
      "mount SRC at guest DST (default /mnt/0, /mnt/1, etc.)"},
    { "write",       'w', 0,     0, "mount image read-write"},
    { "no-home",      -2, 0,     0, "do not bind-mount your home directory"},
+   { "cd",          'c', "DIR", 0, "initial working directory in container"},
 #ifndef SETUID
    { "gid",         'g', "GID", 0, "run as GID within container" },
 #endif
@@ -92,6 +93,7 @@ struct args {
    gid_t container_gid;
    uid_t container_uid;
    char * newroot;
+   char * initial_working_dir;
    bool private_home;
    bool private_tmp;
    bool writable;
@@ -127,6 +129,7 @@ int main(int argc, char * argv[])
    memset(args.binds, 0, sizeof(args.binds));
    args.container_gid = getgid();
    args.container_uid = getuid();
+   args.initial_working_dir = NULL;
    args.private_home = false;
    args.private_tmp = false;
    args.verbose = 0;
@@ -266,6 +269,9 @@ void enter_udss(char * newroot, bool writable, struct bind * binds,
 #ifdef SETUID
    privs_drop_temporarily();
 #endif
+
+   if (args.initial_working_dir != NULL)
+      TRY (chdir(args.initial_working_dir));
 }
 
 /* If verbose, print uids and gids on stderr prefixed with where. */
@@ -313,7 +319,10 @@ static error_t parse_opt(int key, char * arg, struct argp_state * state)
       break;
    case -2:
       as->private_home = true;
-   break;
+      break;
+   case 'c':
+      as->initial_working_dir = arg;
+      break;
    case 'b':
       for (i = 0; as->binds[i].src != NULL; i++)
          ;

--- a/test/run.bats
+++ b/test/run.bats
@@ -361,6 +361,24 @@ EOF
     [[ $output =~ $r ]]
 }
 
+@test '--cd' {
+    # Default initial working directory is /.
+    initial_wd=$(ch-run $CHTEST_IMG -- pwd)
+    [[ $status -eq 0 ]]
+    [[ $initial_wd = '/' ]]
+
+    # Specify initial working directory.
+    initial_wd=$(ch-run --cd /dev $CHTEST_IMG -- pwd)
+    [[ $status -eq 0 ]]
+    [[ $initial_wd = '/dev' ]]
+
+    # Error if directory does not exist.
+    run ch-run --cd /notexisting $CHTEST_IMG -- true
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output =~ 'ch-run: error: No such file or directory' ]]
+}
+
 @test '/usr/bin/ch-ssh' {
     ls -l $CH_BIN/ch-ssh
     ch-run $CHTEST_IMG -- ls -l /usr/bin/ch-ssh


### PR DESCRIPTION
Default remains /.

This fixes #72 .

Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>