### PR TITLE
add ShellCheck lint checks for shell scripts

### DIFF
--- a/bin/base.sh
+++ b/bin/base.sh
@@ -1,30 +1,63 @@
+set -e
+
+# shellcheck disable=SC2034
 CH_BIN="$(cd "$(dirname "$0")" && pwd)"
 
 LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
-. ${LIBEXEC}/version.sh
+. "${LIBEXEC}/version.sh"
+
+
+parse_basic_args () {
+    for i in "$@"; do
+        if [ "$i" = --help ]; then
+            usage 0
+        fi
+        if [ "$i" = --libexec-path ]; then
+            echo "$LIBEXEC"
+            exit 0
+        fi
+        if [ "$1" = --version ]; then
+            version
+            exit 0
+        fi
+    done
+}
+
+usage () {
+    echo "${usage:?}" 1>&2
+    exit "${1:-1}"
+}
 
 # Do we need sudo to run docker?
 if ( docker info > /dev/null 2>&1 ); then
-    export DOCKER="docker"
+    docker_ () {
+        docker "$@"
+    }
 else
-    export DOCKER="sudo docker"
+    docker_ () {
+        sudo docker "$@"
+    }
 fi
 
 # Use parallel gzip if it's available. ("command -v" is POSIX.1-2008.)
 if ( command -v pigz >/dev/null 2>&1 ); then
-    export GZIP_CMD=pigz
+    gzip_ () {
+        pigz "$@"
+    }
 else
-    export GZIP_CMD=gzip
+    gzip_ () {
+        gzip "$@"
+    }
 fi
 
 # Use pv to show a progress bar, if it's available. (We also don't want a
 # progress bar if stdin is not a terminal, but pv takes care of that.)
 if ( command -v pv >/dev/null 2>&1 ); then
-    PV() {
+    pv_ () {
         pv -pteb "$@"
     }
 else
-    PV() {
+    pv_ () {
         # Arguments may be present, but we ignore them.
         cat
     }

--- a/bin/ch-build
+++ b/bin/ch-build
@@ -1,28 +1,21 @@
 #!/bin/sh
 
 LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
-. ${LIBEXEC}/base.sh
+. "${LIBEXEC}/base.sh"
 
-usage () {
-    cat 1>&2 <<EOF
+# shellcheck disable=SC2034
+usage=$(cat <<EOF
 Wrapper for "docker build" with various enhancements.
 
 Usage:
 
-  $ $(basename $0) -t TAG [ARGS ...] CONTEXT
+  $ $(basename "$0") -t TAG [ARGS ...] CONTEXT
 
 ARGS are passed unchanged to "docker build" after the workaround arguments.
 EOF
-    exit ${1:-1}
-}
+)
 
-if [ "$1" = "--help" ]; then
-    usage 0
-fi
-if [ "$1" = "--version" ]; then
-    version
-    exit 0
-fi
+parse_basic_args "$@"
 
 dockerfile=
 if [ -f Dockerfile ]; then
@@ -37,11 +30,12 @@ if [ -f Dockerfile ]; then
 fi
 
 # Coordinate this list with test "build.bats/proxy variables".
-sudo docker build --build-arg HTTP_PROXY=$HTTP_PROXY \
-                  --build-arg HTTPS_PROXY=$HTTPS_PROXY \
-                  --build-arg NO_PROXY=$NO_PROXY \
-                  --build-arg http_proxy=$http_proxy \
-                  --build-arg https_proxy=$https_proxy \
-                  --build-arg no_proxy=$no_proxy \
-                  $dockerfile \
-                  "$@"
+# shellcheck disable=SC2154
+docker_ build --build-arg HTTP_PROXY="$HTTP_PROXY" \
+              --build-arg HTTPS_PROXY="$HTTPS_PROXY" \
+              --build-arg NO_PROXY="$NO_PROXY" \
+              --build-arg http_proxy="$http_proxy" \
+              --build-arg https_proxy="$https_proxy" \
+              --build-arg no_proxy="$no_proxy" \
+              $dockerfile \
+              "$@"

--- a/bin/ch-build2dir
+++ b/bin/ch-build2dir
@@ -1,19 +1,17 @@
 #!/bin/sh
 
 LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
-. ${LIBEXEC}/base.sh
+. "${LIBEXEC}/base.sh"
 
-set -e
-
-usage () {
-    cat 1>&2 <<EOF
+# shellcheck disable=SC2034
+usage=$(cat <<EOF
 Build a Charliecloud image specified by \$PWD/Dockerfile and unpack it.
 Equivalent to ch-build, ch-docker2tar, ch-tar2dir sequence but somewhat less
 flexible.
 
 Usage:
 
-  $ $(basename $0) CONTEXT DEST [ARGS ...]
+  $ $(basename "$0") CONTEXT DEST [ARGS ...]
 
 Arguments:
 
@@ -21,28 +19,23 @@ Arguments:
   DEST     directory in which to place image tarball and directory
   ARGS     additional arguments passed to ch-build
 EOF
-    exit ${1:-1}
-}
+)
 
-if [ "$1" = "--help" ]; then
-    usage 0
-fi
-if [ "$1" = "--version" ]; then
-    version
-    exit 0
-fi
+parse_basic_args "$@"
+
 if [ "$#" -lt 2 ]; then
     usage
 fi
+
 CONTEXT="$1"
 DEST="$2"
 shift 2
 
-TAG=$(basename $PWD)
+TAG=$(basename "$PWD")
 
 set -x
 
-$CH_BIN/ch-build -t $TAG "$CONTEXT" "$@"
-$CH_BIN/ch-docker2tar $TAG "$DEST"
-$CH_BIN/ch-tar2dir "$DEST/$TAG.tar.gz" "$DEST"
+"$CH_BIN"/ch-build -t "$TAG" "$CONTEXT" "$@"
+"$CH_BIN"/ch-docker2tar "$TAG" "$DEST"
+"$CH_BIN"/ch-tar2dir "$DEST/$TAG.tar.gz" "$DEST"
 rm "$DEST/$TAG.tar.gz"

--- a/bin/ch-docker-run
+++ b/bin/ch-docker-run
@@ -1,17 +1,17 @@
 #!/bin/bash
 
-# bash is needed for arrays.
+# Bash is needed for arrays.
 
 LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
-. ${LIBEXEC}/base.sh
+. "${LIBEXEC}/base.sh"
 
-usage () {
-    cat 1>&2 <<EOF
+# shellcheck disable=SC2034
+usage=$(cat <<EOF
 Run CMD in a Docker container TAG.
 
 Usage:
 
-  $ $(basename $0) [-i] [-b HOSTDIR:GUESTDIR ...] TAG CMD [ARGS ...]
+  $ $(basename "$0") [-i] [-b HOSTDIR:GUESTDIR ...] TAG CMD [ARGS ...]
 
 The special sauce is:
 
@@ -26,26 +26,17 @@ Options:
 
 You must have sufficient privilege (via sudo) to run the Docker commands.
 EOF
-    exit ${1:-1}
-}
-
-set -e
+)
 
 MOUNTS=( /etc/passwd:/etc/passwd \
          /etc/group:/etc/group )
 
-if [[ $1 = --help ]]; then
-    usage 0
-fi
-if [[ $1 = --version ]]; then
-    version
-    exit 0
-fi
+parse_basic_args "$@"
 
 while getopts 'b:ih' opt; do
     case $opt in
         i) INTERACTIVE=-it ;;
-        b) MOUNTS+=( $OPTARG ) ;;
+        b) MOUNTS+=( "$OPTARG" ) ;;
         h)
             usage 0
             ;;
@@ -54,7 +45,7 @@ while getopts 'b:ih' opt; do
             ;;
     esac
 done
-shift $(($OPTIND-1))
+shift $((OPTIND-1))
 
 if [[ $# -lt 2 ]]; then
     usage
@@ -70,9 +61,9 @@ fi
 echo 'bind mounts:'
 MOUNTARGS=''
 for (( i = 0; i < ${#MOUNTS[@]}; i++ )); do
-    echo ' ' ${MOUNTS[$i]}
+    echo ' ' "${MOUNTS[$i]}"
     MOUNTARGS+=" -v ${MOUNTS[$i]}"
 done
 
 set -x
-$DOCKER run --read-only -u $USER $INTERACTIVE $MOUNTARGS $TAG "$@"
+$DOCKER run --read-only -u "$USER" "$INTERACTIVE" "$MOUNTARGS" "$TAG" "$@"

--- a/bin/ch-docker2tar
+++ b/bin/ch-docker2tar
@@ -1,45 +1,37 @@
 #!/bin/sh
 
 LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
-. ${LIBEXEC}/base.sh
+. "${LIBEXEC}/base.sh"
 
-set -e
-#set -x
-
-usage () {
-    cat 1>&2 <<EOF
+# shellcheck disable=SC2034
+usage=$(cat <<EOF
 Flatten a Docker image into a Charliecloud image tarball.
 
 Usage:
 
-  $ $(basename $0) IMAGE OUTDIR
+  $ $(basename "$0") IMAGE OUTDIR
 
 You must have sufficient privilege (via sudo) to run the Docker commands.
 EOF
-    exit ${1:-1}
-}
+)
 
-if [ "$1" = "--help" ]; then
-    usage 0
-fi
-if [ "$1" = "--version" ]; then
-    version
-    exit 0
-fi
+parse_basic_args "$@"
+
 if [ "$#" -ne 2 ]; then
     usage
 fi
-IMAGE=$1
-OUTDIR=$2
-TAR=$OUTDIR/$(echo $IMAGE | sed 's/\//./g').tar.gz
 
-cid=$($DOCKER create --read-only $IMAGE)
-size=$($DOCKER image inspect $IMAGE --format='{{.Size}}')
-#$DOCKER ps -af "id=$cid"
-$DOCKER export $cid | PV -s $size | $GZIP_CMD -6 > $TAR
-$DOCKER rm $cid > /dev/null
+IMAGE="$1"
+OUTDIR="$2"
+TAR="$OUTDIR"/$(echo "$IMAGE" | sed 's/\//./g').tar.gz
+
+cid=$(docker_ create --read-only "$IMAGE")
+size=$(docker_ image inspect "$IMAGE" --format='{{.Size}}')
+#docker_ ps -af "id=$cid"
+docker_ export "$cid" | pv_ -s "$size" | gzip_ -6 > "$TAR"
+docker_ rm "$cid" > /dev/null
 # FIXME: This is brittle. We want the filename and size, but not the rest, so
 # we can't just ask ls. Another option is stat and numfmt, but the latter may
 # not be very portable.
-ls -lh $TAR | awk '{ print $5,$9 }'
+find "$TAR" -ls | awk '{ print $5,$9 }'
 

--- a/bin/ch-fromhost
+++ b/bin/ch-fromhost
@@ -1,10 +1,10 @@
 #!/bin/sh
 
 LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
-. ${LIBEXEC}/base.sh
+. "${LIBEXEC}/base.sh"
 
-usage () {
-    cat 1>&2 <<EOF
+# shellcheck disable=SC2034
+usage=$(cat <<EOF
 Inject files from the host into an image directory.
 
 Usage:
@@ -25,8 +25,7 @@ Options:
   -v, --verbose    list the injected files
       --version    print version and exit
 EOF
-    exit ${1:-1}
-}
+)
 
 DEST_DEFAULT=
 IMAGE=
@@ -38,7 +37,9 @@ FOUND_LIBS_P=
 LIB_DEST=
 
 debug () {
-    [ $VERBOSE ] && printf "%s\n" "$1" 1>&2
+    if [ "$VERBOSE" ]; then
+        printf '%s\n' "$1" 1>&2
+    fi
 }
 
 ensure_nonempty () {
@@ -46,13 +47,15 @@ ensure_nonempty () {
 }
 
 fatal () {
-    printf "ch-fromhost: %s\n" "$1" 1>&2
+    printf 'ch-fromhost: %s\n' "$1" 1>&2
     exit 1
 }
 
 info () {
-    printf "ch-fromhost: %s\n" "$1" 1>&2
+    printf 'ch-fromhost: %s\n' "$1" 1>&2
 }
+
+parse_basic_args "$@"
 
 while [ $# -gt 0 ]; do
     OPT="$1"; shift
@@ -60,8 +63,7 @@ while [ $# -gt 0 ]; do
     case $OPT in
         -c|--cmd)
             ensure_nonempty --cmd "$1"
-            OUT=$($1)
-            [ $? -eq 0 ] || fatal "command failed: $1"
+            OUT=$($1) || fatal "command failed: $1"
             shift
             ;;
         -d|--dest)
@@ -71,26 +73,18 @@ while [ $# -gt 0 ]; do
             ;;
         -f|--file)
             ensure_nonempty --file "$1"
-            OUT=$(cat "$1")
-            [ $? -eq 0 ] || fatal "cannot read file: $1"
+            OUT=$(cat "$1") || fatal "cannot read file: $1"
             shift
-            ;;
-        -h|--help)
-            usage 0
             ;;
         --no-infer)
             INFER=
             ;;
         --nvidia)
-            OUT=$(nvidia-container-cli list --binaries --libraries)
-            [ $? -eq 0 ] || fatal "nvidia-container-cli failed; does this host have GPUs?"
+               OUT=$(nvidia-container-cli list --binaries --libraries) \
+            || fatal "nvidia-container-cli failed; does this host have GPUs?"
             ;;
         -v|--verbose)
             VERBOSE=yes
-            ;;
-        --version)
-            version
-            exit 0
             ;;
         -*)
             info "invalid option: $OPT"
@@ -98,8 +92,8 @@ while [ $# -gt 0 ]; do
             ;;
         *)
             ensure_nonempty "image path" "$OPT"
-            [ -z $IMAGE ] || fatal "duplicate image path: $OPT"
-            [ -d $OPT ] || fatal "image not a directory: $OPT"
+            [ -z "$IMAGE" ] || fatal "duplicate image path: $OPT"
+            [ -d "$OPT" ] || fatal "image not a directory: $OPT"
             IMAGE="$OPT"
             ;;
     esac
@@ -127,9 +121,10 @@ if [ $INFER ]; then
         # searches, so that we can override (or overwrite) any of the same
         # library that may already be in the image.
         debug "asking ldconfig for shared library path"
-        $CH_BIN/ch-run -w $IMAGE -- /sbin/ldconfig  # cache may not be present
-        LIB_DEST=$(  $CH_BIN/ch-run $IMAGE -- /sbin/ldconfig -v 2> /dev/null \
-                   | egrep '^/' | cut -d: -f1 | head -1)
+        "$CH_BIN"/ch-run -w "$IMAGE" -- /sbin/ldconfig  # cache maybe absent
+        LIB_DEST=$(  "$CH_BIN"/ch-run "$IMAGE" -- \
+                                      /sbin/ldconfig -v 2> /dev/null \
+                   | grep -E '^/' | cut -d: -f1 | head -1)
         [ -z "${LIB_DEST%%/*}" ] || fatal "bad path from ldconfig: $LIB_DEST"
         debug "shared library destination: $LIB_DEST"
     else
@@ -158,11 +153,11 @@ for FILE in $FOUND_FILES; do
         esac
     fi
     debug "  $TYPE_: $FILE -> $DEST"
-    [ $DEST ] || fatal "no destination for: $FILE"
+    [ "$DEST" ] || fatal "no destination for: $FILE"
     [ -z "${DEST%%/*}" ] || fatal "not an absolute path: $DEST"
-    [ -d $IMAGE$DEST ] || fatal "not a directory: $IMAGE$DEST"
-    cp --dereference --preserve=all "$FILE" "$IMAGE/$DEST"
-    [ $? -eq 0 ] || fatal "cannot inject: $FILE"
+    [ -d "$IMAGE$DEST" ] || fatal "not a directory: $IMAGE$DEST"
+       cp --dereference --preserve=all "$FILE" "$IMAGE/$DEST" \
+    || fatal "cannot inject: $FILE"
 done
 IFS="$OLD_IFS"
 
@@ -170,7 +165,7 @@ IFS="$OLD_IFS"
 
 if [ $FOUND_LIBS_P ] && [ $INFER ]; then
     debug "found shared library, running ldconfig"
