### PR TITLE
Spack example

### DIFF
--- a/examples/other/spack/Dockerfile
+++ b/examples/other/spack/Dockerfile
@@ -1,12 +1,15 @@
 # ch-test-scope: full
-FROM debian:stretch
+FROM debian9
 
-# Install required OS packages and Spack dependencies.
-# Note: Spack needs curl, git, make, and unzip to install.
-# The other packages (patch, procps, python-pkg-resources, etc.)
-# are needed for Spack unit tests
-RUN apt-get update \
-    && apt-get install -y \
+# Note: Spack is a bit of an odd duck testing wise. Because it's a package
+# manager, the key tests we want are to install stuff (this includes the Spack
+# test suite), and those don't make sense at run time. Thus, most of what we
+# care about is here in the Dockerfile, and test.bats just has a few
+# trivialities.
+
+# Spack needs curl, git, make, and unzip to install.
+# The other packages are needed for Spack unit tests.
+RUN apt-get install -y \
     curl \
     g++ \
     git \
@@ -15,12 +18,29 @@ RUN apt-get update \
     procps \
     python \
     python-pkg-resources \
-    unzip \
-    && rm -rf /var/lib/apt/lists/*
+    unzip
 
-# Install Spack
-WORKDIR /
-ENV SPACK_URL https://github.com/spack/spack.git
-ENV SPACK_ROOT /spack
-ENV PATH $SPACK_ROOT/bin:$PATH
-RUN git clone $SPACK_URL
+# Install Spack. This follows the documented procedure to run it out of the
+# source directory. There apparently is no "make install" type operation to
+# place it at a standard path ("spack clone" simply clones another working
+# directory to a new path).
+ENV SPACK_REPO https://github.com/spack/spack
+ENV SPACK_VERSION 0.11.2
+RUN git clone --depth 1 $SPACK_REPO
+#RUN git clone --branch v$SPACK_VERSION --depth 1 $SPACK_REPO
+
+# Set up environment to use Spack. (We can't use setup-env.sh because the
+# Dockerfile shell is sh, not Bash.)
+ENV PATH /spack/bin:$PATH
+RUN spack compilers
+
+# Test: Install a small package.
+RUN spack install libsigsegv
+
+# Test: Run Spack test suite.
+# FIXME: Commented out because the suite fails. It's inconsistent; the number
+# of failures seems to vary between about 1 and 3 inclusive.
+#RUN spack test
+
+# Clean up.
+RUN spack clean --all

--- a/examples/other/spack/Dockerfile
+++ b/examples/other/spack/Dockerfile
@@ -1,0 +1,26 @@
+# ch-test-scope: full
+FROM debian:stretch
+
+# Install required OS packages and Spack dependencies.
+# Note: Spack needs curl, git, make, and unzip to install.
+# The other packages (patch, procps, python-pkg-resources, etc.)
+# are needed for Spack unit tests
+RUN apt-get update \
+    && apt-get install -y \
+    curl \
+    g++ \
+    git \
+    make \
+    patch \
+    procps \
+    python \
+    python-pkg-resources \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Spack
+WORKDIR /
+ENV SPACK_URL https://github.com/spack/spack.git
+ENV SPACK_ROOT /spack
+ENV PATH $SPACK_ROOT/bin:$PATH
+RUN git clone $SPACK_URL

--- a/examples/other/spack/test.bats
+++ b/examples/other/spack/test.bats
@@ -4,21 +4,17 @@ setup() {
     scope full
     prerequisites_ok spack
     SPACK_IMG=$IMGDIR/spack
-    SPACK_BIN=/spack/bin
-    SPACK_ENV=/spack/share/spack/setup-env.sh
+    export PATH=/spack/bin:$PATH
 }
 
-@test "$EXAMPLE_TAG/unittests" {
-    # Run Spack unit tests
-    ch-run -w --no-home -c $SPACK_BIN $SPACK_IMG -- bash -c ". $SPACK_ENV && ./spack test"
+@test "$EXAMPLE_TAG/version" {
+    ch-run $SPACK_IMG -- spack --version
 }
 
-@test "$EXAMPLE_TAG/installpackage" {
-    # Install a small package 
-    ch-run -w --no-home -c $SPACK_BIN $SPACK_IMG -- bash -c ". $SPACK_ENV && ./spack install libsigsegv"
+@test "$EXAMPLE_TAG/compilers" {
+    ch-run $SPACK_IMG -- spack compilers
 }
 
-@test "$EXAMPLE_TAG/clean" {
-    # revert image back to orginal
-    ch-tar2dir $TARDIR/spack.tar.gz $IMGDIR
+@test "$EXAMPLE_TAG/spec" {
+    ch-run $SPACK_IMG -- spack spec netcdf
 }

--- a/examples/other/spack/test.bats
+++ b/examples/other/spack/test.bats
@@ -1,0 +1,24 @@
+load ../../../test/common
+
+setup() {
+    scope full
+    prerequisites_ok spack
+    SPACK_IMG=$IMGDIR/spack
+    SPACK_BIN=/spack/bin
+    SPACK_ENV=/spack/share/spack/setup-env.sh
+}
+
+@test "$EXAMPLE_TAG/unittests" {
+    # Run Spack unit tests
+    ch-run -w --no-home -c $SPACK_BIN $SPACK_IMG -- bash -c ". $SPACK_ENV && ./spack test"
+}
+
+@test "$EXAMPLE_TAG/installpackage" {
+    # Install a small package 
+    ch-run -w --no-home -c $SPACK_BIN $SPACK_IMG -- bash -c ". $SPACK_ENV && ./spack install libsigsegv"
+}
+
+@test "$EXAMPLE_TAG/clean" {
+    # revert image back to orginal
+    ch-tar2dir $TARDIR/spack.tar.gz $IMGDIR
+}


### PR DESCRIPTION
For issue #130 

This PR has improvements over the older (now closed) PR #141

1. Test time optimizations (down to 20 minutes from 2 hours)
2. Rebased around master properly


Removed unnecessary bootstrap command and redundant package installation. Building the Spack environment was unnecessary for unit tests and simple package installation demonstration purposes. The total test time (including a fresh image build) has been reduced to approximately 20 minutes, see below:

```
 ✓ spack/unittests
 ✓ spack/installpackage
 ✓ spack/clean

3 tests, 0 failures

real	12m46.262s
user	7m42.453s
sys	1m36.111s

```
The script used contained the following:

```
ch-build -t spack . \
&& ch-docker2tar spack /var/tmp/images \
&& ch-tar2dir /var/tmp/tarballs/spack.tar.gz /var/tmp/images/ \
&& ../../../test/bats/bin/bats test.bats
```


 