### PR TITLE
ch-fromhost: implement --cray-mpi for MPICH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,6 @@ install: all
 #       shared library tests
 	install -d $(TEST)/sotest $(TEST)/sotest/bin $(TEST)/sotest/lib
 	install -pm 755 -t $(TEST)/sotest test/sotest/files_inferrable.txt \
-	                                  test/sotest/files_noninferrable.txt \
                                           test/sotest/libsotest.so.1.0 \
 	                                  test/sotest/sotest \
 	                                  test/sotest/sotest.c

--- a/bin/ch-fromhost
+++ b/bin/ch-fromhost
@@ -1,43 +1,94 @@
 #!/bin/sh
 
+# The basic algorithm here is that we build up a list of file
+# source:destination pairs separated by newlines, then walk through them and
+# copy them into the image. We also maintain a list of directories to create
+# and a list of file globs to remove.
+#
+# The colon separator to avoid the difficulty of iterating through a sequence
+# of pairs with no arrays or structures in POSIX sh. We could avoid it by
+# taking action immediately upon encountering each file in the argument list,
+# but that would (a) yield a half-injected image for basic errors like
+# misspellings on the command line and (b) would require the image to be first
+# on the command line, which seems awkward.
+#
+# The newline separator is for the same reason and also because it's
+# convenient for input from --cmd and --file.
+#
+# Note on looping through the newlines in a variable: The approach in this
+# script is to set IFS to newline, loop, then restore. This is awkward but
+# seemed the least bad. Alternatives include:
+#
+#   1. Piping echo into "while read -r": This executes the while in a
+#      subshell, so variables don't stick.
+#
+#   2. Here document used as input, e.g.:
+#
+#        while IFS= read -r FILE; do
+#          ...
+#        done <<EOF
+#        $FILES
+#        EOF
+#
+#      This works but seems more awkward.
+#
+#   3. Here string, e.g. 'while IFS= read -r FILE; do ... done <<< "$FILES"'.
+#      This is a bashism.
+
 LIBEXEC="$(cd "$(dirname "$0")" && pwd)"
 . "${LIBEXEC}/base.sh"
+
+set -e
 
 # shellcheck disable=SC2034
 usage=$(cat <<EOF
 Inject files from the host into an image directory.
 
+NOTE: This command is experimental. Features may be incomplete and/or buggy.
+
 Usage:
 
-  $ ch-fromhost [OPTION ...] (-c CMD | -f FILE | --nvidia ...) IMGDIR
+  $ ch-fromhost [OPTION ...] [FILE_OPTION ...] IMGDIR
 
-Which files (one or more required; can be repeated):
+Which files to inject (one or more required; can be repeated):
 
   -c, --cmd CMD    listed in the stdout of CMD
   -f, --file FILE  listed in file FILE
-      --nvidia     recommended by nVidia (via "nvidia-container-cli list")
+  -p, --path PATH  inject the file at PATH
+  --cray-mpi       Cray-enable an MPICH installed within the image
+  --nvidia         recommended by nVidia (via "nvidia-container-cli list")
+
+Destination within image:
+
+  -d, --dest DST   place following files in IMGDIR/DST, overriding inference
 
 Options:
 
-  -d, --dest DST   files whose destination can't be inferred go in IMGDIR/DST
+  --lib-path       print the inferred destination for shared libraries
+  --no-ldconfig    don't run ldconfig even if we injected shared libraries
   -h, --help       print this help and exit
-      --no-infer   don't infer destination for shared libraries and executables
   -v, --verbose    list the injected files
-      --version    print version and exit
+  --version        print version and exit
 EOF
 )
 
-dest_default=
+cray_mpi=        # Cray fixups requested
+#cray_openmpi=    # ... for OpenMPI
+cray_mpich=      # ... for MPICH
+dest=
 image=
-infer=yes
 newline='
 '
-found_files=
-found_libs_p=
+inject_files=    # source:destination files to inject
+inject_mkdirs=   # directories to create in image (image-rooted)
+inject_unlinks=  # files to rm -f (not rmdir or rm -Rf) (image-rooted)
 lib_dest=
+lib_dest_print=
+lib_found=
+no_ldconfig=
 
 debug () {
-    if [ "$VERBOSE" ]; then
+    if [ "$verbose" ]; then
         printf '%s\n' "$1" 1>&2
     fi
 }
@@ -55,117 +106,266 @@ info () {
     printf 'ch-fromhost: %s\n' "$1" 1>&2
 }
 
+is_bin () {
+    case $1 in
+        */bin*)
+            return 0
+            ;;
+        *)
+            return 1
+    esac
+}
+
+is_so () {
+    case $1 in
+        */lib*)
+            return 0
+            ;;
+        *.so)
+            return 0
+            ;;
+        *)
+            return 1
+    esac
+}
+
+queue_files () {
+    old_ifs="$IFS"
+    IFS="$newline"
+    d="${dest:-$2}"
+    for f in $1; do
+        case $f in
+            *:*)
+                fatal "paths can't contain colon: ${f}"
+                ;;
+        esac
+        if is_so "$f"; then
+            debug "found shared library: ${f}"
+            lib_found=yes
+        fi
+        # This adds a delimiter only for the second and subsequent files.
+        # https://chris-lamb.co.uk/posts/joining-strings-in-posix-shell
+        #
+        # If destination empty, we'll infer it later.
+        inject_files="${inject_files:+$inject_files$newline}$f:$d"
+    done
+    IFS="$old_ifs"
+}
+
+queue_mkdir () {
+    [ "$1" ]
+    inject_mkdirs="${inject_mkdirs:+$inject_mkdirs$newline}$1"
+}
+
+queue_unlink () {
+    [ "$1" ]
+    inject_unlinks="${inject_unlinks:+$inject_unlinks$newline}$1"
+}
+
+
 parse_basic_args "$@"
 
 while [ $# -gt 0 ]; do
     opt=$1; shift
-    out=
     case $opt in
         -c|--cmd)
             ensure_nonempty --cmd "$1"
             out=$($1) || fatal "command failed: $1"
+            queue_files "$out"
             shift
+            ;;
+        --cray-mpi)
+            # Can't act right away because we need the image path.
+            cray_mpi=yes
+            lib_found=yes
             ;;
         -d|--dest)
             ensure_nonempty --dest "$1"
