### PR TITLE
fix description of ch-run to include mounted home directory

### DIFF
--- a/doc-src/ch-run_desc.rst
+++ b/doc-src/ch-run_desc.rst
@@ -9,7 +9,8 @@ Description
 ===========
 
 Run command :code:`CMD` in a Charliecloud container using the flattened and
-unpacked image directory located at :code:`NEWROOT`.
+unpacked image directory located at :code:`NEWROOT`. Note: Your current home 
+directory is mounted at :code: `/home/$USER` in the container.
 
   :code:`-b`, :code:`--bind=SRC[:DST]`
     mount :code:`SRC` at guest :code:`DST` (default :code:`/mnt/0`,


### PR DESCRIPTION
I wasn't looking to use the --no-home option so didn't see in the description that my home directory is mounted as /home/$USER. I hope this helps the next person this happens to.