### PR TITLE
fix OpenMPI examples to work on Omni-Path clusters

### DIFF
--- a/doc-src/tutorial.rst
+++ b/doc-src/tutorial.rst
@@ -588,11 +588,14 @@ this with two chained Dockerfiles. First, we build a basic Debian image
    :language: docker
    :lines: 2-
 
-Then, we add OpenMPI with :code:`test/Dockerfile.openmpi`:
+Then, we add OpenMPI with :code:`test/Dockerfile.openmpi`. This is a complex
+Dockerfile that compiles several dependencies in addition to OpenMPI. For the
+purposes of this tutorial, you can skip most of it, but we felt it would be
+useful to show a real example.
 
 .. literalinclude:: ../test/Dockerfile.openmpi
    :language: docker
-   :lines: 2-50
+   :lines: 2-
 
 So what is going on here?
 
@@ -600,14 +603,17 @@ So what is going on here?
 
 2. Install a basic build system using the OS package manager.
 
-3. Download and untar OpenMPI. Note the use of variables to make adjusting the
-   URL and MPI version easier, as well as the explanation of why we're not
-   using :code:`apt-get`, given that OpenMPI is included in Debian.
+3. For a few dependencies and then OpenMPI itself:
 
-4. Build and install OpenMPI. Note the :code:`getconf` trick to guess at an
-   appropriate parallel build.
+   1. Download and untar. Note the use of variables to make adjusting the URL
+      and versions easier, as well as the explanation of why we're not using
+      :code:`apt-get`, given that several of these packages are included in
+      Debian.
 
-5. Clean up, in order to reduce the size of layers as well as the resulting
+   2. Build and install OpenMPI. Note the :code:`getconf` trick to guess at an
+      appropriate parallel build.
+
+4. Clean up, in order to reduce the size of layers as well as the resulting
    Charliecloud tarball (:code:`rm -Rf`).
 
 .. Finally, because it's a container image, you can be less tidy than you
@@ -798,11 +804,7 @@ parameters specifying the configuration path.
 
 The approach used in our example is to set the configuration directory to
 :code:`/mnt/0`. This is done in :code:`openmpi` (and hence
-:code:`mpihello`) with the :code:`--sysconfdir` argument:
-
-.. literalinclude:: ../test/Dockerfile.openmpi
-   :language: docker
-   :lines:    39-49
+:code:`mpihello`) with the :code:`--sysconfdir` argument (see above).
 
 The effect is that the image contains a default MPI configuration, but if you
 specify a different configuration directory with :code:`--bind`, that is

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -1,14 +1,18 @@
 # ch-test-scope: full
 FROM debian9
+WORKDIR /usr/local/src
 
 # OS packages needed to build OpenMPI.
 RUN apt-get install -y \
+    devscripts \
     file \
     flex \
     g++ \
     gcc \
     gfortran \
+    git \
     hwloc-nox \
+    ibverbs-utils \
     less \
     libdb5.3-dev \
     libfabric-dev \
@@ -19,6 +23,22 @@ RUN apt-get install -y \
     libpsm-infinipath1-dev \
     make \
     wget
+
+# Install libpsm2, which is needed for OPA. These packages don't appear to be
+# available anywhere in binary form as of 2018-05-24 [1], so compile from
+# source.
+#
+# Note that libpsm2 is x86_64 only [2].
+#
+# [1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=862313
+# [2]: https://lists.debian.org/debian-hpc/2017/12/msg00015.html
+ENV PSM2_VERSION 10.3-37-1
+RUN git clone --branch debian/${PSM2_VERSION} --depth 1 \
+              https://salsa.debian.org/hpc-team/libpsm2.git
+RUN    cd libpsm2 \
+    && debuild -i -us -uc -b
+RUN dpkg --install libpsm2-2_${PSM2_VERSION}_amd64.deb \
+                   libpsm2-dev_${PSM2_VERSION}_amd64.deb
 
 # Compile OpenMPI. We can't use the Debian package because we need a specific
 # version and we need to build a little differently:
@@ -33,7 +53,6 @@ RUN apt-get install -y \
 #
 ENV MPI_URL https://www.open-mpi.org/software/ompi/v2.1/downloads
 ENV MPI_VERSION 2.1.2
-WORKDIR /usr/src
 RUN wget -nv ${MPI_URL}/openmpi-${MPI_VERSION}.tar.gz
 RUN tar xf openmpi-${MPI_VERSION}.tar.gz
 RUN    cd openmpi-${MPI_VERSION} \
