### PR TITLE
add CH_TEST_TMPDIR, update build.bats (closes #271)

### DIFF
--- a/doc-src/test.rst
+++ b/doc-src/test.rst
@@ -37,13 +37,14 @@ These phases can be tested independently on different systems.
 Testing is coordinated by :code:`make`. The test targets run one or more test
 suites. If any test suite has a failure, testing stops with an error message.
 
-The tests need three work directories with a dozen or so GB of available
+The tests need four work directories with a dozen or so GB of available
 space, in order to store image tarballs, unpacked image directories, and
 permission test fixtures. These are configured with environment variables; for
 example::
 
   $ export CH_TEST_TARDIR=/var/tmp/tarballs
   $ export CH_TEST_IMGDIR=/var/tmp/images
+  $ export CH_TEST_TMPDIR=/var/tmp
   $ export CH_TEST_PERMDIRS='/var/tmp /tmp'
 
 :code:`CH_TEST_PERMDIRS` can be set to :code:`skip` in order to skip the file

--- a/test/common.bash
+++ b/test/common.bash
@@ -169,6 +169,7 @@ fi
 # [1]: https://unix.stackexchange.com/a/136527
 ch_imgdir=$(readlink -ef "$CH_TEST_IMGDIR")
 ch_tardir=$(readlink -ef "$CH_TEST_TARDIR")
+ch_tmpdir=$(readlink -ef "$CH_TEST_TMPDIR")
 
 # Some test variables
 ch_tag=$(basename "$BATS_TEST_DIRNAME")
@@ -246,6 +247,7 @@ fi
 # Do we have what we need?
 env_require CH_TEST_TARDIR
 env_require CH_TEST_IMGDIR
+env_require CH_TEST_TMPDIR
 env_require CH_TEST_PERMDIRS
 if ( bash -c 'set -e; [[ 1 = 0 ]]; exit 0' ); then
     # Bash bug: [[ ... ]] expression doesn't exit with set -e


### PR DESCRIPTION
Address #271.

This PR introduces `CH_TEST_TMPDIR`, a new directory used for used for testing (e.g., `ch-build2dir`, `ch-pull2dir`, and `ch-pull2tar`).