### PR TITLE
Do not fail if PATH is not set.

### DIFF
--- a/bin/ch-run.c
+++ b/bin/ch-run.c
@@ -475,8 +475,11 @@ void run_user_command(int argc, char * argv[], int user_cmd_start)
    argv[argc - user_cmd_start] = NULL;
 
    // Append /bin to $PATH if not already present. See FAQ.
-   TRY (NULL == (old_path = getenv("PATH")));
-   if (strstr(old_path, "/bin") != old_path && !strstr(old_path, ":/bin")) {
+   old_path = getenv("PATH");
+   if (old_path == NULL) {
+      if (args.verbose)
+         fprintf(stderr, "$PATH is not set, leaving it unset\n");
+   } else if (strstr(old_path, "/bin") != old_path && !strstr(old_path, ":/bin")) {
       TRY (0 > asprintf(&new_path, "%s:/bin", old_path));
       TRY (setenv("PATH", new_path, 1));
       if (args.verbose)

--- a/test/run.bats
+++ b/test/run.bats
@@ -187,6 +187,16 @@ load common
     [[ $output = $PATH2:/bin ]]
 }
 
+@test 'ch-run works if $PATH not set, leaves it unset' {
+    BACKUP_PATH=$PATH
+    unset PATH
+    run $CH_RUN_FILE $CHTEST_IMG -- /usr/bin/python3 -c 'import os; print(os.getenv("PATH") is None)'
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = "True" ]]
+    PATH=$BACKUP_PATH
+}
+
 @test 'mountns id differs' {
     host_ns=$(stat -Lc '%i' /proc/self/ns/mnt)
     echo "host:  $host_ns"


### PR DESCRIPTION
Previously, we failed if PATH was not set,
since a check was performed before applying
the /bin workaround.
Now, just set PATH to /bin is it was unset before.

Fixes #80 and also includes the appropriate test.

Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>