### PR TITLE
clarify where to ssh into the VM. and a typo in tutorial

### DIFF
--- a/doc-src/tutorial.rst
+++ b/doc-src/tutorial.rst
@@ -356,7 +356,7 @@ container, even if :code:`ssh` was initiated from a container::
   > ssh localhost stat -L --format='%i' /proc/self/ns/user
   4026531837
 
-There are several ways to SSH to a remote note and run commands inside a
+There are several ways to SSH to a remote node and run commands inside a
 container. The simplest is to manually invoke :code:`ch-run` in the
 :code:`ssh` command::
 

--- a/doc-src/virtualbox.rst
+++ b/doc-src/virtualbox.rst
@@ -74,9 +74,9 @@ Log in and try Charliecloud
 
    $ sudo passwd charlie
 
-5. SSH into the VM using the password you just set. (Accessing the VM using
-   SSH rather than the console is generally more pleasant, because you have a
-   nice terminal with native copy-and-paste, etc.)
+5. SSH (from terminal on the host) into the VM using the password you just set.
+   (Accessing the VM using SSH rather than the console is generally more
+   pleasant, because you have a nice terminal with native copy-and-paste, etc.)
 
 ::
 


### PR DESCRIPTION
I added a small comment when using a VM. I don't know if anyone else will try the ssh command in the console like I did, but I think this clarifies it a bit more. Also there was a typo in the tutorial.