### PR TITLE
add warning about Cray patch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,10 @@ addresses needs such as:
 
 * usability and comprehensibility.
 
+**WARNING: Cray CLE in recent versions** has a bug that crashes nodes when
+cleaning up after some jobs, including if Charliecloud has been used. See the
+installation instructions for a workaround.
+
 How does it work?
 -----------------
 

--- a/doc-src/install.rst
+++ b/doc-src/install.rst
@@ -1,6 +1,15 @@
 Installation
 ************
 
+.. warning::
+
+   **If you are installing on a Cray** and have not applied the patch for Cray
+   case #188073, you must use the `cray branch
+   <https://github.com/hpc/charliecloud/compare/cray>`_ to avoid crashing
+   nodes during job completion. This is a Cray bug that Charliecloud happens
+   to tickle. Non-Cray build boxes and others at the same site can still use
+   the master branch.
+
 .. contents::
    :depth: 2
    :local:


### PR DESCRIPTION
Addresses #89.

This is how it looks in the browser:

![screenshot-2017-11-17 1 installation charliecloud 0 2 3 pre documentation](https://user-images.githubusercontent.com/1682574/32974388-ce86aeaa-cbba-11e7-8e83-a3dba7b17ba1.png)