-            dest_default=$1
+            dest=$1
             shift
             ;;
         -f|--file)
             ensure_nonempty --file "$1"
-            out=$(cat "$1") || fatal "cannot read file: $1"
+            out=$(cat "$1") || fatal "cannot read file: ${1}"
+            queue_files "$out"
             shift
             ;;
-        --no-infer)
-            infer=
+        --lib-path)
+            # Note: If this is specified along with one of the file
+            # specification options, all the file gathering and checking work
+            # will happen, but it will be discarded.
+            lib_found=yes
+            lib_dest_print=yes
+            ;;
+        --no-ldconfig)
+            no_ldconfig=yes
             ;;
         --nvidia)
                out=$(nvidia-container-cli list --binaries --libraries) \
             || fatal "nvidia-container-cli failed; does this host have GPUs?"
+            queue_files "$out"
+            ;;
+        -p|--path)
+            ensure_nonempty --path "$1"
+            queue_files "$1"
+            shift
             ;;
         -v|--verbose)
-            VERBOSE=yes
+            verbose=yes
             ;;
         -*)
             info "invalid option: ${opt}"
             usage
             ;;
         *)
-            ensure_nonempty "image path" "$opt"
-            [ -z "$image" ] || fatal "duplicate image path: ${opt}"
+            ensure_nonempty "image path" "${opt}"
+            [ -z "$image" ] || fatal "duplicate image: ${opt}"
             [ -d "$opt" ] || fatal "image not a directory: ${opt}"
-            image=$opt
+            image="$opt"
             ;;
     esac
-    # This adds a delimiter newline only for the second and subsequent files.
-    # See: https://chris-lamb.co.uk/posts/joining-strings-in-posix-shell
-    found_files=${found_files:+${found_files}${newline}}${out}
 done
+
+[ "$image" ] || fatal "no image specified"
+
+if [ $lib_found ]; then
+    # We want to put the libraries in the first directory that ldconfig
+    # searches, so that we can override (or overwrite) any of the same library
+    # that may already be in the image.
+    debug "asking ldconfig for shared library destination"
+    lib_dest=$(  "$CH_BIN"/ch-run "$image" -- /sbin/ldconfig -Nv 2> /dev/null \
+               | grep -E '^/' | cut -d: -f1 | head -1)
+    [ -z "${lib_dest%%/*}" ] || fatal "bad path from ldconfig: ${lib_dest}"
+    debug "shared library destination: ${lib_dest}"
+fi
+
+if [ $cray_mpi ]; then
+    sentinel=/etc/opt/cray/release/cle-release
+    [ -f $sentinel ] || fatal "not found: ${sentinel}: are you on a Cray?"
+
+    mpi_version=$("$CH_BIN"/ch-run "$image" -- mpirun --version || true)
+    case $mpi_version in
+        *mpich*)
+            cray_mpich=yes
+            ;;
+        *'Open MPI'*)
+            # FIXME: remove when implemented
+            # shellcheck disable=SC2034
+            cray_openmpi=yes
+            ;;
+        *)
+            fatal "can't find MPI in image"
+            ;;
+    esac
+fi
+
+if [ $lib_dest_print ]; then
+    echo "$lib_dest"
+    exit 0
+fi
+
+if [ $cray_mpich ]; then
+    # Remove open source libmpi.so.
+    #
+    # FIXME: These versions are specific to MPICH 3.2.1. I haven't figured out
+    # how to use glob patterns here (they don't get expanded when I tried
+    # basic things).
+    queue_unlink "$lib_dest/libmpi.so"
+    queue_unlink "$lib_dest/libmpi.so.12"
+    queue_unlink "$lib_dest/libmpi.so.12.1.1"
+
+    # Directory containing Cray's libmpi.so.12.
+    # shellcheck disable=SC2016
+       [ "$CRAY_MPICH_DIR" ] \
+    || fatal '$CRAY_MPICH_DIR not set; is module cray-mpich-abi loaded?'
+    cray_libmpi=$CRAY_MPICH_DIR/lib/libmpi.so.12
+       [ -f "$cray_libmpi" ] \
+    || fatal "not found: ${cray_libmpi}; is module cray-mpich-abi loaded?"
+
+    # Note: Most or all of these filenames are symlinks, and the copy will
+    # convert them to normal files (with the same content). In the
+    # documentation, we say not to do that. However, it seems to work, it's
+    # simpler than resolving them, and we apply greater abuse to libmpi.so.12
+    # below.
+
+    # Cray libmpi.so.12.
+    queue_files "$cray_libmpi"
+    # Linked dependencies.
+    queue_files "$(  ldd "$cray_libmpi" \
+                   | grep -F /opt \
+                   | sed -E 's/^.+ => (.+) \(0x.+\)$/\1/')"
+    # dlopen(3)'ed dependencies. I don't know how to not hard-code these.
+    queue_files /opt/cray/alps/default/lib64/libalpsutil.so.0.0.0
+    queue_files /opt/cray/alps/default/lib64/libalpslli.so.0.0.0
+    queue_files /opt/cray/wlm_detect/default/lib64/libwlm_detect.so.0.0.0
+    #queue_files /opt/cray/alps/default/lib64/libalps.so.0.0.0
+
+    # libwlm_detect.so requires this file to be present.
+    queue_mkdir /etc/opt/cray/wlm_detect
+    queue_files /etc/opt/cray/wlm_detect/active_wlm /etc/opt/cray/wlm_detect
+
+    # ALPS libraries require the contents of this directory to be present at
+    # the same path as the host. Create the mount point here, then ch-run
+    # bind-mounts it later.
+    queue_mkdir /var/opt/cray/alps/spool
+
+    # Cray MPICH needs a pile of hugetlbfs filesystems at an arbitrary path
+    # (it searched /proc/mounts). ch-run bind-mounts to here later.
+    queue_mkdir /var/opt/cray/hugetlbfs
+fi
+
+[ "$inject_files" ] || fatal "empty file list"
 
 debug "injecting into image: ${image}"
 