-    $CH_BIN/ch-run -w $IMAGE -- /sbin/ldconfig
+    "$CH_BIN"/ch-run -w "$IMAGE" -- /sbin/ldconfig
 else
     debug "no shared libraries found"
 fi

--- a/bin/ch-tar2dir
+++ b/bin/ch-tar2dir
@@ -1,28 +1,20 @@
 #!/bin/sh
 
 LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
-. ${LIBEXEC}/base.sh
+. "${LIBEXEC}/base.sh"
 
-usage () {
-    cat 1>&2 <<EOF
+# shellcheck disable=SC2034
+usage=$(cat <<EOF
 Unpack a Docker export tarball into a directory.
 
 Usage:
 
-  $ $(basename $0) TARBALL DIR
+  $ $(basename "$0") TARBALL DIR
 EOF
-    exit ${1:-1}
-}
+)
 
-set -e
+parse_basic_args "$@"
 
-if [ "$1" = --help ]; then
-    usage 0
-fi
-if [ "$1" = --version ]; then
-    version
-    exit 0
-fi
 if [ "$1" = --verbose ]; then
     VERBOSE=v
     shift
@@ -36,7 +28,7 @@ NEWROOT="$2/$(basename "${TARBALL%.tar.gz}")"
 SENTINEL=WEIRD_AL_YANKOVIC
 
 # Is the tarball a regular file (or symlink) and readable?
-if [ ! -f "$TARBALL" -o ! -r "$TARBALL" ]; then
+if [ ! -f "$TARBALL" ] || [ ! -r "$TARBALL" ]; then
     echo "can't read $TARBALL" 1>&2
     exit 1
 fi
@@ -49,7 +41,7 @@ else
        && [ -d "$NEWROOT/lib" ] \
        && [ -d "$NEWROOT/usr" ]; then
         echo "replacing existing image $NEWROOT" 1>&2
-        rm -Rf --one-file-system $NEWROOT
+        rm -Rf --one-file-system "$NEWROOT"
     else
         echo "$NEWROOT exists but does not appear to be an image" 1>&2
         exit 1
@@ -60,8 +52,9 @@ mkdir "$NEWROOT"
 echo 'This directory is a Charliecloud container image.' > "$NEWROOT/$SENTINEL"
 # Use a pipe because PV ignores arguments if it's cat rather than PV.
 SIZE=$(stat -c%s "$TARBALL")
-  PV -s $SIZE < "$TARBALL" \
-| tar x$VERBOSE -I $GZIP_CMD -C "$NEWROOT" -f - \
+  pv_ -s "$SIZE" < "$TARBALL" \
+| gzip_ -dc \
+| tar x$VERBOSE -C "$NEWROOT" -f - \
       --anchored --exclude='dev/*' --exclude='./dev/*'
 # Make all directories writeable so we can delete image later (hello, Red Hat).
 find "$NEWROOT" -type d -a ! -perm /200 -exec chmod u+w {} +

