### PR TITLE
remove hardcoded version variables (closes #249)

### DIFF
--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -85,11 +85,11 @@ WORKDIR /usr/local/src
 #
 # Note that libpsm2 is x86_64 only:
 # https://lists.debian.org/debian-hpc/2017/12/msg00015.html
-ENV DEB_URL http://snapshot.debian.org/archive/debian/
+ENV DEB_URL http://snapshot.debian.org/archive/debian/20180928T210119Z/pool/main
 ENV PSM2_VERSION 10.3.58-2
-RUN wget -nv ${DEB_URL}/20180831T212019Z/pool/main/libp/libpsm2/libpsm2-2_${PSM2_VERSION}_amd64.deb
-RUN wget -nv ${DEB_URL}/20180831T212019Z/pool/main/libp/libpsm2/libpsm2-dev_${PSM2_VERSION}_amd64.deb
-ENV IBVERBS_VERSION 19.0-1
+RUN wget -nv ${DEB_URL}/libp/libpsm2/libpsm2-2_${PSM2_VERSION}_amd64.deb
+RUN wget -nv ${DEB_URL}/libp/libpsm2/libpsm2-dev_${PSM2_VERSION}_amd64.deb
+ENV IBVERBS_VERSION 20.0-1
 RUN for i in ibacm \
              ibverbs-providers \
              ibverbs-utils \
@@ -102,7 +102,7 @@ RUN for i in ibacm \
              rdma-core \
              rdmacm-utils ; \
     do \
-        wget -nv ${DEB_URL}/20180628T203116Z/pool/main/r/rdma-core/${i}_${IBVERBS_VERSION}_amd64.deb ; \
+        wget -nv ${DEB_URL}/r/rdma-core/${i}_${IBVERBS_VERSION}_amd64.deb ; \
     done
 RUN dpkg --install *.deb
 

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -85,10 +85,10 @@ WORKDIR /usr/local/src
 #
 # Note that libpsm2 is x86_64 only:
 # https://lists.debian.org/debian-hpc/2017/12/msg00015.html
-ENV DEB_URL http://http.us.debian.org/debian/pool/main
+ENV DEB_URL http://snapshot.debian.org/archive/debian/
 ENV PSM2_VERSION 10.3.58-2
-RUN wget -nv $DEB_URL/libp/libpsm2/libpsm2-2_${PSM2_VERSION}_amd64.deb
-RUN wget -nv $DEB_URL/libp/libpsm2/libpsm2-dev_${PSM2_VERSION}_amd64.deb
+RUN wget -nv ${DEB_URL}/20180831T212019Z/pool/main/libp/libpsm2/libpsm2-2_${PSM2_VERSION}_amd64.deb
+RUN wget -nv ${DEB_URL}/20180831T212019Z/pool/main/libp/libpsm2/libpsm2-dev_${PSM2_VERSION}_amd64.deb
 ENV IBVERBS_VERSION 19.0-1
 RUN for i in ibacm \
              ibverbs-providers \
@@ -102,7 +102,7 @@ RUN for i in ibacm \
              rdma-core \
              rdmacm-utils ; \
     do \
-        wget -nv $DEB_URL/r/rdma-core/${i}_${IBVERBS_VERSION}_amd64.deb ; \
+        wget -nv ${DEB_URL}/20180628T203116Z/pool/main/r/rdma-core/${i}_${IBVERBS_VERSION}_amd64.deb ; \
     done
 RUN dpkg --install *.deb
 


### PR DESCRIPTION
This addresses #249.

Note: The hardcoded psm2 variables still work, I probably shouldn't have touched them for this particular PR but I figured I might as well. 

I am sure the regrex for lines 111-115 could be improved. 