-# First pass tests if we have any shared libraries in the list. If so, we need
-# to figure out where to put them.
-if [ $infer ]; then
-    debug "checking for shared libraries"
-    for f in $found_files; do
-        case $f in
-            */lib*)
-                found_libs_p=yes
-                break
-                ;;
-        esac
-    done
-    if [ $found_libs_p ]; then
-        # We want to put the libraries in the first directory that ldconfig
-        # searches, so that we can override (or overwrite) any of the same
-        # library that may already be in the image.
-        debug "asking ldconfig for shared library path"
-        "${CH_BIN}/ch-run" -w "$image" -- /sbin/ldconfig  # cache maybe absent
-        lib_dest=$(  "${CH_BIN}/ch-run" "$image" -- \
-                                      /sbin/ldconfig -v 2> /dev/null \
-                   | grep -E '^/' | cut -d: -f1 | head -1)
-        [ -z "${lib_dest%%/*}" ] || fatal "bad path from ldconfig: ${lib_dest}"
-        debug "shared library destination: ${lib_dest}"
-    else
-        debug "no shared libraries found"
+old_ifs="$IFS"
+IFS="$newline"
+for u in $inject_unlinks; do
+    debug "  rm -f ${image}${u}"
+    rm -f "${image}${u}"
+done
+for d in $inject_mkdirs; do
+    debug "  mkdir -p ${image}${d}"
+    mkdir -p "${image}${d}"
+done
+for file in $inject_files; do
+    f="${file%%:*}"
+    d="${file#*:}"
+    infer=
+    if is_bin "$f" && [ -z "$d" ]; then
+        d=/usr/bin
+        infer=" (inferred)"
+    elif is_so "$f" && [ -z "$d" ]; then
+        d=$lib_dest
+        infer=" (inferred)"
     fi
-fi
-
-debug "injecting"
-old_ifs=$IFS
-IFS=$newline
-found_file_p=
-for f in $found_files; do
-    found_file_p=yes
-    type_=unk
-    d=$dest_default
-    if [ $infer ]; then
-        case $f in
-            */bin*)
-                type_=bin
-                d=/usr/bin
-                ;;
-            */lib*)
-                type_=lib
-                d=$lib_dest
-                ;;
-        esac
-    fi
-    debug "  ${type_}: ${f} -> ${d}"
+    debug "  ${f} -> ${d}${infer}"
     [ "$d" ] || fatal "no destination for: ${f}"
     [ -z "${d%%/*}" ] || fatal "not an absolute path: ${d}"
     [ -d "${image}${d}" ] || fatal "not a directory: ${image}${d}"
-       cp --dereference --preserve=all "$f" "${image}/${d}" \
+       cp --dereference --preserve=all "$f" "${image}${d}" \
     || fatal "cannot inject: ${f}"
 done
-IFS=$old_ifs
+IFS="$old_ifs"
 
-[ -z $found_file_p ] && fatal "empty file list"
+if [ $cray_mpich ]; then
+    # Restore libmpi.so symlink (it's part of several chains).
+    debug "  ln -s libmpi.so.12 ${image}${lib_dest}/libmpi.so"
+    ln -s libmpi.so.12 "${image}${lib_dest}/libmpi.so"
 
-if [ $found_libs_p ] && [ $infer ]; then
-    debug "found shared library, running ldconfig"
-    "${CH_BIN}/ch-run" -w "$image" -- /sbin/ldconfig
+    # Patch libmpi.so.12 so its soname is "libmpi.so.12" instead of e.g.
+    # "libmpich_gnu_51.so.3". Otherwise, the application won't link without
+    # LD_LIBRARY_PATH, and LD_LIBRARY_PATH is to be avoided.
+    #
+    # Note: This currently requires our patched patchelf (issue #256).
+    debug "fixing soname on libmpi.so.12"
+    "$CH_BIN"/ch-run -w "$image" -- \
+        patchelf --set-soname libmpi.so.12 "$lib_dest/libmpi.so.12"
+fi
+
+if [ $lib_found ] && [ -z "$no_ldconfig" ]; then
+    debug "running ldconfig"
+    "$CH_BIN"/ch-run -w "$image" -- /sbin/ldconfig
 else
-    debug "no shared libraries found"
+    debug "not running ldconfig"
 fi

--- a/bin/charliecloud.h
+++ b/bin/charliecloud.h
@@ -58,6 +58,11 @@ struct bind {
    char *dst;
 };
 