@@ -45,6 +64,7 @@ RUN    cd openmpi-${MPI_VERSION} \
                    --with-pmi \
                    --with-pmi-libdir=/usr/lib/x86_64-linux-gnu \
                    --with-pmix \
+                   --with-psm2 \
                    --with-slurm=no \
     && make -j$(getconf _NPROCESSORS_ONLN) install
 RUN rm -Rf openmpi-${MPI_VERSION}*

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -1,9 +1,60 @@
 # ch-test-scope: full
 FROM debian9
-WORKDIR /usr/local/src
 
-# OS packages needed to build OpenMPI.
-RUN apt-get install -y \
+# A key goal of this Dockerfile is to demonstrate best practices for building
+# OpenMPI for use inside a container.
+#
+# This OpenMPI aspires to work close to optimally on clusters with any of the
+# following interconnects:
+#
+#    - Ethernet (TCP/IP)
+#    - InfiniBand (IB)
+#    - Omni-Path (OPA)
+#    - RDMA over Converged Ethernet (RoCE) interconnects
+#
+# with no environment variables, command line arguments, or additional
+# configuration files. Thus, we try to implement decisions at build time.
+#
+# This is a work in progress, and we're very interested in feedback.
+#
+# OpenMPI has numerous ways to communicate messages [1]. The ones relevant to
+# this build and the interconnects they support are:
+#
+#   Module        Eth   IB    OPA   RoCE    note  decision
+#   ------------  ----  ----  ----  ----    ----  --------
+#
+#   ob1 : tcp      Y*    X     X     X      a     include
+#   ob1 : openib   N     Y     Y     Y      b,c   exclude
+#   cm  : psm2     N     N     Y*    N            include
+#       : ucx      Y?    Y*    N     Y?     b,d   include
+#
+#   Y : supported
+#   Y*: best choice for that interconnect
+#   X : supported but sub-optimal
+#
+#   a : No RDMA, so performance will suffer.
+#   b : Uses libibverbs.
+#   c : Will be removed in OpenMPI 4.
+#   d : Uses Mellanox libraries if available in preference to libibverbs.
+#
+# The other build decisions are:
+#
+#   1. PMI/PMIx: Include these so that we can use srun or any other PMI[x]
+#      provider, with no matching OpenMPI needed on the host.
+#
+#   2. --disable-pty-support to avoid "pipe function call failed when
+#      setting up I/O forwarding subsystem".
+#
+#   3. --with-slurm=no so mpirun in the container doesn't try use Slurm to
+#      launch processes, which will fail in inscrutable ways e.g. if srun is
+#      not found. (If you do want Slurm launching processes, use srun or
+#      mpirun outside the container.)
+#
+# [1]: https://github.com/open-mpi/ompi/blob/master/README
+
+# OS packages needed to build this stuff.
+RUN apt-get install -y --no-install-suggests \
+    cmake \
     devscripts \
     file \
     flex \
@@ -12,21 +63,27 @@ RUN apt-get install -y \
     gfortran \
     git \
     hwloc-nox \
-    ibverbs-utils \
     less \
     libdb5.3-dev \
-    libfabric-dev \
     libhwloc-dev \
-    libibverbs-dev \
+    libnl-3-dev \
+    libnl-route-3-dev \
     libnuma-dev \
     libpmi2-0-dev \
-    libpsm-infinipath1-dev \
+    libsystemd-dev \
+    libudev-dev \
     make \
-    wget
+    ninja-build \
+    pandoc \
+    pkg-config \
+    wget \
+    udev \
+    valgrind
 
-# Install libpsm2, which is needed for OPA. These packages don't appear to be
-# available anywhere in binary form as of 2018-05-24 [1], so compile from
-# source.
+WORKDIR /usr/local/src
+
+# libpsm2. These packages don't appear to be available anywhere in binary form
+# as of 2018-05-24 [1], so compile from source.
 #
 # Note that libpsm2 is x86_64 only [2].
 #
@@ -40,19 +97,30 @@ RUN    cd libpsm2 \
 RUN dpkg --install libpsm2-2_${PSM2_VERSION}_amd64.deb \
                    libpsm2-dev_${PSM2_VERSION}_amd64.deb
 
