### PR TITLE
Auto find the apk-tools-static version using wget

### DIFF
--- a/test/chtest/Build
+++ b/test/chtest/Build
@@ -21,7 +21,7 @@ TARBALL=$2
 TARBALL_UNCOMPRESSED=${TARBALL%.*}
 WORKDIR=$3
 MIRROR=http://dl-cdn.alpinelinux.org/alpine/v3.6
-APK_TOOLS=apk-tools-static-2.7.5-r0.apk
+APK_TOOLS=$(wget --quiet -O - http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/ | grep apk-tools-static | sed -e 's/<[^>]*>//g' | awk '{print $1}')
 IMG="$WORKDIR/img"
 
 cd $WORKDIR

--- a/test/chtest/Build
+++ b/test/chtest/Build
@@ -21,7 +21,7 @@ TARBALL=$2
 TARBALL_UNCOMPRESSED=${TARBALL%.*}
 WORKDIR=$3
 MIRROR=http://dl-cdn.alpinelinux.org/alpine/v3.6
-APK_TOOLS=$(curl -s http://dl-cdn.alpinelinux.org/alpine/v3.6/main/$(arch)/ | grep apk-tools-static | sed -e 's/<[^>]*>//g' | awk '{print $1}')
+APK_TOOLS=$(wget --quiet -O - http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/ | grep apk-tools-static | sed -e 's/<[^>]*>//g' | awk '{print $1}')
 IMG="$WORKDIR/img"
 
 cd $WORKDIR
@@ -37,7 +37,7 @@ CH_RUN="ch-run -u0 -g0 -w --no-home $IMG"
 ## Bootstrap base Alpine Linux.
 
 # Download statically linked apk.
-curl -s $MIRROR/main/$(arch)/$APK_TOOLS -o $APK_TOOLS
+wget $MIRROR/main/x86_64/$APK_TOOLS
 
 # Bootstrap directories.
 mkdir img

--- a/test/chtest/Build
+++ b/test/chtest/Build
@@ -20,8 +20,8 @@ SRCDIR=$1
 TARBALL=$2
 TARBALL_UNCOMPRESSED=${TARBALL%.*}
 WORKDIR=$3
-MIRROR=http://dl-cdn.alpinelinux.org/alpine/latest-stable
-APK_TOOLS=$(curl -s http://dl-cdn.alpinelinux.org/alpine/latest-stable/main/$(arch)/ | grep apk-tools-static | sed -e 's/<[^>]*>//g' | awk '{print $1}')
+MIRROR=http://dl-cdn.alpinelinux.org/alpine/v3.6
+APK_TOOLS=$(curl -s http://dl-cdn.alpinelinux.org/alpine/v3.6/main/$(arch)/ | grep apk-tools-static | sed -e 's/<[^>]*>//g' | awk '{print $1}')
 IMG="$WORKDIR/img"
 
 cd $WORKDIR

--- a/test/chtest/Build
+++ b/test/chtest/Build
@@ -20,8 +20,8 @@ SRCDIR=$1
 TARBALL=$2
 TARBALL_UNCOMPRESSED=${TARBALL%.*}
 WORKDIR=$3
-MIRROR=http://dl-cdn.alpinelinux.org/alpine/v3.6
-APK_TOOLS=$(wget --quiet -O - http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/ | grep apk-tools-static | sed -e 's/<[^>]*>//g' | awk '{print $1}')
+MIRROR=http://dl-cdn.alpinelinux.org/alpine/latest-stable
+APK_TOOLS=$(curl -s http://dl-cdn.alpinelinux.org/alpine/latest-stable/main/$(arch)/ | grep apk-tools-static | sed -e 's/<[^>]*>//g' | awk '{print $1}')
 IMG="$WORKDIR/img"
 
 cd $WORKDIR
@@ -37,7 +37,7 @@ CH_RUN="ch-run -u0 -g0 -w --no-home $IMG"
 ## Bootstrap base Alpine Linux.
 
 # Download statically linked apk.
-wget $MIRROR/main/x86_64/$APK_TOOLS
+curl -s $MIRROR/main/$(arch)/$APK_TOOLS -o $APK_TOOLS
 
 # Bootstrap directories.
 mkdir img

--- a/test/chtest/Build
+++ b/test/chtest/Build
@@ -21,7 +21,9 @@ TARBALL=$2
 TARBALL_UNCOMPRESSED=${TARBALL%.*}
 WORKDIR=$3
 MIRROR=http://dl-cdn.alpinelinux.org/alpine/v3.6
-APK_TOOLS=$(wget --quiet -O - http://dl-cdn.alpinelinux.org/alpine/v3.6/main/x86_64/ | grep apk-tools-static | sed -e 's/<[^>]*>//g' | awk '{print $1}')
+APK_TOOLS=$(  wget -qO - "$MIRROR/main/x86_64" \
+            | grep -F apk-tools-static \
+            | sed -E 's/^.*(apk-tools-static-[0-9.r-]+\.apk).*$/\1/')
 IMG="$WORKDIR/img"
 
 cd $WORKDIR


### PR DESCRIPTION
Looks like this is a consistent issue when apk-tools gets rev'd. I'm proposing a solution that will always find the latest version and populate the variable with it instead of hard coding it.