+enum bind_dep {
+   BD_REQUIRED,  // both source and destination must exist
+   BD_OPTIONAL   // if either source or destination missing, do nothing
+};
+
 struct container {
    struct bind *binds;
    gid_t container_gid;
@@ -79,7 +84,10 @@ extern int verbose;
 
 /** Function prototypes from charliecloud.c **/
 
+void bind_mounts(struct bind *binds, char *newroot,
+                 enum bind_dep dep, unsigned long flags);
 void containerize(struct container *c);
 void msg(int level, char *file, int line, int errno_, char *fmt, ...);
+bool path_exists(char *path);
 void run_user_command(char *argv[], char *initial_dir);
 void version(void);

--- a/doc-src/ch-fromhost_desc.rst
+++ b/doc-src/ch-fromhost_desc.rst
@@ -3,11 +3,16 @@ Synopsis
 
 ::
 
-  $ ch-fromhost [OPTION ...] (-c CMD | -f FILE | --nvidia ...) IMGDIR
+  $ ch-fromhost [OPTION ...] [FILE_OPTION ...] IMGDIR
 
 
 Description
 ===========
+
+.. note::
+
+   This command is experimental. Features may be incomplete and/or buggy.
+   Please report any issues you find, so we can fix them!
 
 Inject files from the host into the Charliecloud image directory
 :code:`IMGDIR`.
@@ -25,13 +30,8 @@ By default, file paths that contain the string :code:`/bin` are assumed to be
 executables and are placed in :code:`/usr/bin` within the container. File
 paths that contain the strings :code:`/lib` or :code:`.so` are assumed to be
 shared libraries and are placed in the first-priority directory reported by
-:code:`ldconfig`. Other files are placed in the directory specified by
-:code:`--dest`.
-
-You can see where shared libraries will go with::
-
-  $ ch-run $IMG -- ldconfig -v 2>/dev/null | egrep '^/' | cut -d: -f1 | head -1
-  /usr/local/lib
+:code:`ldconfig` (see :code:`--lib-path` below). Other files are placed in the
+directory specified by :code:`--dest`.
 
 If any shared libraries are injected, run :code:`ldconfig` inside the
 container (using :code:`ch-run -w`) after injection.
@@ -40,7 +40,8 @@ container (using :code:`ch-run -w`) after injection.
 Options
 =======
 
-To specify which files to inject:
+To specify which files to inject
+--------------------------------
 
   :code:`-c`, :code:`--cmd CMD`
     Inject files listed in the standard output of command :code:`CMD`.
@@ -48,31 +49,80 @@ To specify which files to inject:
   :code:`-f`, :code:`--file FILE`
     Inject files listed in the file :code:`FILE`.
 
+  :code:`-p`, :code:`--path PATH`
+    Inject the file at :code:`PATH`.
+
+  :code:`--cray-mpi`
+    Cray-enable an MPICH installed inside the image. See important details
+    below.
+
   :code:`--nvidia`
     Use :code:`nvidia-container-cli list` (from :code:`libnvidia-container`)
     to find executables and libraries to inject.
 
 These can be repeated, and at least one must be specified.
 
-Additional arguments:
+To specify the destination within the image
+-------------------------------------------
 
   :code:`-d`, :code:`--dest DST`
+    Place files specified later in directory :code:`IMGDIR/DST`, overriding the
+    inferred destination, if any. If a file's destination cannot be inferred
+    and :code:`--dest` has not been specified, exit with an error. This can be
+    repeated to place files in varying destinations.
 
-    Place files whose destination cannot be inferred in directory
-    :code:`IMGDIR/DST`. If such a file is found and this option is not
-    specified, exit with an error.
+Additional arguments
+--------------------
+
+  :code:`--lib-path`
+    Print the guest destination path for shared libraries inferred as
+    described above.
+
+  :code:`--no-ldconfig`
+    Don't run :code:`ldconfig` even if we appear to have injected shared
+    libraries.
 
   :code:`-h`, :code:`--help`
     Print help and exit.
 
-  :code:`--no-infer`
-    Do not infer the type of any files.
-
   :code:`-v`, :code:`--verbose`
-    Pist the injected files.
+    List the injected files.
 
   :code:`--version`
     Print version and exit.
+
+
+:code:`--cray-mpi` prerequisites and quirks
+===========================================
+
+The implementation of :code:`--cray-mpi` for MPICH is messy, foul smelling,
+and brittle. It replaces or overrides the open source MPICH libraries
+installed in the container. Users should be aware of the following.
+
+1. Containers must have the following software installed:
+
+   a. Open source `MPICH <https://www.mpich.org/>`_.
+
+   b. `PatchELF with our patches <https://github.com/hpc/patchelf>`_. Use the
+      :code:`shrink-soname` branch.
+
+   c. :code:`libgfortran.so.3`, because Cray's :code:`libmpi.so.12` links to
+      it.
+
+2. Applications must be linked to :code:`libmpi.so.12` (not e.g.
+   :code:`libmpich.so.12`). How to configure MPICH to accomplish this is not
+   yet clear to us; :code:`test/Dockerfile.mpich` does it, while the Debian
+   packages do not.
+
+3. One of the :code:`cray-mpich-abi` modules must be loaded when
+   :code:`ch-fromhost` is invoked.
+
+4. Tested only for C programs compiled with GCC, and it probably won't work
+   otherwise. If you'd like to use another compiler or another programming
+   language, please get in touch so we can implement the necessary support.
+
+Please file a bug if we missed anything above or if you know how to make the
+code better.
 
 
 Notes
@@ -106,16 +156,18 @@ script for nVidia GPUs, they would not solve the problem for other situations.
 Bugs
 ====
 
-File paths may not contain newlines.
+File paths may not contain colons or newlines.
 
 
 Examples
 ========
 
 Place shared library :code:`/usr/lib64/libfoo.so` at path
-:code:`/usr/lib/libfoo.so` within the image :code:`/var/tmp/baz` and
-executable :code:`/bin/bar` at path :code:`/usr/bin/bar`. Then, create
-appropriate symlinks to :code:`libfoo` and update the :code:`ld.so` cache.
+:code:`/usr/lib/libfoo.so` (assuming :code:`/usr/lib` is the first directory
+searched by the dynamic loader in the image), within the image
+:code:`/var/tmp/baz` and executable :code:`/bin/bar` at path
+:code:`/usr/bin/bar`. Then, create appropriate symlinks to :code:`libfoo` and
+update the :code:`ld.so` cache.
 
 ::
 
@@ -128,16 +180,34 @@ Same as above::
 
   $ ch-fromhost --cmd 'cat qux.txt' /var/tmp/baz
 
+Same as above::
+
+  $ ch-fromhost --path /bin/bar --path /usr/lib64/libfoo.so /var/tmp/baz
+
+Same as above, but place the files into :code:`/corge` instead (and the shared
+library will not be found by :code:`ldconfig`)::
+
+  $ ch-fromhost --dest /corge --file qux.txt /var/tmp/baz
+
 Same as above, and also place file :code:`/etc/quux` at :code:`/etc/quux`
 within the container::
 
-  $ cat corge.txt
-  /bin/bar
-  /etc/quux
-  /usr/lib64/libfoo.so
-  $ ch-fromhost --file corge.txt --dest /etc /var/tmp/baz
+  $ ch-fromhost --file qux.txt --dest /etc --path /etc/quux /var/tmp/baz
 
 Inject the executables and libraries recommended by nVidia into the image, and
 then run :code:`ldconfig`::
 
   $ ch-fromhost --nvidia /var/tmp/baz
+
+
+Acknowledgements
+================
+
+This command was inspired by the similar `Shifter
+<http://www.nersc.gov/research-and-development/user-defined-images/>`_ feature
+that allows Shifter containers to use the Cray Aires network. We particularly
+appreciate the help provided by Shane Canon and Doug Jacobsen during our
+implementation of :code:`--cray-mpi`.
+
+
+..  LocalWords:  libmpi libmpich nvidia

--- a/examples/mpi/mpibench-mpich/test.bash
+++ b/examples/mpi/mpibench-mpich/test.bash
@@ -1,3 +1,4 @@
 setup_specific () {
     prerequisites_ok mpibench-mpich
+    crayify_mpi_maybe "$ch_img"
 }

--- a/examples/mpi/mpibench/test.bats
+++ b/examples/mpi/mpibench/test.bats
@@ -39,6 +39,7 @@ check_process_ct () {
 
 # one from "Single Transfer Benchmarks"
 @test "${ch_tag}/pingpong (guest launch)" {
+    [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
     run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args PingPong
     echo "$output"
@@ -61,6 +62,7 @@ check_process_ct () {
 
 # one from "Parallel Transfer Benchmarks"
 @test "${ch_tag}/sendrecv (guest launch)" {
+    [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
     run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args Sendrecv
     echo "$output"
@@ -83,6 +85,7 @@ check_process_ct () {
 
 # one from "Collective Benchmarks"
 @test "${ch_tag}/allreduce (guest launch)" {
+    [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
     run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args Allreduce
     echo "$output"

--- a/examples/mpi/mpihello-mpich/test.bash
+++ b/examples/mpi/mpihello-mpich/test.bash
@@ -1,3 +1,4 @@
 setup () {
     scope full
+    crayify_mpi_maybe "$ch_img"
 }

--- a/examples/mpi/mpihello/hello.c
+++ b/examples/mpi/mpihello/hello.c
@@ -25,16 +25,23 @@ int rank, rank_ct;
 
 int main(int argc, char ** argv)
 {
-   int msg;
-   struct stat st;
-   MPI_Status mstat;
    char hostname[HOST_NAME_MAX+1];
+   char mpi_version[MPI_MAX_LIBRARY_VERSION_STRING];
+   int mpi_version_len;
+   int msg;
+   MPI_Status mstat;
+   struct stat st;
 
    stat("/proc/self/ns/user", &st);
 
    MPI_Init(&argc, &argv);
    MPI_Comm_size(MPI_COMM_WORLD, &rank_ct);
    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+   if (rank == 0) {
+      MPI_Get_library_version(mpi_version, &mpi_version_len);
+      printf("%d: MPI version:\n%s\n", rank, mpi_version);
+   }
 
    gethostname(hostname, HOST_NAME_MAX+1);
    printf("%d: init ok %s, %d ranks, userns %lu\n",

--- a/examples/mpi/mpihello/test.bats
+++ b/examples/mpi/mpihello/test.bats
@@ -69,10 +69,10 @@ count_ranks () {
     [[ $output = *'0: finalize ok'* ]]
 }
 
-@test "$EXAMPLE_TAG/Cray bind mounts" {
-    [[ $CHTEST_CRAY ]] || skip 'host is not a Cray'
-    [[ $CHTEST_MPI = openmpi ]] && skip 'OpenMPI unsupported on Cray; issue #180'
+@test "${ch_tag}/Cray bind mounts" {
+    [[ $ch_cray ]] || skip 'host is not a Cray'
+    [[ $ch_mpi = openmpi ]] && skip 'OpenMPI unsupported on Cray; issue #180'
 
-    ch-run "$IMG" -- mount | grep -F /var/opt/cray/alps/spool
-    ch-run "$IMG" -- mount | grep -F /var/opt/cray/hugetlbfs
+    ch-run "$ch_img" -- mount | grep -F /var/opt/cray/alps/spool
+    ch-run "$ch_img" -- mount | grep -F /var/opt/cray/hugetlbfs
 }

--- a/examples/mpi/mpihello/test.bats
+++ b/examples/mpi/mpihello/test.bats
@@ -12,14 +12,14 @@ count_ranks () {
 }
 
 @test "${ch_tag}/MPI version" {
-    run ch-run "$IMG" -- /hello/hello
+    run ch-run "$ch_img" -- /hello/hello
     echo "$output"
     [[ $status -eq 0 ]]
-    if [[ $CHTEST_MPI = openmpi ]]; then
+    if [[ $ch_mpi = openmpi ]]; then
         [[ $output = *'Open MPI'* ]]
     else
-        [[ $CHTEST_MPI = mpich ]]
-        if [[ $CHTEST_CRAY ]]; then
+        [[ $ch_mpi = mpich ]]
+        if [[ $ch_cray ]]; then
             [[ $output = *'CRAY MPICH'* ]]
         else
             [[ $output = *'MPICH Version:'* ]]

--- a/examples/mpi/mpihello/test.bats
+++ b/examples/mpi/mpihello/test.bats
@@ -11,6 +11,22 @@ count_ranks () {
     | sed -r 's/^.+ ([0-9]+) ranks.+$/\1/'
 }
 
+@test "${ch_tag}/MPI version" {
+    run ch-run "$IMG" -- /hello/hello
+    echo "$output"
+    [[ $status -eq 0 ]]
+    if [[ $CHTEST_MPI = openmpi ]]; then
+        [[ $output = *'Open MPI'* ]]
+    else
+        [[ $CHTEST_MPI = mpich ]]
+        if [[ $CHTEST_CRAY ]]; then
+            [[ $output = *'CRAY MPICH'* ]]
+        else
+            [[ $output = *'MPICH Version:'* ]]
+        fi
+    fi
+}
+
 @test "${ch_tag}/serial" {
     # This seems to start up the MPI infrastructure (daemons, etc.) within the
     # guest even though there's no mpirun.
@@ -23,6 +39,7 @@ count_ranks () {
 }
 
 @test "${ch_tag}/guest starts ranks" {
+    [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
     run ch-run "$ch_img" -- mpirun $ch_mpirun_np /hello/hello
     echo "$output"
@@ -50,4 +67,12 @@ count_ranks () {
     [[ $rank_ct -eq "$ch_cores_total" ]]
     [[ $output = *'0: send/receive ok'* ]]
     [[ $output = *'0: finalize ok'* ]]
+}
+
+@test "$EXAMPLE_TAG/Cray bind mounts" {
+    [[ $CHTEST_CRAY ]] || skip 'host is not a Cray'
+    [[ $CHTEST_MPI = openmpi ]] && skip 'OpenMPI unsupported on Cray; issue #180'
+
+    ch-run "$IMG" -- mount | grep -F /var/opt/cray/alps/spool
+    ch-run "$IMG" -- mount | grep -F /var/opt/cray/hugetlbfs
 }

--- a/examples/serial/spack/test.bats
+++ b/examples/serial/spack/test.bats
@@ -2,7 +2,7 @@ load ../../../test/common
 
 setup() {
     scope full
-    [[ -z $CHTEST_CRAY ]] || skip 'issue #193 and Spack issue #8618'
+    [[ -z $ch_cray ]] || skip 'issue #193 and Spack issue #8618'
     prerequisites_ok spack
     export PATH=/spack/bin:$PATH
 }

--- a/test/Dockerfile.mpich
+++ b/test/Dockerfile.mpich
@@ -5,9 +5,50 @@ FROM debian9
 # provide an MPICH build that works on a single node and (via ch-fromhost
 # trickery) on Cray Aires systems. That's it for now.
 
+# We build MPICH rather than install the Debian package because something
+# about Debian's build prevents applications from linking against
+# libmpi.so.12, which is the library we need to replace later. I have not
+# figured out what. While we're at it, tweak some other options as well to
+# produce a bare bones build.
+
 RUN apt-get install -y --no-install-suggests \
+    autoconf \
+    g++ \
+    gcc \
+    git \
+    libgfortran3 \
+    libpmi2-0-dev \
     make \
-    mpich
+    wget
 
+# We currently need our own patched patchelf; see issue #256.
+RUN git clone https://github.com/hpc/patchelf.git
+RUN    cd patchelf \
+    && git checkout shrink-soname \
+    && ./bootstrap.sh \
+    && ./configure --prefix=/usr/local \
+    && make install
+RUN rm -Rf patchelf
 
+ENV MPI_VERSION 3.2.1
+ENV MPI_URL http://www.mpich.org/static/downloads/${MPI_VERSION}
+RUN wget -nv ${MPI_URL}/mpich-${MPI_VERSION}.tar.gz
+RUN tar xf mpich-${MPI_VERSION}.tar.gz
+RUN apt-get install -y --no-install-suggests file
 
+RUN    cd mpich-${MPI_VERSION} \
+    && CFLAGS=-O3 \
+       CXXFLAGS=-O3 \
+       ./configure --prefix=/usr/local \
+                   --disable-cxx \
+                   --disable-fortran \
+                   --disable-threads \
+                   --disable-rpath \
+                   --disable-static \
+                   --disable-wrapper-rpath \
+                   --without-ibverbs \
+                   --without-libfabric \
+                   --without-slurm \
+    && make -j$(getconf _NPROCESSORS_ONLN) install
+RUN rm -Rf mpich-${MPI_VERSION}*
+RUN ldconfig

--- a/test/common.bash
+++ b/test/common.bash
@@ -1,7 +1,7 @@
 crayify_mpi_maybe () {
-    if [[ $CHTEST_CRAY ]]; then
+    if [[ $ch_cray ]]; then
         # shellcheck disable=SC2086
-        $MPIRUN_NODE ch-fromhost --cray-mpi "$1"
+        $ch_mpirun_node ch-fromhost --cray-mpi "$1"
     fi
 }
 

--- a/test/common.bash
+++ b/test/common.bash
@@ -1,3 +1,10 @@
+crayify_mpi_maybe () {
+    if [[ $CHTEST_CRAY ]]; then
+        # shellcheck disable=SC2086
+        $MPIRUN_NODE ch-fromhost --cray-mpi "$1"
+    fi
+}
+
 docker_tag_p () {
     printf 'image tag %s ... ' "$1"
     hash_=$(sudo docker images -q "$1" | sort -u)

--- a/test/run/ch-fromhost.bats
+++ b/test/run/ch-fromhost.bats
@@ -102,7 +102,7 @@ fromhost_ls () {
 @test 'ch-fromhost (CentOS)' {
     scope full
     prerequisites_ok centos7
-    img=$imgdir/centos7
+    img=${ch_imgdir}/centos7
 
     fromhost_clean "$img"
     ch-fromhost -v --file sotest/files_inferrable.txt "$img"

--- a/test/run/ch-fromhost.bats
+++ b/test/run/ch-fromhost.bats
@@ -2,17 +2,19 @@ load ../common
 
 fromhost_clean () {
     [[ $1 ]]
-    for file in /{mnt,usr/bin}/sotest \
+    for file in /{lib,mnt,usr/bin}/sotest \
                 /{lib,mnt,usr/lib,usr/local/lib}/libsotest.so.1{.0,} \
                 /usr/local/cuda-9.1/targets/x86_64-linux/lib/libsotest.so.1{.0,} \
                 /mnt/sotest.c \
                 /etc/ld.so.cache ; do
         rm -f "${1}${file}"
     done
+    ch-run -w "$1" -- /sbin/ldconfig  # restore default cache
     fromhost_clean_p "$1"
 }
 
 fromhost_clean_p () {
+    ch-run "$1" -- /sbin/ldconfig -p | grep -F libsotest && return 1
     run fromhost_ls "$1"
     echo "$output"
     [[ $status -eq 0 ]]
@@ -20,7 +22,7 @@ fromhost_clean_p () {
 }
 
 fromhost_ls () {
-    find "$1" -xdev \( -name '*sotest*' -o -name 'ld.so.cache' \) -ls
+    find "$1" -xdev -name '*sotest*' -ls
 }
 
 @test 'ch-fromhost (Debian)' {
@@ -28,35 +30,33 @@ fromhost_ls () {
     prerequisites_ok debian9
     img=${ch_imgdir}/debian9
 
-    # --cmd
+    # inferred path is what we expect
+    [[ $(ch-fromhost --lib-path "$img") = /usr/local/lib ]]
+
+    # --file
     fromhost_clean "$img"
-    ch-fromhost -v --cmd 'cat sotest/files_inferrable.txt' "$img"
+    ch-fromhost -v --file sotest/files_inferrable.txt "$img"
     fromhost_ls "$img"
     test -f "${img}/usr/bin/sotest"
     test -f "${img}/usr/local/lib/libsotest.so.1.0"
     test -L "${img}/usr/local/lib/libsotest.so.1"
-    ch-run "$img" -- /sbin/ldconfig -p | grep -F sotest
+    ch-run "$img" -- /sbin/ldconfig -p | grep -F libsotest
     ch-run "$img" -- sotest
     rm "${img}/usr/bin/sotest"
     rm "${img}/usr/local/lib/libsotest.so.1.0"
     rm "${img}/usr/local/lib/libsotest.so.1"
-    rm "${img}/etc/ld.so.cache"
+    ch-run -w "$img" -- /sbin/ldconfig
     fromhost_clean_p "$img"
 
-    # --cmd twice
-    ch-fromhost -v --cmd 'cat sotest/files_inferrable.txt' \
-                   --cmd 'cat sotest/files_inferrable.txt' "$img"
+    # --cmd
+    ch-fromhost -v --cmd 'cat sotest/files_inferrable.txt' "$img"
     ch-run "$img" -- sotest
     fromhost_clean "$img"
 
-    # --file
-    ch-fromhost -v --file sotest/files_inferrable.txt "$img"
-    ch-run "$img" -- sotest
-    fromhost_clean "$img"
-
-    # --file twice
-    ch-fromhost -v --file sotest/files_inferrable.txt \
-                   --file sotest/files_inferrable.txt "$img"
+    # --path
+    ch-fromhost -v --path sotest/bin/sotest \
+                   --path sotest/lib/libsotest.so.1.0 \
+                   "$img"
     ch-run "$img" -- sotest
     fromhost_clean "$img"
 
@@ -68,30 +68,28 @@ fromhost_ls () {
 
     # --dest
     ch-fromhost -v --file sotest/files_inferrable.txt \
-                   --file sotest/files_noninferrable.txt \
-                   --dest /mnt "$img"
+                   --dest /mnt "$img" \
+                   --path sotest/sotest.c
     ch-run "$img" -- sotest
     ch-run "$img" -- test -f /mnt/sotest.c
     fromhost_clean "$img"
 
-    # file that needs --dest but not specified
-    run ch-fromhost -v --file sotest/files_noninferrable.txt "$img"
-    echo "$output"
-    [[ $status -eq 1 ]]
-    [[ $output = *'no destination for: sotest/sotest.c'* ]]
-    fromhost_clean_p "$img"
+    # --dest overrides inference, but ldconfig still run
+    ch-fromhost -v --dest /lib \
+                   --file sotest/files_inferrable.txt \
+                   "$img"
+    ch-run "$img" -- /lib/sotest
+    fromhost_clean "$img"
 
-    # --no-infer
-    ch-run -w "$img" -- /sbin/ldconfig  # restore default cache
-    ch-fromhost -v --cmd 'echo sotest/bin/sotest' \
-                   --no-infer --dest /usr/bin "$img"
-    ch-fromhost -v --cmd 'echo sotest/lib/libsotest.so.1.0' \
-                   --no-infer --dest /usr/local/lib "$img"
-    fromhost_ls "$img"
-    ch-run "$img" -- /sbin/ldconfig -p | grep -F sotest || true
+    # --no-ldconfig
+    ch-fromhost -v --no-ldconfig --file sotest/files_inferrable.txt "$img"
+    test -f "${img}/usr/bin/sotest"
+    test -f "${img}/usr/local/lib/libsotest.so.1.0"
+    ! test -L "${img}/usr/local/lib/libsotest.so.1"
+    ! ( ch-run "$img" -- /sbin/ldconfig -p | grep -F libsotest )
     run ch-run "$img" -- sotest
     echo "$output"
-    [[ $status -ne 0 ]]
+    [[ $status -eq 127 ]]
     [[ $output = *'libsotest.so.1: cannot open shared object file'* ]]
     fromhost_clean "$img"
 
@@ -99,6 +97,80 @@ fromhost_ls () {
     ch-fromhost --file sotest/files_inferrable.txt "$img"
     ch-run "$img" -- sotest
     fromhost_clean "$img"
+}
+
+@test 'ch-fromhost (CentOS)' {
+    scope full
+    prerequisites_ok centos7
+    img=$imgdir/centos7
+
+    fromhost_clean "$img"
+    ch-fromhost -v --file sotest/files_inferrable.txt "$img"
+    fromhost_ls "$img"
+    test -f "${img}/usr/bin/sotest"
+    test -f "${img}/lib/libsotest.so.1.0"
+    test -L "${img}/lib/libsotest.so.1"
+    ch-run "$img" -- /sbin/ldconfig -p | grep -F libsotest
+    ch-run "$img" -- sotest
+    rm "${img}/usr/bin/sotest"
+    rm "${img}/lib/libsotest.so.1.0"
+    rm "${img}/lib/libsotest.so.1"
+    rm "${img}/etc/ld.so.cache"
+    fromhost_clean_p "$img"
+}
+
+@test 'ch-fromhost errors' {
+    scope standard
+    prerequisites_ok debian9
+    img=${ch_imgdir}/debian9
+
+    # no image
+    run ch-fromhost --path sotest/sotest.c
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'no image specified'* ]]
+    fromhost_clean_p "$img"
+
+    # image is not a directory
+    run ch-fromhost --path sotest/sotest.c /etc/motd
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'image not a directory: /etc/motd'* ]]
+    fromhost_clean_p "$img"
+
+    # two image arguments
+    run ch-fromhost --path sotest/sotest.c "$img" foo
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'duplicate image: foo'* ]]
+    fromhost_clean_p "$img"
+
+    # no files argument
+    run ch-fromhost "$img"
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'empty file list'* ]]
+    fromhost_clean_p "$img"
+
+    # file that needs --dest but not specified
+    run ch-fromhost -v --path sotest/sotest.c "$img"
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'no destination for: sotest/sotest.c'* ]]
+    fromhost_clean_p "$img"
+
+    # file with colon in name
+    run ch-fromhost -v --path 'foo:bar' "$img"
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *"paths can't contain colon: foo:bar"* ]]
+    fromhost_clean_p "$img"
+    # file with newlines in name
+    run ch-fromhost -v --path $'foo\nbar' "$img"
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *"no destination for: foo"* ]]
+    fromhost_clean_p "$img"
 
     # --cmd no argument
     run ch-fromhost "$img" --cmd
@@ -107,13 +179,13 @@ fromhost_ls () {
     [[ $output = *'--cmd must not be empty'* ]]
     fromhost_clean_p "$img"
     # --cmd empty
-    run ch-fromhost --cmd true
+    run ch-fromhost --cmd true "$img"
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output = *'empty file list'* ]]
     fromhost_clean_p "$img"
     # --cmd fails
-    run ch-fromhost --cmd false
+    run ch-fromhost --cmd false "$img"
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output = *'command failed: false'* ]]
@@ -139,11 +211,18 @@ fromhost_ls () {
     [[ $output = *'cannot read file: /doesnotexist'* ]]
     fromhost_clean_p "$img"
 
-    # neither --cmd nor --file
-    run ch-fromhost "$img"
+    # --path no argument
+    run ch-fromhost "$img" --path
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = *'empty file list'* ]]
+    [[ $output = *'--path must not be empty'* ]]
+    fromhost_clean_p "$img"
+    # --path does not exist
+    run ch-fromhost --dest /mnt --path /doesnotexist "$img"
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'No such file or directory'* ]]
+    [[ $output = *'cannot inject: /doesnotexist'* ]]
     fromhost_clean_p "$img"
 
     # --dest no argument
@@ -153,22 +232,19 @@ fromhost_ls () {
     [[ $output = *'--dest must not be empty'* ]]
     fromhost_clean_p "$img"
     # --dest not an absolute path
-    run ch-fromhost --file sotest/files_noninferrable.txt \
-                    --dest relative "$img"
+    run ch-fromhost --dest relative --path sotest/sotest.c "$img"
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output = *'not an absolute path: relative'* ]]
     fromhost_clean_p "$img"
     # --dest does not exist
-    run ch-fromhost --file sotest/files_noninferrable.txt \
-                    --dest /doesnotexist "$img"
+    run ch-fromhost --dest /doesnotexist --path sotest/sotest.c "$img"
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output = *'not a directory:'* ]]
     fromhost_clean_p "$img"
     # --dest is not a directory
-    run ch-fromhost --file sotest/files_noninferrable.txt \
-                    --dest /bin/sh "$img"
+    run ch-fromhost --dest /bin/sh --file sotest/sotest.c "$img"
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output = *'not a directory:'* ]]
@@ -184,28 +260,26 @@ fromhost_ls () {
     run ch-fromhost --file sotest/files_inferrable.txt "$img" "$img"
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = *'duplicate image path'* ]]
+    [[ $output = *'duplicate image'* ]]
     fromhost_clean_p "$img"
 }
 