-# Compile OpenMPI. We can't use the Debian package because we need a specific
-# version and we need to build a little differently:
-#
-#   1. --disable-pty-support to avoid "pipe function call failed when
-#      setting up I/O forwarding subsystem".
-#
-#   2. --with-slurm=no so mpirun in the container doesn't try use Slurm to
-#       launch processes, which will fail in inscrutable ways e.g. if srun is
-#       not found. (If you do want Slurm launching processes, use srun or
-#       mpirun outside the container.)
-#
+# libibverbs. The packages in Stretch are old, and they aren't seeing OPA. See
+# https://packages.debian.org/source/sid/rdma-core for what the various
+# packages are.
+ENV IBVERBS_VERSION 18.0-1
+RUN git clone --branch debian/${IBVERBS_VERSION} --depth 1 \
+              https://github.com/linux-rdma/rdma-core.git
+RUN    cd rdma-core \
+    && debuild -i -us -uc -b
+RUN dpkg --install ibacm_${IBVERBS_VERSION}_amd64.deb \
+                   ibacm_${IBVERBS_VERSION}_amd64.deb \
+                   ibverbs-providers_${IBVERBS_VERSION}_amd64.deb \
+                   ibverbs-utils_${IBVERBS_VERSION}_amd64.deb \
+                   libibumad-dev_${IBVERBS_VERSION}_amd64.deb \
+                   libibumad3_${IBVERBS_VERSION}_amd64.deb \
+                   libibverbs-dev_${IBVERBS_VERSION}_amd64.deb \
+                   libibverbs1_${IBVERBS_VERSION}_amd64.deb \
+                   librdmacm-dev_${IBVERBS_VERSION}_amd64.deb \
+                   librdmacm1_${IBVERBS_VERSION}_amd64.deb \
+                   rdma-core_${IBVERBS_VERSION}_amd64.deb \
+                   rdmacm-utils_${IBVERBS_VERSION}_amd64.deb
+
+# OpenMPI.
 ENV MPI_URL https://www.open-mpi.org/software/ompi/v2.1/downloads
-ENV MPI_VERSION 2.1.2
+ENV MPI_VERSION 2.1.3
 RUN wget -nv ${MPI_URL}/openmpi-${MPI_VERSION}.tar.gz
 RUN tar xf openmpi-${MPI_VERSION}.tar.gz
 RUN    cd openmpi-${MPI_VERSION} \
@@ -64,13 +132,10 @@ RUN    cd openmpi-${MPI_VERSION} \
                    --with-pmi \
                    --with-pmi-libdir=/usr/lib/x86_64-linux-gnu \
                    --with-pmix \
-                   --with-psm2 \
                    --with-slurm=no \
+                   --enable-debug \
     && make -j$(getconf _NPROCESSORS_ONLN) install
 RUN rm -Rf openmpi-${MPI_VERSION}*
-
-# Silence warnings about this directory not existing.
-RUN mkdir /etc/libibverbs.d
 
 # OpenMPI expects this program to exist, even if it's not used. Default is
 # "ssh : rsh", but that's not installed.

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -37,6 +37,10 @@ FROM debian9
 #   c : Will be removed in OpenMPI 4.
 #   d : Uses Mellanox libraries if available in preference to libibverbs.
 #
+# You can check what's available with:
+#
+#   $ ch-run /var/tmp/openmpi -- ompi_info | egrep '(btl|mtl|pml)'
+#
 # The other build decisions are:
 #
 #   1. PMI/PMIx: Include these so that we can use srun or any other PMI[x]
@@ -106,7 +110,6 @@ RUN git clone --branch debian/${IBVERBS_VERSION} --depth 1 \
 RUN    cd rdma-core \
     && debuild -i -us -uc -b
 RUN dpkg --install ibacm_${IBVERBS_VERSION}_amd64.deb \
-                   ibacm_${IBVERBS_VERSION}_amd64.deb \
                    ibverbs-providers_${IBVERBS_VERSION}_amd64.deb \
                    ibverbs-utils_${IBVERBS_VERSION}_amd64.deb \
                    libibumad-dev_${IBVERBS_VERSION}_amd64.deb \
@@ -118,6 +121,15 @@ RUN dpkg --install ibacm_${IBVERBS_VERSION}_amd64.deb \
                    rdma-core_${IBVERBS_VERSION}_amd64.deb \
                    rdmacm-utils_${IBVERBS_VERSION}_amd64.deb
 
+# UCX. There is stuff to build Debian packages, but it seems not too polished.
+ENV UCX_VERSION 1.2.2
+RUN git clone --branch v${UCX_VERSION} --depth 1 \
+              https://github.com/openucx/ucx.git
+RUN    cd ucx \
+    && ./autogen.sh \
+    && ./contrib/configure-release --prefix=/usr \
+    && make -j$(getconf _NPROCESSORS_ONLN) install
+
 # OpenMPI.
 ENV MPI_URL https://www.open-mpi.org/software/ompi/v2.1/downloads
 ENV MPI_VERSION 2.1.3