--- a/examples/mpi/lammps/test.bats
+++ b/examples/mpi/lammps/test.bats
@@ -44,27 +44,29 @@ setup () {
 lammps_try () {
     # These examples cd because some (not all) of the LAMMPS tests expect to
     # find things based on $CWD.
-    infiles=$(ch-run --cd /lammps/examples/$1 $IMG -- bash -c "ls in.*")
+    infiles=$(ch-run --cd "/lammps/examples/$1" "$IMG" -- bash -c "ls in.*")
     for i in $infiles; do
-        printf '\n\n%s\n' $i
-        $MPIRUN_CORE ch-run --join --cd /lammps/examples/$1 $IMG -- \
-                            lmp_mpi -log none -in $i
+        printf '\n\n%s\n' "$i"
+        # shellcheck disable=SC2086
+        $MPIRUN_CORE ch-run --join --cd /lammps/examples/$1 "$IMG" -- \
+                            lmp_mpi -log none -in "$i"
     done
 
 }
 
 @test "$EXAMPLE_TAG/using all cores" {
-    run $MPIRUN_CORE ch-run --join $IMG -- \
+    # shellcheck disable=SC2086
+    run $MPIRUN_CORE ch-run --join "$IMG" -- \
                             lmp_mpi -log none -in /lammps/examples/melt/in.melt
     echo "$output"
     [[ $status -eq 0 ]]
     ranks_found=$(  echo "$output" \
-                  | fgrep 'MPI tasks' \
+                  | grep -F 'MPI tasks' \
                   | tail -1 \
                   | sed -r 's/^.+with ([0-9]+) MPI tasks.+$/\1/')
     echo "ranks expected: $CHTEST_CORES_TOTAL"
     echo "ranks found: $ranks_found"
-    [[ $ranks_found -eq $CHTEST_CORES_TOTAL ]]
+    [[ $ranks_found -eq "$CHTEST_CORES_TOTAL" ]]
 }
 
 @test "$EXAMPLE_TAG/crack"    { lammps_try crack; }

--- a/examples/mpi/mpibench/test.bats
+++ b/examples/mpi/mpibench/test.bats
@@ -20,26 +20,27 @@ setup () {
 }
 
 check_errors () {
-    [[ ! $1 =~ 'errno =' ]]
+    [[ ! "$1" =~ 'errno =' ]]
 }
 
 check_finalized () {
-    [[ $1 =~ 'All processes entering MPI_Finalize' ]]
+    [[ "$1" =~ 'All processes entering MPI_Finalize' ]]
 }
 
 check_process_ct () {
-    ranks_expected=$1
+    ranks_expected="$1"
     echo "ranks expected: $ranks_expected"
     ranks_found=$(  echo "$output" \
-                  | fgrep '#processes =' \
+                  | grep -F '#processes =' \
                   | sed -r 's/^.+#processes = ([0-9]+)\s+$/\1/')
     echo "ranks found: $ranks_found"
-    [[ $ranks_found -eq $ranks_expected ]]
+    [[ $ranks_found -eq "$ranks_expected" ]]
 }
 
 # one from "Single Transfer Benchmarks"
 @test "$EXAMPLE_TAG/pingpong (guest launch)" {
-    run ch-run $IMG -- mpirun $CHTEST_MPIRUN_NP $IMB_MPI1 $IMB_ARGS PingPong
+    # shellcheck disable=SC2086
+    run ch-run "$IMG" -- mpirun $CHTEST_MPIRUN_NP "$IMB_MPI1" $IMB_ARGS PingPong
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"
@@ -48,7 +49,8 @@ check_process_ct () {
 }
 @test "$EXAMPLE_TAG/pingpong (host launch)" {
     multiprocess_ok
-    run $MPIRUN_CORE ch-run --join $IMG -- $IMB_MPI1 $IMB_ARGS PingPong
+    # shellcheck disable=SC2086
+    run $MPIRUN_CORE ch-run --join "$IMG" -- "$IMB_MPI1" $IMB_ARGS PingPong
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"
@@ -58,38 +60,42 @@ check_process_ct () {
 
 # one from "Parallel Transfer Benchmarks"
 @test "$EXAMPLE_TAG/sendrecv (guest launch)" {
-    run ch-run $IMG -- mpirun $CHTEST_MPIRUN_NP $IMB_MPI1 $IMB_ARGS Sendrecv
+    # shellcheck disable=SC2086
+    run ch-run "$IMG" -- mpirun $CHTEST_MPIRUN_NP "$IMB_MPI1" $IMB_ARGS Sendrecv
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"
-    check_process_ct $CHTEST_CORES_NODE "$output"
+    check_process_ct "$CHTEST_CORES_NODE" "$output"
     check_finalized "$output"
 }
 @test "$EXAMPLE_TAG/sendrecv (host launch)" {
     multiprocess_ok
-    run $MPIRUN_CORE ch-run --join $IMG -- $IMB_MPI1 $IMB_ARGS Sendrecv
+    # shellcheck disable=SC2086
+    run $MPIRUN_CORE ch-run --join "$IMG" -- "$IMB_MPI1" $IMB_ARGS Sendrecv
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"
-    check_process_ct $CHTEST_CORES_TOTAL "$output"
+    check_process_ct "$CHTEST_CORES_TOTAL" "$output"
     check_finalized "$output"
 }
 
 # one from "Collective Benchmarks"
 @test "$EXAMPLE_TAG/allreduce (guest launch)" {
-    run ch-run $IMG -- mpirun $CHTEST_MPIRUN_NP $IMB_MPI1 $IMB_ARGS Allreduce
+    # shellcheck disable=SC2086
+    run ch-run "$IMG" -- mpirun $CHTEST_MPIRUN_NP "$IMB_MPI1" $IMB_ARGS Allreduce
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"
-    check_process_ct $CHTEST_CORES_NODE "$output"
+    check_process_ct "$CHTEST_CORES_NODE" "$output"
     check_finalized "$output"
 }
 @test "$EXAMPLE_TAG/allreduce (host launch)" {
     multiprocess_ok
-    run $MPIRUN_CORE ch-run --join $IMG -- $IMB_MPI1 $IMB_ARGS Allreduce
+    # shellcheck disable=SC2086
+    run $MPIRUN_CORE ch-run --join "$IMG" -- "$IMB_MPI1" $IMB_ARGS Allreduce
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"
-    check_process_ct $CHTEST_CORES_TOTAL "$output"
+    check_process_ct "$CHTEST_CORES_TOTAL" "$output"
     check_finalized "$output"
 }

--- a/examples/mpi/mpibench/test.sh
+++ b/examples/mpi/mpibench/test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
-CHBASE=$(dirname $0)/../..
+CHBASE=$(dirname "$0")/../..
 CHBIN=$CHBASE/bin
 OUTDIR=/tmp
 OUTTAG=$(date -u +'%Y%m%dT%H%M%SZ')
@@ -11,20 +11,20 @@ IMB=/usr/local/src/imb/src/IMB-MPI1
 
 if [[ $1 == build ]]; then
     shift
-    $CHBIN/ch-build -t $USER/mpibench $CHBASE
-    $CHBIN/ch-docker2tar $USER/mpibench /tmp
-    $CHBIN/ch-tar2dir /tmp/$USER.mpibench.tar.gz /tmp/mpibench
+    "$CHBIN/ch-build" -t "$USER/mpibench" "$CHBASE"
+    "$CHBIN/ch-docker2tar" "$USER/mpibench" /tmp
+    "$CHBIN/ch-tar2dir" "/tmp/$USER.mpibench.tar.gz" /tmp/mpibench
 fi
 
-if [[ -n $1 ]]; then
+if [[ -n "$1" ]]; then
 
     echo "testing on host"
-    time mpirun -n $1 $IMB \
-         > $OUTDIR/mpibench.host.$OUTTAG.txt
+    time mpirun -n "$1" "$IMB" \
+         > "$OUTDIR/mpibench.host.$OUTTAG.txt"
 
     echo "testing in container"
-    time mpirun -n $1 $CHBIN/ch-run /tmp/mpibench -- $IMB \
-         > $OUTDIR/mpibench.guest.$OUTTAG.txt
+    time mpirun -n "$1" "$CHBIN/ch-run" /tmp/mpibench -- "$IMB" \
+         > "$OUTDIR/mpibench.guest.$OUTTAG.txt"
 
     echo "done; output in $OUTDIR"
 fi

--- a/examples/mpi/mpihello/slurm.sh
+++ b/examples/mpi/mpihello/slurm.sh
@@ -29,14 +29,14 @@ module load charliecloud
 
 # MPI version on host.
 printf 'host:      '
-mpirun --version | egrep '^mpirun'
+mpirun --version | grep -E '^mpirun'
 
 # Unpack image.
-srun ch-tar2dir $TAR $IMGDIR
+srun ch-tar2dir "$TAR" "$IMGDIR"
 
 # MPI version in container.
 printf 'container: '
-ch-run $IMG -- mpirun --version | egrep '^mpirun'
+ch-run "$IMG" -- mpirun --version | grep -E '^mpirun'
 
 # Run the app.
-srun --cpus-per-task=1 ch-run $IMG -- /hello/hello
+srun --cpus-per-task=1 ch-run "$IMG" -- /hello/hello

--- a/examples/mpi/mpihello/test.bats
+++ b/examples/mpi/mpihello/test.bats
@@ -6,7 +6,7 @@ load ./test
 
 count_ranks () {
       echo "$1" \
-    | egrep '^0: init ok' \
+    | grep -E '^0: init ok' \
     | tail -1 \
     | sed -r 's/^.+ ([0-9]+) ranks.+$/\1/'
 }
@@ -14,38 +14,40 @@ count_ranks () {
 @test "$EXAMPLE_TAG/serial" {
     # This seems to start up the MPI infrastructure (daemons, etc.) within the
     # guest even though there's no mpirun.
-    run ch-run $IMG -- /hello/hello
+    run ch-run "$IMG" -- /hello/hello
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output =~ ' 1 ranks' ]]
-    [[ $output =~ '0: send/receive ok' ]]
-    [[ $output =~ '0: finalize ok' ]]
+    [[ $output = *' 1 ranks'* ]]
+    [[ $output = *'0: send/receive ok'* ]]
+    [[ $output = *'0: finalize ok'* ]]
 }
 
 @test "$EXAMPLE_TAG/guest starts ranks" {
-    run ch-run $IMG -- mpirun $CHTEST_MPIRUN_NP /hello/hello
+    # shellcheck disable=SC2086
+    run ch-run "$IMG" -- mpirun $CHTEST_MPIRUN_NP /hello/hello
     echo "$output"
     [[ $status -eq 0 ]]
     rank_ct=$(count_ranks "$output")
     echo "found $rank_ct ranks, expected $CHTEST_CORES_NODE"
-    [[ $rank_ct -eq $CHTEST_CORES_NODE ]]
-    [[ $output =~ '0: send/receive ok' ]]
-    [[ $output =~ '0: finalize ok' ]]
+    [[ $rank_ct -eq "$CHTEST_CORES_NODE" ]]
+    [[ $output = *'0: send/receive ok'* ]]
+    [[ $output = *'0: finalize ok'* ]]
 }
 
 @test "$EXAMPLE_TAG/host starts ranks" {
     multiprocess_ok
     echo "starting ranks with: $MPIRUN_CORE"
 
-    GUEST_MPI=$(ch-run $IMG -- mpirun --version | head -1)
+    GUEST_MPI=$(ch-run "$IMG" -- mpirun --version | head -1)
     echo "guest MPI: $GUEST_MPI"
 
-    run $MPIRUN_CORE ch-run --join $IMG -- /hello/hello
+    # shellcheck disable=SC2086
+    run $MPIRUN_CORE ch-run --join "$IMG" -- /hello/hello
     echo "$output"
     [[ $status -eq 0 ]]
     rank_ct=$(count_ranks "$output")
     echo "found $rank_ct ranks, expected $CHTEST_CORES_TOTAL"
-    [[ $rank_ct -eq $CHTEST_CORES_TOTAL ]]
-    [[ $output =~ '0: send/receive ok' ]]
-    [[ $output =~ '0: finalize ok' ]]
+    [[ $rank_ct -eq "$CHTEST_CORES_TOTAL" ]]
+    [[ $output = *'0: send/receive ok'* ]]
+    [[ $output = *'0: finalize ok'* ]]
 }

--- a/examples/mpi/paraview/test.bats
+++ b/examples/mpi/paraview/test.bats
@@ -8,7 +8,8 @@ setup () {
     OUTDIR=$BATS_TMPDIR
     if [[ $CHTEST_MULTINODE ]]; then
         # Bats only creates $BATS_TMPDIR on the first node.
-        $MPIRUN_NODE mkdir -p $BATS_TMPDIR
+        # shellcheck disable=SC2086
+        $MPIRUN_NODE mkdir -p "$BATS_TMPDIR"
     fi
 }
 
@@ -22,34 +23,36 @@ setup () {
 #
 #   .vtk: The number of extra and/or duplicate points and indexing of these
 #         points into polygons varied by rank count on my VM, but not on the
-#         cluster. The resulting VTK file is dependent on whether an image was 
-# 	  rendered serially or using 2 or n processes.
+#         cluster. The resulting VTK file is dependent on whether an image was
+#         rendered serially or using 2 or n processes.
 #
 # We do not check .pvtp (and its companion .vtp) output because it's a
 # collection of XML files containing binary data and it seems too hairy to me.
 
 @test "$EXAMPLE_TAG/cone serial" {
-    ch-run -b $INDIR -b $OUTDIR $IMG -- \
+    ch-run -b "$INDIR" -b "$OUTDIR" "$IMG" -- \
            pvbatch /mnt/0/cone.py /mnt/1
-    ls -l $OUTDIR/cone*
-    diff -u $INDIR/cone.serial.vtk $OUTDIR/cone.vtk
-    cmp $INDIR/cone.png $OUTDIR/cone.png
+    ls -l "$OUTDIR"/cone*
+    diff -u "$INDIR/cone.serial.vtk" "$OUTDIR/cone.vtk"
+    cmp "$INDIR/cone.png" "$OUTDIR/cone.png"
 }
 
 @test "$EXAMPLE_TAG/cone ranks=2" {
     multiprocess_ok
-    $MPIRUN_2 ch-run --join -b $INDIR -b $OUTDIR $IMG -- \
+    # shellcheck disable=SC2086
+    $MPIRUN_2 ch-run --join -b "$INDIR" -b "$OUTDIR" "$IMG" -- \
               pvbatch /mnt/0/cone.py /mnt/1
-    ls -l $OUTDIR/cone*
-       diff -u $INDIR/cone.2ranks.vtk $OUTDIR/cone.vtk
-       cmp $INDIR/cone.png $OUTDIR/cone.png
+    ls -l "$OUTDIR"/cone*
+    diff -u "$INDIR/cone.2ranks.vtk" "$OUTDIR/cone.vtk"
+    cmp "$INDIR/cone.png" "$OUTDIR/cone.png"
 }
 
 @test "$EXAMPLE_TAG/cone ranks=N" {
     multiprocess_ok
-    $MPIRUN_CORE ch-run --join -b $INDIR -b $OUTDIR $IMG -- \
+    # shellcheck disable=SC2086
+    $MPIRUN_CORE ch-run --join -b "$INDIR" -b "$OUTDIR" "$IMG" -- \
                  pvbatch /mnt/0/cone.py /mnt/1
-    ls -l $OUTDIR/cone*
-       diff -u $INDIR/cone.nranks.vtk $OUTDIR/cone.vtk
-       cmp $INDIR/cone.png $OUTDIR/cone.png
+    ls -l "$OUTDIR"/cone*
+    diff -u "$INDIR/cone.nranks.vtk" "$OUTDIR/cone.vtk"
+    cmp "$INDIR/cone.png" "$OUTDIR/cone.png"
 }

--- a/examples/serial/hello/test.bats
+++ b/examples/serial/hello/test.bats
@@ -6,7 +6,7 @@ setup () {
 }
 
 @test "$EXAMPLE_TAG/hello" {
-    run ch-run $EXAMPLE_IMG -- /hello/hello.sh
+    run ch-run "$EXAMPLE_IMG" -- /hello/hello.sh
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output = 'hello world' ]]
@@ -15,9 +15,9 @@ setup () {
 @test "$EXAMPLE_TAG/distribution sanity" {
     # Try various simple things that should work in a basic Debian
     # distribution. (This does not test anything Charliecloud manipulates.)
-    ch-run $EXAMPLE_IMG -- /bin/bash -c true
-    ch-run $EXAMPLE_IMG -- /bin/true
-    ch-run $EXAMPLE_IMG -- find /etc -name 'a*'
-    ch-run $EXAMPLE_IMG -- sh -c 'echo foo | /bin/egrep foo'
-    ch-run $EXAMPLE_IMG -- nice true
+    ch-run "$EXAMPLE_IMG" -- /bin/bash -c true
+    ch-run "$EXAMPLE_IMG" -- /bin/true
+    ch-run "$EXAMPLE_IMG" -- find /etc -name 'a*'
+    ch-run "$EXAMPLE_IMG" -- sh -c 'echo foo | /bin/grep -E foo'
+    ch-run "$EXAMPLE_IMG" -- nice true
 }

--- a/examples/serial/obspy/test.bats
+++ b/examples/serial/obspy/test.bats
@@ -14,5 +14,5 @@ setup () {
     # finer-grained exclusion mechanism.
     #
     # [1]: https://github.com/obspy/obspy/issues/1660
-    ch-run $IMG -- bash -c '. activate && obspy-runtests -d -x core -x signal'
+    ch-run "$IMG" -- bash -c '. activate && obspy-runtests -d -x core -x signal'
 }

--- a/examples/serial/spack/test.bats
+++ b/examples/serial/spack/test.bats
@@ -4,18 +4,18 @@ setup() {
     scope skip  # issue #204
     [[ -z $CHTEST_CRAY ]] || skip 'issue #193 and Spack issue #8618'
     prerequisites_ok spack
-    SPACK_IMG=$IMGDIR/spack
+    SPACK_IMG="$IMGDIR/spack"
     export PATH=/spack/bin:$PATH
 }
 
 @test "$EXAMPLE_TAG/version" {
-    ch-run $SPACK_IMG -- spack --version
+    ch-run "$SPACK_IMG" -- spack --version
 }
 
 @test "$EXAMPLE_TAG/compilers" {
-    ch-run $SPACK_IMG -- spack compilers
+    ch-run "$SPACK_IMG" -- spack compilers
 }
 
 @test "$EXAMPLE_TAG/spec" {
-    ch-run $SPACK_IMG -- spack spec netcdf
+    ch-run "$SPACK_IMG" -- spack spec netcdf
 }

--- a/packaging/debian/travis.sh
+++ b/packaging/debian/travis.sh
@@ -21,5 +21,5 @@ sudo ln -f -s /usr/local/bin/sphinx-build /usr/bin/sphinx-build
 
 # Need -d because dependencies can not be satisfied on trusty.
 # Need -fno-builtin -fPIC to hack around the broken 14.04 travis image.
-ln -s packaging/debian
+ln -s packaging/debian .
 DEB_CFLAGS_SET="-fno-builtin -fPIC" debuild -d -i -us -uc

--- a/packaging/redhat/travis.sh
+++ b/packaging/redhat/travis.sh
@@ -17,8 +17,8 @@ mkdir -p $RPMBUILD/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 make VERSION.full
 VERSION=$(cat VERSION.full)
 
-tar czf $RPMBUILD/SOURCES/charliecloud-${VERSION}.tar.gz \
-    --xform "s#^\.#charliecloud-${VERSION}#" \
+tar czf $RPMBUILD/SOURCES/charliecloud-"${VERSION}".tar.gz \
+    --xform "s#^\\.#charliecloud-${VERSION}#" \
     --exclude=.git \
     .
 

--- a/test/build.bats
+++ b/test/build.bats
@@ -2,23 +2,23 @@ load common
 
 @test 'create tarball directory if needed' {
     scope quick
-    mkdir -p $TARDIR
+    mkdir -p "$TARDIR"
 }
 
 @test 'documentations build' {
     scope standard
     command -v sphinx-build > /dev/null 2>&1 || skip "sphinx is not installed"
     test -d ../doc-src || skip "documentation source code absent"
-    cd ../doc-src && make -j $(getconf _NPROCESSORS_ONLN)
+    cd ../doc-src && make -j "$(getconf _NPROCESSORS_ONLN)"
 }
 
 @test 'version number seems sane' {
     echo "version: $CH_VERSION"
-    [[ $(echo $CH_VERSION | wc -l) -eq 1 ]]  # one line
+    [[ $(echo "$CH_VERSION" | wc -l) -eq 1 ]]  # one line
     [[ $CH_VERSION =~ ^0\.[0-9]+\.[0-9]+ ]]  # starts with a number triplet
     # matches VERSION.full if available
     if [[ -e $CH_BIN/../VERSION.full ]]; then
-        diff -u <(echo $CH_VERSION) $CH_BIN/../VERSION.full
+        diff -u <(echo "$CH_VERSION") "$CH_BIN/../VERSION.full"
     fi
 }
 
@@ -28,26 +28,66 @@ load common
     # either (1) is executable or (2) ends in ".c". Demand satisfaction from
     # each. The latter is to catch cases when we haven't compiled everything;
     # if we have, the test makes duplicate demands, but that's low cost.
-    for i in $(find $CH_BIN -name 'ch-*' -a \( -executable -o -name '*.c' \));
-    do
-        i=$(echo $i | sed s/.c$//)
+    while IFS= read -r -d '' i; do
+        i=${i%.c}
         echo
-        echo $i
+        echo "$i"
         # --version
-        run $i --version
+        run "$i" --version
         echo "$output"
         [[ $status -eq 0 ]]
-        diff -u <(echo "$output") <(echo $CH_VERSION)
+        diff -u <(echo "$output") <(echo "$CH_VERSION")
         # --help: returns 0, says "Usage:" somewhere.
-        run $i --help
+        run "$i" --help
         echo "$output"
         [[ $status -eq 0 ]]
         [[ $output =~ Usage: ]]
         # not setuid or setgid
-        ls -l $i
+        ls -l "$i"
         [[ ! -u $i ]]
         [[ ! -g $i ]]
+    done < <( find "$CH_BIN" -name 'ch-*' -a \( -executable -o -name '*.c' \) \
+                   -print0 )
+
+}
+
+@test 'lint shell scripts' {
+    scope standard
+    ( command -v shellcheck >/dev/null 2>&1 ) || skip "no shellcheck found"
+    # user executables
+    for i in "$CH_BIN"/ch-*; do
+        echo "shellcheck: $i"
+        [[ ! $(file "$i") = *'shell script'* ]] && continue
+        shellcheck -e SC1090 "$i"
     done
+    # libraries for user executables
+    for i in "$CH_LIBEXEC"/*.sh; do
+        echo "shellcheck: $i"
+        shellcheck -s sh -e SC1090 "$i"
+    done
+    # BATS scripts
+    #
+    # The sed horror encapsulated here is because BATS requires that the curly
+    # open brace after @test be on the same line, while ShellCheck requires
+    # that it not be (otherwise parse error). Thus, line numbers are wrong.
+    while IFS= read -r -d '' i; do
+        echo "shellcheck: $i"
+          sed -r $'s/(@test .+) \{/\\1\\\n{/g' "$i" \
+        | shellcheck -s bash -e SC1090,SC2002,SC2154,SC2164 -
+    done < <( find . ../examples -name bats -prune -o -name '*.bats' -print0 )
+    # libraries for BATS scripts
+    shellcheck -s bash -e SC2034 ./common.bash
+    # misc shell scripts
+    if [[ -e ../packaging ]]; then
+        MISC=". ../examples ../packaging"
+    else
+        MISC=". ../examples"
+    fi
+    # shellcheck disable=SC2086
+    while IFS= read -r -d '' i; do
+        echo "shellcheck: $i"
+        shellcheck -e SC2002 "$i"
+    done < <( find $MISC -name bats -prune -o -name '*.sh' -print0 )
 }
 
 @test 'proxy variables' {
@@ -85,15 +125,15 @@ load common
     # This test unpacks into $TARDIR so we don't put anything in $IMGDIR at
     # build time. It removes the image on completion.
     need_docker
-    TAR=$TARDIR/alpine36.tar.gz
-    IMG=$TARDIR/test
+    TAR="$TARDIR/alpine36.tar.gz"
+    IMG="$TARDIR/test"
     [[ ! -e $IMG ]]
-    ch-build2dir .. $TARDIR --file=Dockerfile.alpine36
-    sudo docker tag test test:$CH_VERSION_DOCKER
+    ch-build2dir .. "$TARDIR" --file=Dockerfile.alpine36
+    sudo docker tag test "test:$CH_VERSION_DOCKER"
     docker_ok test
-    image_ok $IMG
+    image_ok "$IMG"
     # Remove since we don't want it hanging around later.
-    rm -Rf --one-file-system $TAR $IMG
+    rm -Rf --one-file-system "$TAR" "$IMG"
 }
 
 @test 'sotest executable works' {

--- a/test/build_post.bats
+++ b/test/build_post.bats
@@ -3,7 +3,7 @@ load common
 @test 'nothing unexpected in tarball directory' {
     scope quick
     # We want nothing that's not a .tar.gz or .pg_missing.
-    run find $TARDIR -mindepth 1 \
+    run find "$TARDIR" -mindepth 1 \
         -not \( -name '*.tar.gz' -o -name '*.pq_missing' \)
     echo "$output"
     [[ $output = '' ]]

--- a/test/docker-clean.sh
+++ b/test/docker-clean.sh
@@ -10,7 +10,7 @@ while true; do
     cs_ct=$($cmd | wc -l)
     echo "found $cs_ct containers"
     [[ 0 -eq $cs_ct ]] && break
-    sudo docker rm $($cmd)
+    sudo docker rm "$($cmd)"
 done
 
 # Untag all images
@@ -19,7 +19,7 @@ while true; do
     tag_ct=$($cmd | wc -l)
     echo "found $tag_ct tagged images"
     [[ 0 -eq $tag_ct ]] && break
-    sudo docker rmi -f --no-prune $($cmd)
+    sudo docker rmi -f --no-prune "$($cmd)"
 done
 
 # If --all specified, remove all images.
@@ -29,6 +29,6 @@ if [[ $1 = --all ]]; then
         img_ct=$($cmd | wc -l)
         echo "found $img_ct images"
         [[ 0 -eq $img_ct ]] && break
-        sudo docker rmi -f $($cmd)
+        sudo docker rmi -f "$($cmd)"
     done
 fi

--- a/test/make-auto
+++ b/test/make-auto
@@ -44,14 +44,14 @@ for path in sys.argv[2:]:
     TARBALL=$TARDIR/%(tag)s.tar.gz
     PQ=$TARDIR/%(tag)s.pq_missing
     WORKDIR=$TARDIR/%(tag)s.tmp
-    rm -f $PQ
-    mkdir $WORKDIR
-    cd %(d)s
-    run ./%(f)s $PWD $TARBALL $WORKDIR
+    rm -f "$PQ"
+    mkdir "$WORKDIR"
+    cd "%(d)s"
+    run ./%(f)s "$PWD" "$TARBALL" "$WORKDIR"
     echo "$output"
-    rm -Rf $WORKDIR
+    rm -Rf "$WORKDIR"
     if [[ $status -eq 65 ]]; then
-         touch $PQ
+         touch "$PQ"
          skip 'prerequisites not met'
     fi
     [[ $status -eq 0 ]]
@@ -62,8 +62,8 @@ for path in sys.argv[2:]:
 @test 'ch-build %(tag)s' {
     scope %(scope)s
     need_docker %(tag)s
-    ch-build -t %(tag)s --file=%(path)s ..
-    sudo docker tag %(tag)s %(tag)s:$CH_VERSION_DOCKER
+    ch-build -t %(tag)s --file="%(path)s" ..
+    sudo docker tag %(tag)s "%(tag)s:$CH_VERSION_DOCKER"
     docker_ok %(tag)s
 }"""
          else:
@@ -76,16 +76,16 @@ for path in sys.argv[2:]:
     need_docker %(tag)s
     sudo docker pull %(addr)s
     sudo docker tag %(addr)s %(tag)s
-    sudo docker tag %(tag)s %(tag)s:$CH_VERSION_DOCKER
+    sudo docker tag %(tag)s "%(tag)s:$CH_VERSION_DOCKER"
     docker_ok %(tag)s
 }"""
          template += """
 @test 'ch-docker2tar %(tag)s' {
     scope %(scope)s
     need_docker
-    TARBALL=$TARDIR/%(tag)s.tar.gz
-    ch-docker2tar %(tag)s $TARDIR
-    tarball_ok $TARBALL
+    TARBALL="$TARDIR/%(tag)s.tar.gz"
+    ch-docker2tar %(tag)s "$TARDIR"
+    tarball_ok "$TARBALL"
 }"""
       else:
          assert False, "unknown build type"
@@ -98,11 +98,11 @@ for path in sys.argv[2:]:
 @test 'ch-tar2dir %(tag)s' {
     scope %(scope)s
     prerequisites_ok %(tag)s
-    ch-tar2dir $TARDIR/%(tag)s.tar.gz $IMGDIR
+    ch-tar2dir "$TARDIR/%(tag)s.tar.gz" "$IMGDIR"
 }
 @test 'ch-run %(tag)s /bin/true' {
     scope %(scope)s
     prerequisites_ok %(tag)s
-    IMG=$IMGDIR/%(tag)s
-    ch-run $IMG /bin/true
+    IMG="$IMGDIR/%(tag)s"
+    ch-run "$IMG" /bin/true
 }""" % locals())

--- a/test/run/ch-fromhost.bats
+++ b/test/run/ch-fromhost.bats
@@ -7,20 +7,20 @@ fromhost_clean () {
                 /usr/local/cuda-9.1/targets/x86_64-linux/lib/libsotest.so.1{.0,} \
                 /mnt/sotest.c \
                 /etc/ld.so.cache ; do
-        rm -f $1/$file
+        rm -f "$1/$file"
     done
-    fromhost_clean_p $1
+    fromhost_clean_p "$1"
 }
 
 fromhost_clean_p () {
-    run fromhost_ls $1
+    run fromhost_ls "$1"
     echo "$output"
     [[ $status -eq 0 ]]
     [[ -z $output ]]
 }
 
 fromhost_ls () {
-    find $1 -xdev \( -name '*sotest*' -o -name 'ld.so.cache' \) -ls
+    find "$1" -xdev \( -name '*sotest*' -o -name 'ld.so.cache' \) -ls
 }
 
 @test 'ch-fromhost (Debian)' {
@@ -29,163 +29,163 @@ fromhost_ls () {
     IMG=$IMGDIR/debian9
 
     # --cmd
-    fromhost_clean $IMG
-    ch-fromhost -v --cmd 'cat sotest/files_inferrable.txt' $IMG
-    fromhost_ls $IMG
-    test -f $IMG/usr/bin/sotest
-    test -f $IMG/usr/local/lib/libsotest.so.1.0
-    test -L $IMG/usr/local/lib/libsotest.so.1
-    ch-run $IMG -- /sbin/ldconfig -p | fgrep sotest
-    ch-run $IMG -- sotest
-    rm $IMG/usr/bin/sotest
-    rm $IMG/usr/local/lib/libsotest.so.1.0
-    rm $IMG/usr/local/lib/libsotest.so.1
-    rm $IMG/etc/ld.so.cache
-    fromhost_clean_p $IMG
+    fromhost_clean "$IMG"
+    ch-fromhost -v --cmd 'cat sotest/files_inferrable.txt' "$IMG"
+    fromhost_ls "$IMG"
+    test -f "$IMG/usr/bin/sotest"
+    test -f "$IMG/usr/local/lib/libsotest.so.1.0"
+    test -L "$IMG/usr/local/lib/libsotest.so.1"
+    ch-run "$IMG" -- /sbin/ldconfig -p | grep -F sotest
+    ch-run "$IMG" -- sotest
+    rm "$IMG/usr/bin/sotest"
+    rm "$IMG/usr/local/lib/libsotest.so.1.0"
+    rm "$IMG/usr/local/lib/libsotest.so.1"
+    rm "$IMG/etc/ld.so.cache"
+    fromhost_clean_p "$IMG"
 
     # --cmd twice
     ch-fromhost -v --cmd 'cat sotest/files_inferrable.txt' \
-                   --cmd 'cat sotest/files_inferrable.txt' $IMG
-    ch-run $IMG -- sotest
-    fromhost_clean $IMG
+                   --cmd 'cat sotest/files_inferrable.txt' "$IMG"
+    ch-run "$IMG" -- sotest
+    fromhost_clean "$IMG"
 
     # --file
-    ch-fromhost -v --file sotest/files_inferrable.txt $IMG
-    ch-run $IMG -- sotest
-    fromhost_clean $IMG
+    ch-fromhost -v --file sotest/files_inferrable.txt "$IMG"
+    ch-run "$IMG" -- sotest
+    fromhost_clean "$IMG"
 
     # --file twice
     ch-fromhost -v --file sotest/files_inferrable.txt \
-                   --file sotest/files_inferrable.txt $IMG
-    ch-run $IMG -- sotest
-    fromhost_clean $IMG
+                   --file sotest/files_inferrable.txt "$IMG"
+    ch-run "$IMG" -- sotest
+    fromhost_clean "$IMG"
 
     # --cmd and --file
     ch-fromhost -v --cmd 'cat sotest/files_inferrable.txt' \
-                   --file sotest/files_inferrable.txt $IMG
-    ch-run $IMG -- sotest
-    fromhost_clean $IMG
+                   --file sotest/files_inferrable.txt "$IMG"
+    ch-run "$IMG" -- sotest
+    fromhost_clean "$IMG"
 
     # --dest
     ch-fromhost -v --file sotest/files_inferrable.txt \
                    --file sotest/files_noninferrable.txt \
-                   --dest /mnt $IMG
-    ch-run $IMG -- sotest
-    ch-run $IMG -- test -f /mnt/sotest.c
-    fromhost_clean $IMG
+                   --dest /mnt "$IMG"
+    ch-run "$IMG" -- sotest
+    ch-run "$IMG" -- test -f /mnt/sotest.c
+    fromhost_clean "$IMG"
 
     # file that needs --dest but not specified
-    run ch-fromhost -v --file sotest/files_noninferrable.txt $IMG
+    run ch-fromhost -v --file sotest/files_noninferrable.txt "$IMG"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'no destination for: sotest/sotest.c' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'no destination for: sotest/sotest.c'* ]]
+    fromhost_clean_p "$IMG"
 
     # --no-infer
-    ch-run -w $IMG -- /sbin/ldconfig  # restore default cache
+    ch-run -w "$IMG" -- /sbin/ldconfig  # restore default cache
     ch-fromhost -v --cmd 'echo sotest/bin/sotest' \
-                   --no-infer --dest /usr/bin $IMG
+                   --no-infer --dest /usr/bin "$IMG"
     ch-fromhost -v --cmd 'echo sotest/lib/libsotest.so.1.0' \
-                   --no-infer --dest /usr/local/lib $IMG
-    fromhost_ls $IMG
-    ch-run $IMG -- /sbin/ldconfig -p | fgrep sotest || true
-    run ch-run $IMG -- sotest
+                   --no-infer --dest /usr/local/lib "$IMG"
+    fromhost_ls "$IMG"
+    ch-run "$IMG" -- /sbin/ldconfig -p | grep -F sotest || true
+    run ch-run "$IMG" -- sotest
     echo "$output"
     [[ $status -ne 0 ]]
-    [[ $output =~ 'libsotest.so.1: cannot open shared object file' ]]
-    fromhost_clean $IMG
+    [[ $output = *'libsotest.so.1: cannot open shared object file'* ]]
+    fromhost_clean "$IMG"
 
     # no --verbose
-    ch-fromhost --file sotest/files_inferrable.txt $IMG
-    ch-run $IMG -- sotest
-    fromhost_clean $IMG
+    ch-fromhost --file sotest/files_inferrable.txt "$IMG"
+    ch-run "$IMG" -- sotest
+    fromhost_clean "$IMG"
 
     # --cmd no argument
-    run ch-fromhost $IMG --cmd
+    run ch-fromhost "$IMG" --cmd
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ '--cmd must not be empty' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'--cmd must not be empty'* ]]
+    fromhost_clean_p "$IMG"
     # --cmd empty
     run ch-fromhost --cmd true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'empty file list' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'empty file list'* ]]
+    fromhost_clean_p "$IMG"
     # --cmd fails
     run ch-fromhost --cmd false
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'command failed: false' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'command failed: false'* ]]
+    fromhost_clean_p "$IMG"
 
     # --file no argument
-    run ch-fromhost $IMG --file
+    run ch-fromhost "$IMG" --file
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ '--file must not be empty' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'--file must not be empty'* ]]
+    fromhost_clean_p "$IMG"
     # --file empty
-    run ch-fromhost --file /dev/null $IMG
+    run ch-fromhost --file /dev/null "$IMG"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'empty file list' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'empty file list'* ]]
+    fromhost_clean_p "$IMG"
     # --file does not exist
-    run ch-fromhost --file /doesnotexist $IMG
+    run ch-fromhost --file /doesnotexist "$IMG"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ '/doesnotexist: No such file or directory' ]]
-    [[ $output =~ 'cannot read file: /doesnotexist' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'/doesnotexist: No such file or directory'* ]]
+    [[ $output = *'cannot read file: /doesnotexist'* ]]
+    fromhost_clean_p "$IMG"
 
     # neither --cmd nor --file
-    run ch-fromhost $IMG
+    run ch-fromhost "$IMG"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'empty file list' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'empty file list'* ]]
+    fromhost_clean_p "$IMG"
 
     # --dest no argument
-    run ch-fromhost $IMG --dest
+    run ch-fromhost "$IMG" --dest
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ '--dest must not be empty' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'--dest must not be empty'* ]]
+    fromhost_clean_p "$IMG"
     # --dest not an absolute path
     run ch-fromhost --file sotest/files_noninferrable.txt \
-                    --dest relative $IMG
+                    --dest relative "$IMG"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'not an absolute path: relative' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'not an absolute path: relative'* ]]
+    fromhost_clean_p "$IMG"
     # --dest does not exist
     run ch-fromhost --file sotest/files_noninferrable.txt \
-                    --dest /doesnotexist $IMG
+                    --dest /doesnotexist "$IMG"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'not a directory:' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'not a directory:'* ]]
+    fromhost_clean_p "$IMG"
     # --dest is not a directory
     run ch-fromhost --file sotest/files_noninferrable.txt \
-                    --dest /bin/sh $IMG
+                    --dest /bin/sh "$IMG"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'not a directory:' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'not a directory:'* ]]
+    fromhost_clean_p "$IMG"
 
     # image does not exist
     run ch-fromhost --file sotest/files_inferrable.txt /doesnotexist
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'image not a directory: /doesnotexist' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'image not a directory: /doesnotexist'* ]]
+    fromhost_clean_p "$IMG"
     # image specified twice
-    run ch-fromhost --file sotest/files_inferrable.txt $IMG $IMG
+    run ch-fromhost --file sotest/files_inferrable.txt "$IMG" "$IMG"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'duplicate image path' ]]
-    fromhost_clean_p $IMG
+    [[ $output = *'duplicate image path'* ]]
+    fromhost_clean_p "$IMG"
 }
 
 @test 'ch-fromhost (CentOS)' {
@@ -193,26 +193,26 @@ fromhost_ls () {
     prerequisites_ok centos7
     IMG=$IMGDIR/centos7
 
-    fromhost_clean $IMG
-    ch-fromhost -v --file sotest/files_inferrable.txt $IMG
-    fromhost_ls $IMG
-        test -f $IMG/usr/bin/sotest
-    test -f $IMG/lib/libsotest.so.1.0
-    test -L $IMG/lib/libsotest.so.1
-    ch-run $IMG -- /sbin/ldconfig -p | fgrep sotest
-    ch-run $IMG -- sotest
-    rm $IMG/usr/bin/sotest
-    rm $IMG/lib/libsotest.so.1.0
-    rm $IMG/lib/libsotest.so.1
-    rm $IMG/etc/ld.so.cache
-    fromhost_clean_p $IMG
+    fromhost_clean "$IMG"
+    ch-fromhost -v --file sotest/files_inferrable.txt "$IMG"
+    fromhost_ls "$IMG"
+    test -f "$IMG/usr/bin/sotest"
+    test -f "$IMG/lib/libsotest.so.1.0"
+    test -L "$IMG/lib/libsotest.so.1"
+    ch-run "$IMG" -- /sbin/ldconfig -p | grep -F sotest
+    ch-run "$IMG" -- sotest
+    rm "$IMG/usr/bin/sotest"
+    rm "$IMG/lib/libsotest.so.1.0"
+    rm "$IMG/lib/libsotest.so.1"
+    rm "$IMG/etc/ld.so.cache"
+    fromhost_clean_p "$IMG"
 }
 
 @test 'ch-fromhost --nvidia with GPU' {
     scope full
     prerequisites_ok nvidia
     command -v nvidia-container-cli >/dev/null 2>&1 \
-        || skip 'nvidia-container-cli not in $PATH'
+        || skip 'nvidia-container-cli not in PATH'
     IMG=$IMGDIR/nvidia
 
     # nvidia-container-cli --version (to make sure it's linked correctly)
@@ -229,43 +229,43 @@ fromhost_ls () {
     fi
 
     # --nvidia
-    ch-fromhost -v --nvidia $IMG
+    ch-fromhost -v --nvidia "$IMG"
 
     # nvidia-smi runs in guest
-    ch-run $IMG -- nvidia-smi -L
+    ch-run "$IMG" -- nvidia-smi -L
 
     # nvidia-smi -L matches host
     host=$(nvidia-smi -L)
     echo "host GPUs:"
     echo "$host"
-    guest=$(ch-run $IMG -- nvidia-smi -L)
+    guest=$(ch-run "$IMG" -- nvidia-smi -L)
     echo "guest GPUs:"
     echo "$guest"
     cmp <(echo "$host") <(echo "$guest")
 
     # --nvidia and --cmd
-    fromhost_clean $IMG
-    ch-fromhost --nvidia --file sotest/files_inferrable.txt $IMG
-    ch-run $IMG -- nvidia-smi -L
-    ch-run $IMG -- sotest
+    fromhost_clean "$IMG"
+    ch-fromhost --nvidia --file sotest/files_inferrable.txt "$IMG"
+    ch-run "$IMG" -- nvidia-smi -L
+    ch-run "$IMG" -- sotest
     # --nvidia and --file
-    fromhost_clean $IMG
-    ch-fromhost --nvidia --cmd 'cat sotest/files_inferrable.txt' $IMG
-    ch-run $IMG -- nvidia-smi -L
-    ch-run $IMG -- sotest
+    fromhost_clean "$IMG"
+    ch-fromhost --nvidia --cmd 'cat sotest/files_inferrable.txt' "$IMG"
+    ch-run "$IMG" -- nvidia-smi -L
+    ch-run "$IMG" -- sotest
 
     # CUDA sample
     SAMPLE=/matrixMulCUBLAS
     # should fail without ch-fromhost --nvidia
-    fromhost_clean $IMG
-    run ch-run $IMG -- $SAMPLE
+    fromhost_clean "$IMG"
+    run ch-run "$IMG" -- $SAMPLE
     echo "$output"
     [[ $status -eq 127 ]]
     [[ $output =~ 'matrixMulCUBLAS: error while loading shared libraries' ]]
     # should succeed with it
-    fromhost_clean_p $IMG
-    ch-fromhost --nvidia $IMG
-    run ch-run $IMG -- $SAMPLE
+    fromhost_clean_p "$IMG"
+    ch-fromhost --nvidia "$IMG"
+    run ch-run "$IMG" -- $SAMPLE
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ 'Comparing CUBLAS Matrix Multiply with CPU results: PASS' ]]
@@ -288,14 +288,14 @@ fromhost_ls () {
         else
             [[ $status -eq 1 ]]
             [[ $output = *'cuda error'* ]]
-            run ch-fromhost -v --nvidia $IMG
+            run ch-fromhost -v --nvidia "$IMG"
             echo "$output"
             [[ $status -eq 1 ]]
             [[ $output = *'does this host have GPUs'* ]]
         fi
     else
         # nvidia-container-cli not in $PATH
-        run ch-fromhost -v --nvidia $IMG
+        run ch-fromhost -v --nvidia "$IMG"
         echo "$output"
         [[ $status -eq 1 ]]
         r="nvidia-container-cli: (command )?not found"

--- a/test/run/ch-run_escalated.bats
+++ b/test/run/ch-run_escalated.bats
@@ -6,42 +6,42 @@ load ../common
     GID=$(id -g)
     GID2=$(id -G | cut -d' ' -f2)
     echo "GIDs: $GID $GID2"
-    [[ $GID != $GID2 ]]
-    cp -a $CH_RUN_FILE $CH_RUN_TMP
-    ls -l $CH_RUN_TMP
-    chgrp $GID2 $CH_RUN_TMP
-    chmod g+s $CH_RUN_TMP
-    ls -l $CH_RUN_TMP
+    [[ $GID != "$GID2" ]]
+    cp -a "$CH_RUN_FILE" "$CH_RUN_TMP"
+    ls -l "$CH_RUN_TMP"
+    chgrp "$GID2" "$CH_RUN_TMP"
+    chmod g+s "$CH_RUN_TMP"
+    ls -l "$CH_RUN_TMP"
     [[ -g $CH_RUN_TMP ]]
-    run $CH_RUN_TMP --version
+    run "$CH_RUN_TMP" --version
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ ': error (' ]]
-    rm $CH_RUN_TMP
+    [[ $output = *': error ('* ]]
+    rm "$CH_RUN_TMP"
 }
 
 @test 'ch-run refuses to run if setuid' {
     scope quick
     [[ -n $CHTEST_HAVE_SUDO ]] || skip 'sudo not available'
     CH_RUN_TMP=$BATS_TMPDIR/ch-run.setuid
-    cp -a $CH_RUN_FILE $CH_RUN_TMP
-    ls -l $CH_RUN_TMP
-    sudo chown root $CH_RUN_TMP
-    sudo chmod u+s $CH_RUN_TMP
-    ls -l $CH_RUN_TMP
+    cp -a "$CH_RUN_FILE" "$CH_RUN_TMP"
+    ls -l "$CH_RUN_TMP"
+    sudo chown root "$CH_RUN_TMP"
+    sudo chmod u+s "$CH_RUN_TMP"
+    ls -l "$CH_RUN_TMP"
     [[ -u $CH_RUN_TMP ]]
-    run $CH_RUN_TMP --version
+    run "$CH_RUN_TMP" --version
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ ': error (' ]]
-    sudo rm $CH_RUN_TMP
+    [[ $output = *': error ('* ]]
+    sudo rm "$CH_RUN_TMP"
 }
 
 @test 'ch-run as root: --version and --test' {
     scope quick
     [[ -n $CHTEST_HAVE_SUDO ]] || skip 'sudo not available'
-    sudo $CH_RUN_FILE --version
-    sudo $CH_RUN_FILE --help
+    sudo "$CH_RUN_FILE" --version
+    sudo "$CH_RUN_FILE" --help
 }
 
 @test 'ch-run as root: run image' {
@@ -57,15 +57,15 @@ load ../common
     #   ch-run: [...]/chtest: Permission denied (ch-run.c:195:13)
     #
     skip 'issue #76'
-    sudo $CH_RUN_FILE $CHTEST_IMG -- true
+    sudo "$CH_RUN_FILE" "$CHTEST_IMG" -- true
 }
 
 @test 'ch-run as root: root with non-zero GID refused' {
     scope quick
     [[ -n $CHTEST_HAVE_SUDO ]] || skip 'sudo not available'
     [[ -z $TRAVIS ]] || skip 'not permitted on Travis'
-    run sudo -u root -g $(id -gn) $CH_RUN_FILE -v --version
+    run sudo -u root -g "$(id -gn)" "$CH_RUN_FILE" -v --version
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'error (' ]]
+    [[ $output = *'error ('* ]]
 }

--- a/test/run/ch-run_isolation.bats
+++ b/test/run/ch-run_isolation.bats
@@ -4,7 +4,7 @@ load ../common
     scope quick
     host_ns=$(stat -Lc '%i' /proc/self/ns/mnt)
     echo "host:  $host_ns"
-    guest_ns=$(ch-run $CHTEST_IMG -- stat -Lc '%i' /proc/self/ns/mnt)
+    guest_ns=$(ch-run "$CHTEST_IMG" -- stat -Lc %i /proc/self/ns/mnt)
     echo "guest: $guest_ns"
     [[ -n $host_ns && -n $guest_ns && $host_ns -ne $guest_ns ]]
 }
@@ -13,7 +13,7 @@ load ../common
     scope quick
     host_ns=$(stat -Lc '%i' /proc/self/ns/user)
     echo "host:  $host_userns"
-    guest_ns=$(ch-run $CHTEST_IMG -- stat -Lc '%i' /proc/self/ns/user)
+    guest_ns=$(ch-run "$CHTEST_IMG" -- stat -Lc %i /proc/self/ns/user)
     echo "guest: $guest_ns"
     [[ -n $host_ns && -n $guest_ns && $host_ns -ne $guest_ns ]]
 }
@@ -23,35 +23,35 @@ load ../common
     # This is a catch-all and a bit of a guess. Even if it fails, however, we
     # get an empty string, which is fine for the purposes of the test.
     host_distro=$(  cat /etc/os-release /etc/*-release /etc/*_version \
-                  | egrep -m1 '[A-Za-z] [0-9]' \
+                  | grep -Em1 '[A-Za-z] [0-9]' \
                   | sed -r 's/^(.*")?(.+)(")$/\2/')
     echo "host: $host_distro"
     guest_expected='Alpine Linux v3.6'
     echo "guest expected: $guest_expected"
-    if [[ $host_distro = $guest_expected ]]; then
+    if [[ $host_distro = "$guest_expected" ]]; then
         skip 'host matches expected guest distro'
     fi
-    guest_distro=$(ch-run $CHTEST_IMG -- \
+    guest_distro=$(ch-run "$CHTEST_IMG" -- \
                           cat /etc/os-release \
-                   | fgrep PRETTY_NAME \
+                   | grep -F PRETTY_NAME \
                    | sed -r 's/^(.*")?(.+)(")$/\2/')
     echo "guest: $guest_distro"
-    [[ $guest_distro = $guest_expected ]]
-    [[ $guest_distro != $host_distro ]]
+    [[ $guest_distro = "$guest_expected" ]]
+    [[ $guest_distro != "$host_distro" ]]
 }
 
 @test 'user and group match host' {
     scope quick
     host_uid=$(id -u)
-    guest_uid=$(ch-run $CHTEST_IMG -- id -u)
-    [[ $host_uid = $guest_uid ]]
+    guest_uid=$(ch-run "$CHTEST_IMG" -- id -u)
+    [[ $host_uid = "$guest_uid" ]]
     host_pgid=$(id -g)
-    guest_pgid=$(ch-run $CHTEST_IMG -- id -g)
-    [[ $host_pgid = $guest_pgid ]]
+    guest_pgid=$(ch-run "$CHTEST_IMG" -- id -g)
+    [[ $host_pgid = "$guest_pgid" ]]
     host_username=$(id -un)
-    guest_username=$(ch-run $CHTEST_IMG -- id -un)
-    [[ $host_username = $guest_username ]]
+    guest_username=$(ch-run "$CHTEST_IMG" -- id -un)
+    [[ $host_username = "$guest_username" ]]
     host_pgroup=$(id -gn)
-    guest_pgroup=$(ch-run $CHTEST_IMG -- id -gn)
-    [[ $host_pgroup = $guest_pgroup ]]
+    guest_pgroup=$(ch-run "$CHTEST_IMG" -- id -gn)
+    [[ $host_pgroup = "$guest_pgroup" ]]
 }

--- a/test/run/ch-run_join.bats
+++ b/test/run/ch-run_join.bats
@@ -25,45 +25,45 @@ joined_ok () {
     if [[ $status -eq 0 ]]; then
         printf 'ok\n' 1>&2
     else
-        printf 'fail (%d)\n' $status 1>&2
+        printf 'fail (%d)\n' "$status" 1>&2
         return 1
     fi
     # number of processes
-    printf '  process count; expected %d: ' $proc_ct_total 1>&2
-    proc_ct_found=$(echo "$output" | egrep -c 'join: 1 [0-9]+ [0-9a-z]+')
-    if [[ $proc_ct_total -eq $proc_ct_found ]]; then
+    printf '  process count; expected %d: ' "$proc_ct_total" 1>&2
+    proc_ct_found=$(echo "$output" | grep -Ec 'join: 1 [0-9]+ [0-9a-z]+')
+    if [[ $proc_ct_total -eq "$proc_ct_found" ]]; then
         printf 'ok\n'
     else
-        printf 'fail (%d)\n' $proc_ct_found 1>&2
+        printf 'fail (%d)\n' "$proc_ct_found" 1>&2
         return 1
     fi
     # number of peers
-    printf '  peer group size; expected %d: ' $peer_ct_node 1>&2
+    printf '  peer group size; expected %d: ' "$peer_ct_node" 1>&2
     peer_cts=$(  echo "$output" \
                | sed -rn 's/^ch-run\[[0-9]+\]: join: 1 ([0-9]+) .+$/\1/p')
     peer_ct_found=$(echo "$peer_cts" | sort -u)
     peer_cts_found=$(echo "$peer_ct_found" | wc -l)
     if [[ $peer_cts_found -ne 1 ]]; then
-        printf 'fail (%d different counts reported)\n' $peer_cts_found 1>&2
+        printf 'fail (%d different counts reported)\n' "$peer_cts_found" 1>&2
         return 1
     fi
-    if [[ $peer_ct_found -eq $peer_ct_node ]]; then
+    if [[ $peer_ct_found -eq "$peer_ct_node" ]]; then
         printf 'ok\n' 1>&2
     else
-        printf 'fail (%d)\n' $peer_ct_found 1>&2
+        printf 'fail (%d)\n' "$peer_ct_found" 1>&2
         return 1
     fi
     # correct number of namespace IDs
-    for i in $(ls /proc/self/ns); do
-        printf '  namespace ID count; expected %d: %s: ' $namespace_ct $i 1>&2
+    for i in /proc/self/ns/*; do
+        printf '  namespace count; expected %d: %s: ' "$namespace_ct" "$i" 1>&2
         namespace_ct_found=$(  echo "$output" \
-                             | egrep "^/proc/self/ns/$i:" \
+                             | grep -E "^$i:" \
                              | sort -u \
                              | wc -l)
-        if [[ $namespace_ct -eq $namespace_ct_found ]]; then
+        if [[ $namespace_ct -eq "$namespace_ct_found" ]]; then
             printf 'ok\n' 1>&2
         else
-            printf 'fail (%d)\n' $namespace_ct_found 1>&2
+            printf 'fail (%d)\n' "$namespace_ct_found" 1>&2
             return 1
         fi
     done
@@ -83,73 +83,72 @@ unset_vars () {
     ipc_clean_p
 
     # --join-ct
-    run ch-run -v --join-ct=1 $CHTEST_IMG -- /test/printns
-    joined_ok 1 1 1 $status "$output"
+    run ch-run -v --join-ct=1 "$CHTEST_IMG" -- /test/printns
+    joined_ok 1 1 1 "$status" "$output"
     r='join: 1 1 [0-9]+ '   # status from getppid(2) is all digits
     [[ $output =~ $r ]]
-    [[ $output =~ 'join: peer group size from command line' ]]
+    [[ $output = *'join: peer group size from command line'* ]]
     ipc_clean_p
 
     # join count from an environment variable
-    SLURM_CPUS_ON_NODE=1 run ch-run -v --join $CHTEST_IMG -- /test/printns
-    joined_ok 1 1 1 $status "$output"
-    [[ $output =~ 'join: peer group size from SLURM_CPUS_ON_NODE' ]]
+    SLURM_CPUS_ON_NODE=1 run ch-run -v --join "$CHTEST_IMG" -- /test/printns
+    joined_ok 1 1 1 "$status" "$output"
+    [[ $output = *'join: peer group size from SLURM_CPUS_ON_NODE'* ]]
     ipc_clean_p
 
     # join count from an environment variable with extra goop
-    SLURM_CPUS_ON_NODE=1foo ch-run --join $CHTEST_IMG -- /test/printns
-    joined_ok 1 1 1 $status "$output"
-    [[ $output =~ 'join: peer group size from SLURM_CPUS_ON_NODE' ]]
+    SLURM_CPUS_ON_NODE=1foo ch-run --join "$CHTEST_IMG" -- /test/printns
+    joined_ok 1 1 1 "$status" "$output"
+    [[ $output = *'join: peer group size from SLURM_CPUS_ON_NODE'* ]]
     ipc_clean_p
 
     # join tag
-    run ch-run -v --join-ct=1 --join-tag=foo $CHTEST_IMG -- /test/printns
-    joined_ok 1 1 1 $status "$output"
-    [[ $output =~ 'join: 1 1 foo' ]]
-    [[ $output =~ 'join: peer group tag from command line' ]]
+    run ch-run -v --join-ct=1 --join-tag=foo "$CHTEST_IMG" -- /test/printns
+    joined_ok 1 1 1 "$status" "$output"
+    [[ $output = *'join: 1 1 foo'* ]]
+    [[ $output = *'join: peer group tag from command line'* ]]
     ipc_clean_p
-    SLURM_STEP_ID=bar run ch-run -v --join-ct=1 $CHTEST_IMG -- /test/printns
-    joined_ok 1 1 1 $status "$output"
-    [[ $output =~ 'join: 1 1 bar' ]]
-    [[ $output =~ 'join: peer group tag from SLURM_STEP_ID' ]]
+    SLURM_STEP_ID=bar run ch-run -v --join-ct=1 "$CHTEST_IMG" -- /test/printns
+    joined_ok 1 1 1 "$status" "$output"
+    [[ $output = *'join: 1 1 bar'* ]]
+    [[ $output = *'join: peer group tag from SLURM_STEP_ID'* ]]
     ipc_clean_p
 }
 
 @test 'ch-run --join: two peers, direct launch' {
     unset_vars
     ipc_clean_p
-    outfiles="$BATS_TMPDIR/join.?.*"
-    rm -f $outfiles
+    rm -f "$BATS_TMPDIR"/join.?.*
 
     # first peer (winner)
-    ch-run -v --join-ct=2 --join-tag=foo $CHTEST_IMG -- \
-           /test/printns 5 $BATS_TMPDIR/join.1.ns \
-           >& $BATS_TMPDIR/join.1.err &
+    ch-run -v --join-ct=2 --join-tag=foo "$CHTEST_IMG" -- \
+           /test/printns 5 "$BATS_TMPDIR/join.1.ns" \
+           >& "$BATS_TMPDIR/join.1.err" &
     sleep 1
-    cat $BATS_TMPDIR/join.1.err
-    cat $BATS_TMPDIR/join.1.ns
-      fgrep -q 'join: 1 2' $BATS_TMPDIR/join.1.err
-      fgrep -q 'join: I won' $BATS_TMPDIR/join.1.err
-    ! fgrep -q 'join: cleaning up IPC' $BATS_TMPDIR/join.1.err
+    cat "$BATS_TMPDIR/join.1.err"
+    cat "$BATS_TMPDIR/join.1.ns"
+      grep -Fq 'join: 1 2' "$BATS_TMPDIR/join.1.err"
+      grep -Fq 'join: I won' "$BATS_TMPDIR/join.1.err"
+    ! grep -Fq 'join: cleaning up IPC' "$BATS_TMPDIR/join.1.err"
 
     # IPC resources present?
     test -e /dev/shm/ch-run_foo
     test -e /dev/shm/sem.ch-run_foo
 
     # second peer (loser)
-    run ch-run -v --join-ct=2 --join-tag=foo $CHTEST_IMG -- \
-               /test/printns 0 $BATS_TMPDIR/join.2.ns \
+    run ch-run -v --join-ct=2 --join-tag=foo "$CHTEST_IMG" -- \
+               /test/printns 0 "$BATS_TMPDIR/join.2.ns" \
     echo "$output"
     [[ $status -eq 0 ]]
-    cat $BATS_TMPDIR/join.2.ns
-      echo "$output" | fgrep -q 'join: 1 2'
-      echo "$output" | fgrep -q 'join: winner pid:'
-      echo "$output" | fgrep -q 'join: cleaning up IPC'
+    cat "$BATS_TMPDIR/join.2.ns"
+      echo "$output" | grep -Fq 'join: 1 2'
+      echo "$output" | grep -Fq 'join: winner pid:'
+      echo "$output" | grep -Fq 'join: cleaning up IPC'
 
     # same namespaces?
-    for i in $(ls /proc/self/ns); do
-        [[ 1 = $(  cat $BATS_TMPDIR/join.?.ns \
-                 | egrep "^/proc/self/ns/$i:" | uniq | wc -l) ]]
+    for i in /proc/self/ns/*; do
+        [[ 1 = $(  cat "$BATS_TMPDIR"/join.?.ns \
+                 | grep -E "^$i:" | uniq | wc -l) ]]
     done
 
     ipc_clean_p
@@ -158,52 +157,51 @@ unset_vars () {
 @test 'ch-run --join: three peers, direct launch' {
     unset_vars
     ipc_clean_p
-    outfiles="$BATS_TMPDIR/join.?.*"
-    rm -f $outfiles
+    rm -f "$BATS_TMPDIR"/join.?.*
 
     # first peer (winner)
-    ch-run -v --join-ct=3 --join-tag=foo $CHTEST_IMG -- \
-           /test/printns 5 $BATS_TMPDIR/join.1.ns \
-           >& $BATS_TMPDIR/join.1.err &
+    ch-run -v --join-ct=3 --join-tag=foo "$CHTEST_IMG" -- \
+           /test/printns 5 "$BATS_TMPDIR/join.1.ns" \
+           >& "$BATS_TMPDIR/join.1.err" &
     sleep 1
-    cat $BATS_TMPDIR/join.1.err
-    cat $BATS_TMPDIR/join.1.ns
-      fgrep -q 'join: 1 3' $BATS_TMPDIR/join.1.err
-      fgrep -q 'join: I won' $BATS_TMPDIR/join.1.err
-      fgrep -q 'join: 2 peers left' $BATS_TMPDIR/join.1.err
-    ! fgrep -q 'join: cleaning up IPC' $BATS_TMPDIR/join.1.err
+    cat "$BATS_TMPDIR/join.1.err"
+    cat "$BATS_TMPDIR/join.1.ns"
+      grep -Fq 'join: 1 3' "$BATS_TMPDIR/join.1.err"
+      grep -Fq 'join: I won' "$BATS_TMPDIR/join.1.err"
+      grep -Fq 'join: 2 peers left' "$BATS_TMPDIR/join.1.err"
+    ! grep -Fq 'join: cleaning up IPC' "$BATS_TMPDIR/join.1.err"
 
     # second peer (loser, no cleanup)
-    ch-run -v --join-ct=3 --join-tag=foo $CHTEST_IMG -- \
-           /test/printns 0 $BATS_TMPDIR/join.2.ns \
-           >& $BATS_TMPDIR/join.2.err &
+    ch-run -v --join-ct=3 --join-tag=foo "$CHTEST_IMG" -- \
+           /test/printns 0 "$BATS_TMPDIR/join.2.ns" \
+           >& "$BATS_TMPDIR/join.2.err" &
     sleep 1
-    cat $BATS_TMPDIR/join.2.err
-    cat $BATS_TMPDIR/join.2.ns
-      fgrep -q 'join: 1 3' $BATS_TMPDIR/join.2.err
-      fgrep -q 'join: winner pid:' $BATS_TMPDIR/join.2.err
-      fgrep -q 'join: 1 peers left' $BATS_TMPDIR/join.2.err
-    ! fgrep -q 'join: cleaning up IPC' $BATS_TMPDIR/join.2.err
+    cat "$BATS_TMPDIR/join.2.err"
+    cat "$BATS_TMPDIR/join.2.ns"
+      grep -Fq 'join: 1 3' "$BATS_TMPDIR/join.2.err"
+      grep -Fq 'join: winner pid:' "$BATS_TMPDIR/join.2.err"
+      grep -Fq 'join: 1 peers left' "$BATS_TMPDIR/join.2.err"
+    ! grep -Fq 'join: cleaning up IPC' "$BATS_TMPDIR/join.2.err"
 
     # IPC resources present?
     test -e /dev/shm/ch-run_foo
     test -e /dev/shm/sem.ch-run_foo
 
     # third peer (loser, cleanup)
-    ch-run -v --join-ct=3 --join-tag=foo $CHTEST_IMG -- \
-           /test/printns 0 $BATS_TMPDIR/join.3.ns \
-           >& $BATS_TMPDIR/join.3.err &
-    cat $BATS_TMPDIR/join.3.err
-    cat $BATS_TMPDIR/join.3.ns
-      fgrep -q 'join: 1 3' $BATS_TMPDIR/join.3.err
-      fgrep -q 'join: winner pid:' $BATS_TMPDIR/join.3.err
-      fgrep -q 'join: 0 peers left' $BATS_TMPDIR/join.3.err
-      fgrep -q 'join: cleaning up IPC' $BATS_TMPDIR/join.3.err
+    ch-run -v --join-ct=3 --join-tag=foo "$CHTEST_IMG" -- \
+           /test/printns 0 "$BATS_TMPDIR/join.3.ns" \
+           >& "$BATS_TMPDIR/join.3.err" &
+    cat "$BATS_TMPDIR/join.3.err"
+    cat "$BATS_TMPDIR/join.3.ns"
+      grep -Fq 'join: 1 3' "$BATS_TMPDIR/join.3.err"
+      grep -Fq 'join: winner pid:' "$BATS_TMPDIR/join.3.err"
+      grep -Fq 'join: 0 peers left' "$BATS_TMPDIR/join.3.err"
+      grep -Fq 'join: cleaning up IPC' "$BATS_TMPDIR/join.3.err"
 
     # same namespaces?
-    for i in $(ls /proc/self/ns); do
-        [[ 1 = $(  cat $BATS_TMPDIR/join.?.ns \
-                 | egrep "^/proc/self/ns/$i:" | uniq | wc -l) ]]
+    for i in /proc/self/ns/*; do
+        [[ 1 = $(  cat "$BATS_TMPDIR"/join.?.ns \
+                 | grep -E "^$i:" | uniq | wc -l) ]]
     done
 
     ipc_clean_p
@@ -215,69 +213,51 @@ unset_vars () {
 
     # Two peers, one node. Should be one of each of the namespaces. Make sure
     # everyone chdir(2)s properly.
-    run $MPIRUN_2_1NODE ch-run -v --join --cd /test $CHTEST_IMG -- ./printns 2
+    # shellcheck disable=SC2086
+    run $MPIRUN_2_1NODE ch-run -v --join --cd /test "$CHTEST_IMG" -- ./printns 2
     ipc_clean_p
-    joined_ok 2 2 1 $status "$output"
+    joined_ok 2 2 1 "$status" "$output"
 
     # One peer per core across the allocation. Should be $CHTEST_NODES of each
     # of the namespaces.
-    run $MPIRUN_CORE ch-run -v --join $CHTEST_IMG -- /test/printns 4
-    joined_ok $CHTEST_CORES_TOTAL $CHTEST_CORES_NODE $CHTEST_NODES \
-              $status "$output"
+    # shellcheck disable=SC2086
+    run $MPIRUN_CORE ch-run -v --join "$CHTEST_IMG" -- /test/printns 4
+    joined_ok "$CHTEST_CORES_TOTAL" "$CHTEST_CORES_NODE" "$CHTEST_NODES" \
+              "$status" "$output"
     ipc_clean_p
 }
 
 @test 'ch-run --join: peer group size errors' {
     unset_vars
 
-    # join count negative
-    run ch-run --join-ct=-1 $CHTEST_IMG -- true
-    echo "$output"
-    [[ $status -eq 1 ]]
-    [[ $output =~ 'join: no valid peer group size found' ]]
-    SLURM_CPUS_ON_NODE=-1 run ch-run --join $CHTEST_IMG -- true
-    echo "$output"
-    [[ $status -eq 1 ]]
-    [[ $output =~ 'join: no valid peer group size found' ]]
-
-    # join count zero
-    run ch-run --join-ct=0 $CHTEST_IMG -- true
-    echo "$output"
-    [[ $status -eq 1 ]]
-    [[ $output =~ 'join: no valid peer group size found' ]]
-    SLURM_CPUS_ON_NODE=0 run ch-run --join $CHTEST_IMG -- true
-    echo "$output"
-    [[ $status -eq 1 ]]
-    [[ $output =~ 'join: no valid peer group size found' ]]
-
     # --join but no join count
-    run ch-run --join $CHTEST_IMG -- true
+    run ch-run --join "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ 'join: no valid peer group size found' ]]
 
     # join count no digits
-    run ch-run --join-ct=a $CHTEST_IMG -- true
+    run ch-run --join-ct=a "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ 'join-ct: no digits found' ]]
-    SLURM_CPUS_ON_NODE=a run ch-run --join $CHTEST_IMG -- true
+    SLURM_CPUS_ON_NODE=a run ch-run --join "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ 'SLURM_CPUS_ON_NODE: no digits found' ]]
 
     # join count empty string
-    run ch-run --join-ct='' $CHTEST_IMG -- true
+    run ch-run --join-ct='' "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ '--join-ct: no digits found' ]]
-    SLURM_CPUS_ON_NODE=-1 run ch-run --join $CHTEST_IMG -- true
+    SLURM_CPUS_ON_NODE=-1 run ch-run --join "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ 'join: no valid peer group size found' ]]
 
     # --join-ct digits followed by extra goo (OK from environment variable)
-    run ch-run --join-ct=1a $CHTEST_IMG -- true
+    run ch-run --join-ct=1a "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ '--join-ct: extra characters after digits' ]]
@@ -286,45 +266,45 @@ unset_vars () {
     range_re='.*: .*out of range'
 
     # join count above INT_MAX
-    run ch-run --join-ct=2147483648 $CHTEST_IMG -- true
+    run ch-run --join-ct=2147483648 "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ $range_re ]]
     SLURM_CPUS_ON_NODE=2147483648 \
-        run ch-run --join $CHTEST_IMG -- true
+        run ch-run --join "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ $range_re ]]
 
     # join count below INT_MIN
-    run ch-run --join-ct=-2147483649 $CHTEST_IMG -- true
+    run ch-run --join-ct=-2147483649 "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ $range_re ]]
     SLURM_CPUS_ON_NODE=-2147483649 \
-        run ch-run --join $CHTEST_IMG -- true
+        run ch-run --join "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ $range_re ]]
 
     # join count above LONG_MAX
-    run ch-run --join-ct=9223372036854775808 $CHTEST_IMG -- true
+    run ch-run --join-ct=9223372036854775808 "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ $range_re ]]
     SLURM_CPUS_ON_NODE=9223372036854775808 \
-        run ch-run --join $CHTEST_IMG -- true
+        run ch-run --join "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ $range_re ]]
 
     # join count below LONG_MIN
-    run ch-run --join-ct=-9223372036854775809 $CHTEST_IMG -- true
+    run ch-run --join-ct=-9223372036854775809 "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ $range_re ]]
     SLURM_CPUS_ON_NODE=-9223372036854775809 \
-        run ch-run --join $CHTEST_IMG -- true
+        run ch-run --join "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ $range_re ]]
@@ -337,11 +317,11 @@ unset_vars () {
     export SLURM_CPUS_ON_NODE=1
 
     # join tag empty string
-    run ch-run --join-tag='' $CHTEST_IMG -- true
+    run ch-run --join-tag='' "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ 'join: peer group tag cannot be empty string' ]]
-    SLURM_STEP_ID='' run ch-run --join $CHTEST_IMG -- true
+    SLURM_STEP_ID='' run ch-run --join "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ 'join: peer group tag cannot be empty string' ]]

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -1,23 +1,21 @@
 load ../common
 
-@test 'relative path to image' {
-    # issue #6
+@test 'relative path to image' {  # issue #6
     scope quick
-    DIRNAME=$(dirname $CHTEST_IMG)
-    BASEDIR=$(basename $CHTEST_IMG)
-    cd $DIRNAME && ch-run $BASEDIR -- true
+    DIRNAME=$(dirname "$CHTEST_IMG")
+    BASEDIR=$(basename "$CHTEST_IMG")
+    cd "$DIRNAME" && ch-run "$BASEDIR" -- true
 }
 
-@test 'symlink to image' {
-    # issue #50
+@test 'symlink to image' {  # issue #50
     scope quick
-    ln -sf $CHTEST_IMG $BATS_TMPDIR/symlink-test
-    ch-run $BATS_TMPDIR/symlink-test -- true
+    ln -sf "$CHTEST_IMG" "$BATS_TMPDIR/symlink-test"
+    ch-run "$BATS_TMPDIR/symlink-test" -- true
 }
 
 @test 'mount image read-only' {
     scope quick
-    run ch-run $CHTEST_IMG sh <<EOF
+    run ch-run "$CHTEST_IMG" sh <<EOF
 set -e
 test -w /WEIRD_AL_YANKOVIC
 dd if=/dev/zero bs=1 count=1 of=/WEIRD_AL_YANKOVIC
@@ -29,21 +27,22 @@ EOF
 
 @test 'mount image read-write' {
     scope quick
-    ch-run -w $CHTEST_IMG -- sh -c 'echo writable > write'
-    ch-run -w $CHTEST_IMG rm write
+    ch-run -w "$CHTEST_IMG" -- sh -c 'echo writable > write'
+    ch-run -w "$CHTEST_IMG" rm write
 }
 
 @test '/usr/bin/ch-ssh' {
     scope quick
-    ls -l $CH_BIN/ch-ssh
-    ch-run $CHTEST_IMG -- ls -l /usr/bin/ch-ssh
-    ch-run $CHTEST_IMG -- test -x /usr/bin/ch-ssh
-    host_size=$(stat -c %s $CH_BIN/ch-ssh)
-    guest_size=$(ch-run $CHTEST_IMG -- stat -c %s /usr/bin/ch-ssh)
+    ls -l "$CH_BIN/ch-ssh"
+    ch-run "$CHTEST_IMG" -- ls -l /usr/bin/ch-ssh
+    ch-run "$CHTEST_IMG" -- test -x /usr/bin/ch-ssh
+    host_size=$(stat -c %s "$CH_BIN/ch-ssh")
+    guest_size=$(ch-run "$CHTEST_IMG" -- stat -c %s /usr/bin/ch-ssh)
     echo "host: $host_size, guest: $guest_size"
-    [[ $host_size -eq $guest_size ]]
+    [[ $host_size -eq "$guest_size" ]]
 }
 
+# shellcheck disable=SC2016
 @test '$HOME' {
     scope quick
     echo "host: $HOME"
@@ -51,92 +50,103 @@ EOF
     [[ $USER ]]
 
     # default: set $HOME
-    run ch-run $CHTEST_IMG -- /bin/sh -c 'echo $HOME'
+    # shellcheck disable=SC2016
+    run ch-run "$CHTEST_IMG" -- /bin/sh -c 'echo $HOME'
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output = /home/$USER ]]
 
     # no change if --no-home
-    run ch-run --no-home $CHTEST_IMG -- /bin/sh -c 'echo $HOME'
+    # shellcheck disable=SC2016
+    run ch-run --no-home "$CHTEST_IMG" -- /bin/sh -c 'echo $HOME'
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output = $HOME ]]
+    [[ $output = "$HOME" ]]
 
     # puke if $HOME not set
     home_tmp=$HOME
     unset HOME
-    run ch-run $CHTEST_IMG -- /bin/sh -c 'echo $HOME'
-    export HOME=$home_tmp
+    # shellcheck disable=SC2016
+    run ch-run "$CHTEST_IMG" -- /bin/sh -c 'echo $HOME'
+    export HOME="$home_tmp"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ 'cannot find home directory: $HOME not set' ]]
+    # shellcheck disable=SC2016
+    [[ $output = *'cannot find home directory: $HOME not set'* ]]
 
     # warn if $USER not set
     user_tmp=$USER
     unset USER
-    run ch-run $CHTEST_IMG -- /bin/sh -c 'echo $HOME'
+    # shellcheck disable=SC2016
+    run ch-run "$CHTEST_IMG" -- /bin/sh -c 'echo $HOME'
     export USER=$user_tmp
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output =~ '$USER not set; cannot rewrite $HOME' ]]
-    [[ $output =~ $HOME ]]
+    # shellcheck disable=SC2016
+    [[ $output = *'$USER not set; cannot rewrite $HOME'* ]]
+    [[ $output = *"$HOME"* ]]
 }
 
+# shellcheck disable=SC2016
 @test '$PATH: add /bin' {
     scope quick
     echo "$PATH"
     # if /bin is in $PATH, latter passes through unchanged
     PATH2="$CH_BIN:/bin:/usr/bin"
-    echo $PATH2
-    PATH=$PATH2 run ch-run $CHTEST_IMG -- /bin/sh -c 'echo $PATH'
+    echo "$PATH2"
+    # shellcheck disable=SC2016
+    PATH=$PATH2 run ch-run "$CHTEST_IMG" -- /bin/sh -c 'echo $PATH'
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output = $PATH2 ]]
+    [[ $output = "$PATH2" ]]
     PATH2="/bin:$CH_BIN:/usr/bin"
-    echo $PATH2
-    PATH=$PATH2 run ch-run $CHTEST_IMG -- /bin/sh -c 'echo $PATH'
+    echo "$PATH2"
+    # shellcheck disable=SC2016
+    PATH=$PATH2 run ch-run "$CHTEST_IMG" -- /bin/sh -c 'echo $PATH'
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output = $PATH2 ]]
+    [[ $output = "$PATH2" ]]
     # if /bin isn't in $PATH, former is added to end
     PATH2="$CH_BIN:/usr/bin"
-    echo $PATH2
-    PATH=$PATH2 run ch-run $CHTEST_IMG -- /bin/sh -c 'echo $PATH'
+    echo "$PATH2"
+    # shellcheck disable=SC2016
+    PATH=$PATH2 run ch-run "$CHTEST_IMG" -- /bin/sh -c 'echo $PATH'
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output = $PATH2:/bin ]]
 }
 
+# shellcheck disable=SC2016
 @test '$PATH: unset' {
     scope standard
     BACKUP_PATH=$PATH
     unset PATH
-    run $CH_RUN_FILE $CHTEST_IMG -- \
+    run "$CH_RUN_FILE" "$CHTEST_IMG" -- \
         /usr/bin/python3 -c 'import os; print(os.getenv("PATH") is None)'
     PATH=$BACKUP_PATH
     echo "$output"
     [[ $status -eq 0 ]]
-    r=': \$PATH not set'
-    [[ $output =~ $r ]]
-    [[ $output =~ 'True' ]]
+    # shellcheck disable=SC2016
+    [[ $output = *': $PATH not set'* ]]
+    [[ $output = *'True'* ]]
 }
 
 @test 'ch-run --cd' {
     scope quick
     # Default initial working directory is /.
-    run ch-run $CHTEST_IMG -- pwd
+    run ch-run "$CHTEST_IMG" -- pwd
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output = '/' ]]
 
     # Specify initial working directory.
-    run ch-run --cd /dev $CHTEST_IMG -- pwd
+    run ch-run --cd /dev "$CHTEST_IMG" -- pwd
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output = '/dev' ]]
 
     # Error if directory does not exist.
-    run ch-run --cd /goops $CHTEST_IMG -- true
+    run ch-run --cd /goops "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ "can't cd to /goops: No such file or directory" ]]
@@ -145,115 +155,115 @@ EOF
 @test 'ch-run --bind' {
     scope quick
     # one bind, default destination (/mnt/0)
-    ch-run -b $IMGDIR/bind1 $CHTEST_IMG -- cat /mnt/0/file1
+    ch-run -b "$IMGDIR/bind1" "$CHTEST_IMG" -- cat /mnt/0/file1
     # one bind, explicit destination
-    ch-run -b $IMGDIR/bind1:/mnt/9 $CHTEST_IMG -- cat /mnt/9/file1
+    ch-run -b "$IMGDIR/bind1:/mnt/9" "$CHTEST_IMG" -- cat /mnt/9/file1
 
     # two binds, default destination
-    ch-run -b $IMGDIR/bind1 -b $IMGDIR/bind2 $CHTEST_IMG \
+    ch-run -b "$IMGDIR/bind1" -b "$IMGDIR/bind2" "$CHTEST_IMG" \
            -- cat /mnt/0/file1 /mnt/1/file2
     # two binds, explicit destinations
-    ch-run -b $IMGDIR/bind1:/mnt/8 -b $IMGDIR/bind2:/mnt/9 $CHTEST_IMG \
+    ch-run -b "$IMGDIR/bind1:/mnt/8" -b "$IMGDIR/bind2:/mnt/9" "$CHTEST_IMG" \
            -- cat /mnt/8/file1 /mnt/9/file2
     # two binds, default/explicit
-    ch-run -b $IMGDIR/bind1 -b $IMGDIR/bind2:/mnt/9 $CHTEST_IMG \
+    ch-run -b "$IMGDIR/bind1" -b "$IMGDIR/bind2:/mnt/9" "$CHTEST_IMG" \
            -- cat /mnt/0/file1 /mnt/9/file2
     # two binds, explicit/default
-    ch-run -b $IMGDIR/bind1:/mnt/8 -b $IMGDIR/bind2 $CHTEST_IMG \
+    ch-run -b "$IMGDIR/bind1:/mnt/8" -b "$IMGDIR/bind2" "$CHTEST_IMG" \
            -- cat /mnt/8/file1 /mnt/1/file2
 
     # bind one source at two destinations
-    ch-run -b $IMGDIR/bind1:/mnt/8 -b $IMGDIR/bind1:/mnt/9 $CHTEST_IMG \
+    ch-run -b "$IMGDIR/bind1:/mnt/8" -b "$IMGDIR/bind1:/mnt/9" "$CHTEST_IMG" \
            -- diff -u /mnt/8/file1 /mnt/9/file1
     # bind two sources at one destination
-    ch-run -b $IMGDIR/bind1:/mnt/9 -b $IMGDIR/bind2:/mnt/9 $CHTEST_IMG \
+    ch-run -b "$IMGDIR/bind1:/mnt/9" -b "$IMGDIR/bind2:/mnt/9" "$CHTEST_IMG" \
            -- sh -c '[ ! -e /mnt/9/file1 ] && cat /mnt/9/file2'
 
     # omit tmpfs at /home, which shouldn't be empty
-    ch-run --no-home $CHTEST_IMG -- cat /home/overmount-me
+    ch-run --no-home "$CHTEST_IMG" -- cat /home/overmount-me
     # overmount tmpfs at /home
-    ch-run -b $IMGDIR/bind1:/home $CHTEST_IMG -- cat /home/file1
+    ch-run -b "$IMGDIR/bind1:/home" "$CHTEST_IMG" -- cat /home/file1
     # bind to /home without overmount
-    ch-run --no-home -b $IMGDIR/bind1:/home $CHTEST_IMG -- cat /home/file1
+    ch-run --no-home -b "$IMGDIR/bind1:/home" "$CHTEST_IMG" -- cat /home/file1
     # omit default /home, with unrelated --bind
-    ch-run --no-home -b $IMGDIR/bind1 $CHTEST_IMG -- cat /mnt/0/file1
+    ch-run --no-home -b "$IMGDIR/bind1" "$CHTEST_IMG" -- cat /mnt/0/file1
 }
 
 @test 'ch-run --bind errors' {
     scope quick
 
     # more binds (11) than default destinations
-    run ch-run -b $IMGDIR/bind1 \
-               -b $IMGDIR/bind1 \
-               -b $IMGDIR/bind1 \
-               -b $IMGDIR/bind1 \
-               -b $IMGDIR/bind1 \
-               -b $IMGDIR/bind1 \
-               -b $IMGDIR/bind1 \
-               -b $IMGDIR/bind1 \
-               -b $IMGDIR/bind1 \
-               -b $IMGDIR/bind1 \
-               -b $IMGDIR/bind1 \
-               $CHTEST_IMG -- true
+    run ch-run -b "$IMGDIR/bind1" \
+               -b "$IMGDIR/bind1" \
+               -b "$IMGDIR/bind1" \
+               -b "$IMGDIR/bind1" \
+               -b "$IMGDIR/bind1" \
+               -b "$IMGDIR/bind1" \
+               -b "$IMGDIR/bind1" \
+               -b "$IMGDIR/bind1" \
+               -b "$IMGDIR/bind1" \
+               -b "$IMGDIR/bind1" \
+               -b "$IMGDIR/bind1" \
+               "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     r="can't bind .+/bind1 to $CHTEST_IMG/mnt/10: No such file or directory"
     [[ $output =~ $r ]]
 
     # no argument to --bind
-    run ch-run $CHTEST_IMG -b
+    run ch-run "$CHTEST_IMG" -b
     echo "$output"
     [[ $status -eq 64 ]]
     [[ $output =~ 'option requires an argument' ]]
 
     # empty argument to --bind
-    run ch-run -b '' $CHTEST_IMG -- true
+    run ch-run -b '' "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ '--bind: no source provided' ]]
 
     # source not provided
-    run ch-run -b :/mnt/9 $CHTEST_IMG -- true
+    run ch-run -b :/mnt/9 "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ '--bind: no source provided' ]]
 
     # destination not provided
-    run ch-run -b $IMGDIR/bind1: $CHTEST_IMG -- true
+    run ch-run -b "$IMGDIR/bind1:" "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output =~ '--bind: no destination provided' ]]
 
     # source does not exist
-    run ch-run -b $IMGDIR/hoops $CHTEST_IMG -- true
+    run ch-run -b "$IMGDIR/hoops" "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     r="can't bind .+/hoops to $CHTEST_IMG/mnt/0: No such file or directory"
     [[ $output =~ $r ]]
 
     # destination does not exist
-    run ch-run -b $IMGDIR/bind1:/goops $CHTEST_IMG -- true
+    run ch-run -b "$IMGDIR/bind1:/goops" "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     r="can't bind .+/bind1 to $CHTEST_IMG/goops: No such file or directory"
     [[ $output =~ $r ]]
 
     # neither source nor destination exist
-    run ch-run -b $IMGDIR/hoops:/goops $CHTEST_IMG -- true
+    run ch-run -b "$IMGDIR/hoops:/goops" "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     r="can't bind .+/hoops to $CHTEST_IMG/goops: No such file or directory"
     [[ $output =~ $r ]]
 
     # correct bind followed by source does not exist
-    run ch-run -b $IMGDIR/bind1:/mnt/9 -b $IMGDIR/hoops $CHTEST_IMG -- true
+    run ch-run -b "$IMGDIR/bind1:/mnt/9" -b "$IMGDIR/hoops" "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     r="can't bind .+/hoops to $CHTEST_IMG/mnt/1: No such file or directory"
     [[ $output =~ $r ]]
 
     # correct bind followed by destination does not exist
-    run ch-run -b $IMGDIR/bind1 -b $IMGDIR/bind2:/goops $CHTEST_IMG -- true
+    run ch-run -b "$IMGDIR/bind1" -b "$IMGDIR/bind2:/goops" "$CHTEST_IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
     r="can't bind .+/bind2 to $CHTEST_IMG/goops: No such file or directory"
@@ -262,28 +272,29 @@ EOF
 
 @test 'broken image errors' {
     scope standard
-    IMG=$BATS_TMPDIR/broken-image
+    IMG="$BATS_TMPDIR/broken-image"
 
     # Create an image skeleton.
     DIRS=$(echo {dev,proc,sys})
     FILES=$(echo etc/{group,hosts,passwd,resolv.conf})
+    # shellcheck disable=SC2116
     FILES_OPTIONAL=$(echo usr/bin/ch-ssh)
-    mkdir -p $IMG
-    for d in $DIRS; do mkdir -p $IMG/$d; done
-    mkdir -p $IMG/etc $IMG/home $IMG/usr/bin $IMG/tmp
-    for f in $FILES $FILES_OPTIONAL; do touch $IMG/$f; done
+    mkdir -p "$IMG"
+    for d in $DIRS; do mkdir -p "$IMG/$d"; done
+    mkdir -p "$IMG/etc" "$IMG/home" "$IMG/usr/bin" "$IMG/tmp"
+    for f in $FILES $FILES_OPTIONAL; do touch "$IMG/$f"; done
 
     # This should start up the container OK but fail to find the user command.
-    run ch-run $IMG -- true
+    run ch-run "$IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ "can't execve(2): true: No such file or directory" ]]
+    [[ $output = *"can't execve(2): true: No such file or directory"* ]]
 
     # For each required file, we want a correct error if it's missing.
     for f in $FILES; do
-        rm $IMG/$f
-        run ch-run $IMG -- true
-        touch $IMG/$f  # restore before test fails for idempotency
+        rm "$IMG/$f"
+        run ch-run "$IMG" -- true
+        touch "$IMG/$f"  # restore before test fails for idempotency
         echo "$output"
         [[ $status -eq 1 ]]
         r="can't bind .+ to /.+/$f: No such file or directory"
@@ -292,21 +303,21 @@ EOF
 
     # For each optional file, we want no error if it's missing.
     for f in $FILES_OPTIONAL; do
-        rm $IMG/$f
-        run ch-run $IMG -- true
-        touch $IMG/$f  # restore before test fails for idempotency
+        rm "$IMG/$f"
+        run ch-run "$IMG" -- true
+        touch "$IMG/$f"  # restore before test fails for idempotency
         echo "$output"
         [[ $status -eq 1 ]]
-        [[ $output =~ "can't execve(2): true: No such file or directory" ]]
+        [[ $output = *"can't execve(2): true: No such file or directory"* ]]
     done
 
     # For all files, we want a correct error if it's not a regular file.
     for f in $FILES $FILES_OPTIONAL; do
-        rm $IMG/$f
-        mkdir $IMG/$f
-        run ch-run $IMG -- true
-        rmdir $IMG/$f  # restore before test fails for idempotency
-        touch $IMG/$f
+        rm "$IMG/$f"
+        mkdir "$IMG/$f"
+        run ch-run "$IMG" -- true
+        rmdir "$IMG/$f"  # restore before test fails for idempotency
+        touch "$IMG/$f"
         echo "$output"
         [[ $status -eq 1 ]]
         r="can't bind .+ to /.+/$f: Not a directory"
@@ -316,9 +327,9 @@ EOF
 
     # For each directory, we want a correct error if it's missing.
     for d in $DIRS tmp; do
-        rmdir $IMG/$d
-        run ch-run $IMG -- true
-        mkdir $IMG/$d  # restore before test fails for idempotency
+        rmdir "$IMG/$d"
+        run ch-run "$IMG" -- true
+        mkdir "$IMG/$d"  # restore before test fails for idempotency
         echo "$output"
         [[ $status -eq 1 ]]
         r="can't bind .+ to /.+/$d: No such file or directory"
@@ -328,11 +339,11 @@ EOF
 
     # For each directory, we want a correct error if it's not a directory.
     for d in $DIRS tmp; do
-        rmdir $IMG/$d
-        touch $IMG/$d
-        run ch-run $IMG -- true
-        rm $IMG/$d  # restore before test fails for idempotency
-        mkdir $IMG/$d
+        rmdir "$IMG/$d"
+        touch "$IMG/$d"
+        run ch-run "$IMG" -- true
+        rm "$IMG/$d"  # restore before test fails for idempotency
+        mkdir "$IMG/$d"
         echo "$output"
         [[ $status -eq 1 ]]
         r="can't bind .+ to /.+/$d: Not a directory"
@@ -341,9 +352,9 @@ EOF
     done
 
     # --private-tmp
-    rmdir $IMG/tmp
-    run ch-run --private-tmp $IMG -- true
-    mkdir $IMG/tmp  # restore before test fails for idempotency
+    rmdir "$IMG/tmp"
+    run ch-run --private-tmp "$IMG" -- true
+    mkdir "$IMG/tmp"  # restore before test fails for idempotency
     echo "$output"
     [[ $status -eq 1 ]]
     r="can't mount tmpfs at /.+/tmp: No such file or directory"
@@ -352,9 +363,9 @@ EOF
 
     # /home without --private-home
     # FIXME: Not sure how to make the second mount(2) fail.
-    rmdir $IMG/home
-    run ch-run $IMG -- true
-    mkdir $IMG/home  # restore before test fails for idempotency
+    rmdir "$IMG/home"
+    run ch-run "$IMG" -- true
+    mkdir "$IMG/home"  # restore before test fails for idempotency
     echo "$output"
     [[ $status -eq 1 ]]
     r="can't mount tmpfs at /.+/home: No such file or directory"
@@ -362,16 +373,16 @@ EOF
     [[ $output =~ $r ]]
 
     # --no-home shouldn't care if /home is missing
-    rmdir $IMG/home
-    run ch-run --no-home $IMG -- true
-    mkdir $IMG/home  # restore before test fails for idempotency
+    rmdir "$IMG/home"
+    run ch-run --no-home "$IMG" -- true
+    mkdir "$IMG/home"  # restore before test fails for idempotency
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ "can't execve(2): true: No such file or directory" ]]
+    [[ $output = *"can't execve(2): true: No such file or directory"* ]]
 
     # Everything should be restored and back to the original error.
-    run ch-run $IMG -- true
+    run ch-run "$IMG" -- true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output =~ "can't execve(2): true: No such file or directory" ]]
+    [[ $output = *"can't execve(2): true: No such file or directory"* ]]
 }

--- a/test/run/ch-run_uidgid.bats
+++ b/test/run/ch-run_uidgid.bats
@@ -5,8 +5,8 @@ setup () {
     if [[ -n $GUEST_USER ]]; then
         # Specific user requested for testing.
         [[ -n $GUEST_GROUP ]]
-        GUEST_UID=$(id -u $GUEST_USER)
-        GUEST_GID=$(getent group $GUEST_GROUP | cut -d: -f3)
+        GUEST_UID=$(id -u "$GUEST_USER")
+        GUEST_GID=$(getent group "$GUEST_GROUP" | cut -d: -f3)
         UID_ARGS="-u $GUEST_UID"
         GID_ARGS="-g $GUEST_GID"
         echo "ID arguments: $GUEST_USER/$GUEST_UID $GUEST_GROUP/$GUEST_GID"
@@ -16,7 +16,7 @@ setup () {
         [[ -z $GUEST_GROUP ]]
         GUEST_USER=$(id -un)
         GUEST_UID=$(id -u)
-        [[ $GUEST_USER = $USER ]]
+        [[ $GUEST_USER = "$USER" ]]
         [[ $GUEST_UID -ne 0 ]]
         GUEST_GROUP=$(id -gn)
         GUEST_GID=$(id -g)
@@ -29,24 +29,24 @@ setup () {
 }
 
 @test 'user and group as specified' {
-    g=$(ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- id -un)
-    [[ $GUEST_USER = $g ]]
-    g=$(ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- id -u)
-    [[ $GUEST_UID = $g ]]
-    g=$(ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- id -gn)
-    [[ $GUEST_GROUP = $g ]]
-    g=$(ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- id -g)
-    [[ $GUEST_GID = $g ]]
+    g=$(ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- id -un)
+    [[ $GUEST_USER = "$g" ]]
+    g=$(ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- id -u)
+    [[ $GUEST_UID = "$g" ]]
+    g=$(ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- id -gn)
+    [[ $GUEST_GROUP = "$g" ]]
+    g=$(ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- id -g)
+    [[ $GUEST_GID = "$g" ]]
 }
 
 @test 'chroot escape' {
     # Try to escape a chroot(2) using the standard approach.
-    ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- /test/chroot-escape
+    ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- /test/chroot-escape
 }
 
 @test '/dev /proc /sys' {
     # Read some files in /dev, /proc, and /sys that I shouldn't have access to.
-    ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- /test/dev_proc_sys.py
+    ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- /test/dev_proc_sys.py
 }
 
 @test 'filesystem permission enforcement' {
@@ -55,7 +55,7 @@ setup () {
         d="$d/perms_test/pass"
         echo "verifying: $d"
           ch-run --no-home --private-tmp \
-                 $UID_ARGS $GID_ARGS -b $d $CHTEST_IMG -- \
+                 $UID_ARGS $GID_ARGS -b "$d" "$CHTEST_IMG" -- \
                  /test/fs_perms.py /mnt/0
     done
 }
@@ -63,7 +63,8 @@ setup () {
 @test 'mknod(2)' {
     # Make some device files. If this works, we might be able to later read or
     # write them to do things we shouldn't. Try on all mount points.
-    ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- \
+    # shellcheck disable=SC2016
+    ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- \
            sh -c '/test/mknods $(cat /proc/mounts | cut -d" " -f2)'
 }
 
@@ -73,7 +74,8 @@ setup () {
     # Some supported distributions don't have "hostname --all-ip-addresses".
     # Hence the awk voodoo.
     ADDRS=$(ip -o addr | awk '/inet / {gsub(/\/.*/, " ",$4); print $4}')
-    ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- /test/bind_priv.py $ADDRS
+    # shellcheck disable=SC2086
+    ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- /test/bind_priv.py $ADDRS
 }
 
 @test 'remount host root' {
@@ -86,13 +88,13 @@ setup () {
     #   - We leave the filesystem mounted even if successful, again to make
     #     the test simpler. The rest of the tests will ignore it or maybe
     #     over-mount something else.
-    ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- \
+    ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- \
            sh -c '[ -f /bin/mount -a -x /bin/mount ]'
     dev=$(findmnt -n -o SOURCE -T /)
     type=$(findmnt -n -o FSTYPE -T /)
     opts=$(findmnt -n -o OPTIONS -T /)
-    run ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- \
-               /bin/mount -n -o $opts -t $type $dev /mnt/0
+    run ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- \
+               /bin/mount -n -o "$opts" -t "$type" "$dev" /mnt/0
     echo "$output"
     # return codes from http://man7.org/linux/man-pages/man8/mount.8.html
     # busybox seems to use the same list
@@ -103,14 +105,14 @@ setup () {
             ;;
         1)  ;&  # "incorrect invocation of permissions" (we care which)
         255)    # undocumented
-            if [[ $output =~ 'ermission denied' ]]; then
-                printf 'SAFE\tmount exit %d, permission denied\n' $status
+            if [[ $output = *'ermission denied'* ]]; then
+                printf 'SAFE\tmount exit %d, permission denied\n' "$status"
                 return 0
             elif [[ $dev = 'rootfs' && $output =~ 'No such device' ]]; then
-                printf 'SAFE\tmount exit %d, no such device for rootfs' $status
+                printf 'SAFE\tmount exit %d, no such device' "$status"
                 return 0
             else
-                printf 'RISK\tmount exit %d w/o known explanation\n' $status
+                printf 'RISK\tmount exit %d w/o known explanation\n' "$status"
                 return 1
             fi
             ;;
@@ -119,22 +121,22 @@ setup () {
             return 0
             ;;
     esac
-    printf 'ERROR\tunknown exit code: %s\n' $status
+    printf 'ERROR\tunknown exit code: %s\n' "$status"
     return 1
 }
 
 @test 'setgroups(2)' {
     # Can we change our supplemental groups?
-    ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- /test/setgroups
+    ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- /test/setgroups
 }
 
 @test 'seteuid(2)' {
     # Try to seteuid(2) to another UID we shouldn't have access to
-    ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- /test/setuid
+    ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- /test/setuid
 }
 
 @test 'signal process outside container' {
     # Send a signal to a process we shouldn't be able to signal.
     [[ $(pgrep -c getty) -eq 0 ]] && skip 'no getty process found'
-    ch-run $UID_ARGS $GID_ARGS $CHTEST_IMG -- /test/signal_out.py
+    ch-run $UID_ARGS $GID_ARGS "$CHTEST_IMG" -- /test/signal_out.py
 }

--- a/test/run/ch-tar2dir.bats
+++ b/test/run/ch-tar2dir.bats
@@ -2,37 +2,37 @@ load ../common
 
 @test 'ch-tar2dir: unpack image' {
     scope standard
-    if ( image_ok $CHTEST_IMG ); then
+    if ( image_ok "$CHTEST_IMG" ); then
         # image exists, remove so we can test new unpack
-        rm -Rf --one-file-system $CHTEST_IMG
+        rm -Rf --one-file-system "$CHTEST_IMG"
     fi
-    ch-tar2dir $CHTEST_TARBALL $IMGDIR  # new unpack
-    image_ok $CHTEST_IMG
-    ch-tar2dir $CHTEST_TARBALL $IMGDIR  # overwrite
-    image_ok $CHTEST_IMG
+    ch-tar2dir "$CHTEST_TARBALL" "$IMGDIR"  # new unpack
+    image_ok "$CHTEST_IMG"
+    ch-tar2dir "$CHTEST_TARBALL" "$IMGDIR"  # overwrite
+    image_ok "$CHTEST_IMG"
 }
 
 @test 'ch-tar2dir: /dev cleaning' {  # issue #157
     scope standard
     [[ ! -e $CHTEST_IMG/dev/foo ]]
     [[ -e $CHTEST_IMG/mnt/dev/foo ]]
-    ch-run $CHTEST_IMG -- test -e /mnt/dev/foo
+    ch-run "$CHTEST_IMG" -- test -e /mnt/dev/foo
 }
 
 @test 'ch-tar2dir: errors' {
     scope quick
     # tarball doesn't exist
-    run ch-tar2dir does_not_exist.tar.gz $IMGDIR
+    run ch-tar2dir does_not_exist.tar.gz "$IMGDIR"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = "can't read does_not_exist.tar.gz" ]]
+    [[ $output = *"can't read does_not_exist.tar.gz"* ]]
 
     # tarball exists but isn't readable
-    touch $BATS_TMPDIR/unreadable.tar.gz
-    chmod 000 $BATS_TMPDIR/unreadable.tar.gz
-    run ch-tar2dir $BATS_TMPDIR/unreadable.tar.gz $IMGDIR
+    touch "$BATS_TMPDIR/unreadable.tar.gz"
+    chmod 000 "$BATS_TMPDIR/unreadable.tar.gz"
+    run ch-tar2dir "$BATS_TMPDIR/unreadable.tar.gz" "$IMGDIR"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = "can't read $BATS_TMPDIR/unreadable.tar.gz" ]]
+    [[ $output = *"can't read $BATS_TMPDIR/unreadable.tar.gz"* ]]
 }
 