-@test 'ch-fromhost (CentOS)' {
+@test 'ch-fromhost --cray-mpi not on a Cray' {
     scope full
-    prerequisites_ok centos7
-    img=${ch_imgdir}/centos7
+    [[ $ch_cray ]] && skip 'host is a Cray'
+    run ch-fromhost --cray-mpi "$ch_timg"
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'are you on a Cray?'* ]]
+}
 
-    fromhost_clean "$img"
-    ch-fromhost -v --file sotest/files_inferrable.txt "$img"
-    fromhost_ls "$img"
-    test -f "${img}/usr/bin/sotest"
-    test -f "${img}/lib/libsotest.so.1.0"
-    test -L "${img}/lib/libsotest.so.1"
-    ch-run "$img" -- /sbin/ldconfig -p | grep -F sotest
-    ch-run "$img" -- sotest
-    rm "${img}/usr/bin/sotest"
-    rm "${img}/lib/libsotest.so.1.0"
-    rm "${img}/lib/libsotest.so.1"
-    rm "${img}/etc/ld.so.cache"
-    fromhost_clean_p "$img"
+@test 'ch-fromhost --cray-mpi with no MPI installed' {
+    scope full
+    [[ $ch_cray ]] || skip 'host is not a Cray'
+    run ch-fromhost --cray-mpi "$ch_timg"
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *"can't find MPI in image"* ]]
 }
 
 @test 'ch-fromhost --nvidia with GPU' {

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -40,6 +40,16 @@ EOF
     [[ $host_size -eq "$guest_size" ]]
 }
 
