### PR TITLE
Fix tmp symbolic link issue

### DIFF
--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -305,8 +305,9 @@ EOF
         run ch-run "$img" -- true
         touch "${img}/${f}"  # restore before test fails for idempotency
         echo "$output"
+        echo "$output" >> ruff
         [[ $status -eq 1 ]]
-        [[ $output = *"can't bind: not found: ${img}/${f}"* ]]
+        [[ $output =~ .*"can't bind: not found: "[\/a-zA-Z._0-9-]*$f.* ]]
     done
 
     # For each optional file, we want no error if it's missing.
@@ -343,7 +344,7 @@ EOF
         mkdir "${img}/${d}"  # restore before test fails for idempotency
         echo "$output"
         [[ $status -eq 1 ]]
-        [[ $output = *"can't bind: not found: ${img}/${d}"* ]]
+        [[ $output =~ .*"can't bind: not found: "[\/a-zA-Z._0-9-]*$d.* ]]
     done
 
     # For each directory, we want a correct error if it's not a directory.


### PR DESCRIPTION
Addresses issue #279. My only concern is if the regex will cover all possible image names. 