### PR TITLE
Use findmnt to extract details of / rather than grepping /proc/mounts

### DIFF
--- a/test/run_uidgid.bats
+++ b/test/run_uidgid.bats
@@ -89,9 +89,9 @@ setup () {
     #     over-mount something else.
     ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- \
            sh -c '[ -f /bin/mount -a -x /bin/mount ]'
-    dev=$(fgrep ' / ' /proc/mounts | cut -d' ' -f1)
-    type=$(fgrep ' / ' /proc/mounts | cut -d' ' -f3)
-    opts=$(fgrep ' / ' /proc/mounts | cut -d' ' -f4)
+    dev=$(findmnt -n -o SOURCE -T /)
+    type=$(findmnt -n -o FSTYPE -T /)
+    opts=$(findmnt -n -o OPTIONS -T /)
     run ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- \
                /bin/mount -n -o $opts -t $type $dev /mnt/0
     echo "$output"


### PR DESCRIPTION
On some systems (e.g. RHEL 7.4 in OpenStack) there are two lines for /
in /proc/mounts:

```
[cloud-user@mv3-rh74-charliecloud ~]$ fgrep ' / ' /proc/mounts
rootfs / rootfs rw 0 0
/dev/vda1 / xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
```

This means that the mount invocation at `run_uidgid.bats` line 95 fails
as there are newlines embedded in the command arguments.

`findmnt`(8) is a command designed for the task of finding out about
mounted filesystems and has been in util-linux for a fair while, so
use that instead.

Signed-off-by: Matthew Vernon <mv3@sanger.ac.uk>