@@ -128,12 +140,14 @@ RUN    cd openmpi-${MPI_VERSION} \
        CXXFLAGS=-O3 \
        ./configure --prefix=/usr \
                    --sysconfdir=/mnt/0 \
-                   --disable-pty-support \
                    --with-pmi \
                    --with-pmi-libdir=/usr/lib/x86_64-linux-gnu \
                    --with-pmix \
+                   --with-psm2 \
+                   --with-ucx \
+                   --disable-pty-support \
+                   --enable-mca-no-build=btl-openib \
                    --with-slurm=no \
-                   --enable-debug \
     && make -j$(getconf _NPROCESSORS_ONLN) install
 RUN rm -Rf openmpi-${MPI_VERSION}*
 


### PR DESCRIPTION
On Omni-Path (OPA) clusters, the `mpihello` example does not work, and the `openib` module fails to find the relevant network interface:

```
$ OMPI_MCA_btl='self,vader,openib' srun -n4 ch-run /var/tmp/mpihello -- /hello/hello
--------------------------------------------------------------------------
[[8641,0],1]: A high-performance Open MPI point-to-point messaging module
was unable to find any relevant network interfaces:

Module: OpenFabrics (openib)
  Host: fg001

Another transport will be used instead, although this may result in
lower performance.

NOTE: You can disable this warning by setting the MCA parameter
btl_base_warn_component_unused to 0.
--------------------------------------------------------------------------
[...]
--------------------------------------------------------------------------
At least one pair of MPI processes are unable to reach each other for
MPI communications.  This means that no Open MPI device has indicated
that it can be used to communicate between these processes.  This is
an error; Open MPI requires that all MPI processes be able to reach
each other.  This error can sometimes be the result of forgetting to
specify the "self" BTL.

  Process 1 ([[8641,0],0]) is on host: fg001
  Process 2 ([[8641,0],2]) is on host: fg002
  BTLs attempted: vader self

Your MPI job is now going to abort; sorry.
--------------------------------------------------------------------------
[fg001:24855] *** An error occurred in MPI_Send
[fg001:24855] *** reported by process [566296576,0]
[fg001:24855] *** on communicator MPI_COMM_WORLD
[fg001:24855] *** MPI_ERR_INTERN: internal error
[fg001:24855] *** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
[fg001:24855] ***    and potentially your MPI job)
```

One gets a different, and expected, failure when allowing only the `self` BTL. (Why I tried this will become clear below.)

```
$ OMPI_MCA_btl='self' srun -n4 ch-run /var/tmp/mpihello -- /hello/hello
--------------------------------------------------------------------------
At least one pair of MPI processes are unable to reach each other for
MPI communications.  This means that no Open MPI device has indicated
that it can be used to communicate between these processes.  This is
an error; Open MPI requires that all MPI processes be able to reach
each other.  This error can sometimes be the result of forgetting to
specify the "self" BTL.

  Process 1 ([[8641,0],0]) is on host: fg001
  Process 2 ([[8641,0],1]) is on host: fg001
  BTLs attempted: self

Your MPI job is now going to abort; sorry.
--------------------------------------------------------------------------
```

If we add `libpsm2` to the container (this PR), then the first command gets the same warning but now completes:

```
$ OMPI_MCA_btl='self,vader,openib' srun -n4 ch-run /var/tmp/mpihello -- /hello/hello
--------------------------------------------------------------------------
[[8641,0],1]: A high-performance Open MPI point-to-point messaging module
was unable to find any relevant network interfaces:

Module: OpenFabrics (openib)
  Host: fg001

Another transport will be used instead, although this may result in
lower performance.

NOTE: You can disable this warning by setting the MCA parameter
btl_base_warn_component_unused to 0.
--------------------------------------------------------------------------
[...]
0: init ok fg001.localdomain, 4 ranks, userns 4026554747
1: init ok fg001.localdomain, 4 ranks, userns 4026554745
2: init ok fg002.localdomain, 4 ranks, userns 4026554745
3: init ok fg002.localdomain, 4 ranks, userns 4026554746
0: send/receive ok
0: finalize ok
```

Further, specifying only `self` also works with no warnings! Shouldn't this fail? (This unexplained success is why the PR is WIP.)

```
$ OMPI_MCA_btl='self' srun -n4 ch-run /var/tmp/mpihello -- /hello/hello
0: init ok fg001.localdomain, 4 ranks, userns 4026554746
1: init ok fg001.localdomain, 4 ranks, userns 4026554745
2: init ok fg002.localdomain, 4 ranks, userns 4026554745
3: init ok fg002.localdomain, 4 ranks, userns 4026554746
0: send/receive ok
0: finalize ok
```