+@test 'optional default bind mounts silently skipped' {
+    scope standard
+
+    [[ ! -e "$CHTEST_IMG/var/opt/cray/alps/spool" ]]
+    [[ ! -e "$CHTEST_IMG/var/opt/cray/hugetlbfs" ]]
+
+    ch-run "$CHTEST_IMG" -- mount | ( ! grep -F /var/opt/cray/alps/spool )
+    ch-run "$CHTEST_IMG" -- mount | ( ! grep -F /var/opt/cray/hugetlbfs )
+}
+
 # shellcheck disable=SC2016
 @test '$HOME' {
     scope quick

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -43,11 +43,11 @@ EOF
 @test 'optional default bind mounts silently skipped' {
     scope standard
 
-    [[ ! -e "$CHTEST_IMG/var/opt/cray/alps/spool" ]]
-    [[ ! -e "$CHTEST_IMG/var/opt/cray/hugetlbfs" ]]
+    [[ ! -e "${ch_timg}/var/opt/cray/alps/spool" ]]
+    [[ ! -e "${ch_timg}/var/opt/cray/hugetlbfs" ]]
 
-    ch-run "$CHTEST_IMG" -- mount | ( ! grep -F /var/opt/cray/alps/spool )
-    ch-run "$CHTEST_IMG" -- mount | ( ! grep -F /var/opt/cray/hugetlbfs )
+    ch-run "$ch_timg" -- mount | ( ! grep -F /var/opt/cray/alps/spool )
+    ch-run "$ch_timg" -- mount | ( ! grep -F /var/opt/cray/hugetlbfs )
 }
 
 # shellcheck disable=SC2016

--- a/test/sotest/files_noninferrable.txt
+++ b/test/sotest/files_noninferrable.txt
@@ -1,1 +1,0 @@
-sotest/sotest.c


### PR DESCRIPTION
This fixes issue #182. We replace open source MPICH with Cray MPICH and then perform a bunch of black magic to make it work. This approach is patterned after Shifter. Tests do pass on a Cray.

This changes the UI of `ch-fromhost` significantly, but I think it's a lot better now.

The code is ... flavorful. But, I think good enough for an experimental feature.