### PR TITLE
Fix bind-error symlink issue by dereferencing symlinks in $CH_TEST_IMGDIR

### DIFF
--- a/test/common.bash
+++ b/test/common.bash
@@ -161,8 +161,8 @@ else
 fi
 
 # Separate directories for tarballs and images
-# This Ensures that the bind-error test works correctly see #143
-ch_imgdir=$(cd -P $CH_TEST_IMGDIR; cd .; cd -)
+# We use readlink because 
+ch_imgdir=$(readlink -f $CH_TEST_IMGDIR)
 ch_tardir=$CH_TEST_TARDIR
 
 # Some test variables

--- a/test/common.bash
+++ b/test/common.bash
@@ -162,7 +162,7 @@ fi
 
 # Separate directories for tarballs and images
 # We use readlink because 
-ch_imgdir=$(readlink -f $CH_TEST_IMGDIR)
+ch_imgdir=$(readlink -f "$CH_TEST_IMGDIR")
 ch_tardir=$CH_TEST_TARDIR
 
 # Some test variables

--- a/test/common.bash
+++ b/test/common.bash
@@ -161,7 +161,8 @@ else
 fi
 
 # Separate directories for tarballs and images
-ch_imgdir=$CH_TEST_IMGDIR
+# This Ensures that the bind-error test works correctly see #143
+ch_imgdir=$(cd -P $CH_TEST_IMGDIR; cd .; cd -)
 ch_tardir=$CH_TEST_TARDIR
 
 # Some test variables

--- a/test/common.bash
+++ b/test/common.bash
@@ -160,10 +160,15 @@ else
     ch_cray=
 fi
 
-# Separate directories for tarballs and images
-# We use readlink because 
-ch_imgdir=$(readlink -f "$CH_TEST_IMGDIR")
-ch_tardir=$CH_TEST_TARDIR
+# Separate directories for tarballs and images.
+#
+# Canonicalize both so the have consistent paths and we can reliably use them
+# in tests (see issue #143). We use readlink(1) rather than realpath(2),
+# despite the admonition in the man page, because it's more portable [1].
+#
+# [1]: https://unix.stackexchange.com/a/136527
+ch_imgdir=$(readlink -ef "$CH_TEST_IMGDIR")
+ch_tardir=$(readlink -ef "$CH_TEST_TARDIR")
 
 # Some test variables
 ch_tag=$(basename "$BATS_TEST_DIRNAME")


### PR DESCRIPTION
This PR resolves #143. We dereference the symlink using cd -P. readlink -f is the more usual, but it is less portable. 