--- a/test/run_first.bats
+++ b/test/run_first.bats
@@ -8,23 +8,23 @@ load common
         # or supporting directories, or nothing, then we're ok. Remove any
         # images (this makes test-build and test-run follow the same path when
         # run on the same or different machines). Otherwise, error.
-        for i in $IMGDIR/*; do
+        for i in "$IMGDIR"/*; do
             if [[ -d $i && -f $i/WEIRD_AL_YANKOVIC ]]; then
                 echo "found image $i; removing"
-                rm -Rf --one-file-system $i
+                rm -Rf --one-file-system "$i"
             else
                 echo "found non-image $i; aborting"
                 false
             fi
         done
     fi
-    mkdir -p $IMGDIR
-    mkdir -p $IMGDIR/bind1
-    touch $IMGDIR/bind1/WEIRD_AL_YANKOVIC  # fool logic above
-    touch $IMGDIR/bind1/file1
-    mkdir -p $IMGDIR/bind2
-    touch $IMGDIR/bind2/WEIRD_AL_YANKOVIC
-    touch $IMGDIR/bind2/file2
+    mkdir -p "$IMGDIR"
+    mkdir -p "$IMGDIR/bind1"
+    touch "$IMGDIR/bind1/WEIRD_AL_YANKOVIC"  # fool logic above
+    touch "$IMGDIR/bind1/file1"
+    mkdir -p "$IMGDIR/bind2"
+    touch "$IMGDIR/bind2/WEIRD_AL_YANKOVIC"
+    touch "$IMGDIR/bind2/file2"
 }
 
 @test 'permissions test directories exist' {
@@ -32,13 +32,13 @@ load common
     [[ $CH_TEST_PERMDIRS = skip ]] && skip 'user request'
     for d in $CH_TEST_PERMDIRS; do
         d=$d/perms_test
-        echo $d
-        test -d $d
-        test -d $d/pass
-        test -f $d/pass/file
-        test -d $d/nopass
-        test -d $d/nopass/dir
-        test -f $d/nopass/file
+        echo "$d"
+        test -d "$d"
+        test -d "$d/pass"
+        test -f "$d/pass/file"
+        test -d "$d/nopass"
+        test -d "$d/nopass/dir"
+        test -f "$d/nopass/file"
     done
 }
 

--- a/test/travis.sh
+++ b/test/travis.sh
@@ -9,11 +9,11 @@ set -e
 PREFIX=/var/tmp
 
 # Remove sbin directories from $PATH (see issue #43). Assume none are first.
-echo $PATH
+echo "$PATH"
 for i in /sbin /usr/sbin /usr/local/sbin; do
     export PATH=${PATH/:$i/}
 done
-echo $PATH
+echo "$PATH"
 
 set -x
 
@@ -21,15 +21,15 @@ case $TARBALL in
     export)
         (cd doc-src && make)
         make export
-        mv charliecloud-*.tar.gz $PREFIX
-        cd $PREFIX
+        mv charliecloud-*.tar.gz "$PREFIX"
+        cd "$PREFIX"
         tar xf charliecloud-*.tar.gz
         cd charliecloud-*
         ;;
     archive)
         # The Travis image already has Bats installed.
-        git archive HEAD --prefix=charliecloud/ -o $PREFIX/charliecloud.tar
-        cd $PREFIX
+        git archive HEAD --prefix=charliecloud/ -o "$PREFIX/charliecloud.tar"
+        cd "$PREFIX"
         tar xf charliecloud.tar
         cd charliecloud
         ;;
@@ -47,8 +47,8 @@ make
 bin/ch-run --version
 
 if [[ $INSTALL ]]; then
-    sudo make install PREFIX=$PREFIX
-    cd $PREFIX/share/doc/charliecloud
+    sudo make install PREFIX="$PREFIX"
+    cd "$PREFIX/share/doc/charliecloud"
 fi
 
 cd test
@@ -57,12 +57,12 @@ make where-bats
 make test
 
 # To test without Docker, move the binary out of the way.
-DOCKER=$(which docker)
-sudo mv $DOCKER $DOCKER.tmp
+DOCKER=$(command -v docker)
+sudo mv "$DOCKER" "$DOCKER.tmp"
 
 make test
 
 # For Travis, this isn't really necessary, since the VM will go away
 # immediately after this script exits. However, restore the binary to enable
 # testing this script in other environments.
-sudo mv $DOCKER.tmp $DOCKER
+sudo mv "$DOCKER.tmp" "$DOCKER"

--- a/test/travis.yml
+++ b/test/travis.yml
@@ -47,9 +47,36 @@ install:
 # entering the namespaces and we get ENOENT. Work around this bug. See:
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=851427
 # https://wiki.debian.org/ReleaseGoals/RunDirectory
-  - sudo rm /dev/shm
+  - sudo rm /dev/shm  # will fail once it's a directory again
   - sudo mkdir /dev/shm
   - sudo mount --bind /run/shm /dev/shm
+# The following is the mess needed to get a working ShellCheck on Travis.
+# Approaches that don't work include:
+#
+#   - Static binary provided by ShellCheck upstream (0.5.0): Segfault due to
+#     Trusty bug [1]. The described workaround didn't work for me.
+#
+#   - Compile from source (0.5.0): Build is supposedly very long (30 minutes)
+#     and one must install the Haskell build environment.
+#
+#   - Travis-provided (0.4.6): Segfault again, I think for the same reason.
+#
+#   - Ubunty Trusty, i.e. plain "apt-get" (0.3.3): Super old.
+#
+#   - Debian Sid (0.4.7): glibc dependency too new, default dpkg can't read
+#     the .deb because it's xz-compressed, and only gain one point release.
+#
+# Once Travis finally gets around to upgrading Ubuntu [2], we should just
+# install the static binary.
+#
+# [1]: https://github.com/koalaman/shellcheck/issues/1053
+# [2]: https://github.com/travis-ci/travis-ci/issues/5821
+  - fgrep Trusty /etc/os-release
+  - sudo rm -f /usr/local/bin/shellcheck
+  - wget http://mirrors.kernel.org/ubuntu/pool/universe/s/shellcheck/shellcheck_0.4.6-1_amd64.deb
+  - sudo dpkg --install shellcheck_0.4.6-1_amd64.deb
+  - which shellcheck
+  - shellcheck --version
 
 before_script:
   - getconf _NPROCESSORS_ONLN
@@ -59,7 +86,6 @@ before_script:
   - export CH_TEST_TARDIR=/var/tmp/tarballs
   - export CH_TEST_IMGDIR=/var/tmp/images
   - export CH_TEST_PERMDIRS='/var/tmp /run'
-  - export CH_TEST_OMIT=mpi
   - unset JAVA_HOME  # otherwise Spark tries to use host's Java
   - for d in $CH_TEST_PERMDIRS; do sudo test/make-perms-test $d $USER nobody; done
 


### PR DESCRIPTION
This PR addresses #98 by adding a [ShellCheck](https://github.com/koalaman/shellcheck) lint test to `build.bats` and updating all the shell scripts with the numerous changes suggested.

To decode the lint numbers now scattered throughout the code, see the ShellCheck [wiki pages](https://github.com/koalaman/shellcheck/wiki/SC1000).

I'd like to get this reviewed and merged expediently because it will conflict with essentially all other shell script changes.