### PR TITLE
add ch-run --set-env feature

### DIFF
--- a/bin/ch-run.c
+++ b/bin/ch-run.c
@@ -110,6 +110,7 @@ int main(int argc, char *argv[])
    args.c.private_home = false;
    args.c.private_tmp = false;
    args.c.old_home = getenv("HOME");
+   args.c.writable = false;
    T_ (args.env_deltas = calloc(1, sizeof(struct env_delta)));
    args.initial_dir = NULL;
    verbose = 1;  // in charliecloud.h

--- a/bin/charliecloud.c
+++ b/bin/charliecloud.c
@@ -193,16 +193,15 @@ void enter_udss(struct container *c)
    }
    // Container /home.
    if (!c->private_home) {
-      char *oldhome, *newhome;
+      char *newhome;
       // Mount tmpfs on guest /home because guest root is read-only
       tmpfs_mount("/home", c->newroot, "size=4m");
       // Bind-mount user's home directory at /home/$USER. The main use case is
       // dotfiles.
-      oldhome = getenv("HOME");
-      Tf (oldhome != NULL, "cannot find home directory: $HOME not set");
+      Tf (c->old_home != NULL, "cannot find home directory: is $HOME set?");
       newhome = cat("/home/", getenv("USER"));
       Z_ (mkdir(cat(c->newroot, newhome), 0755));
-      bind_mount(oldhome, newhome, c->newroot, BD_REQUIRED, 0);
+      bind_mount(c->old_home, newhome, c->newroot, BD_REQUIRED, 0);
    }
    // Bind-mount /usr/bin/ch-ssh if it exists.
    if (path_exists(cat(c->newroot, "/usr/bin/ch-ssh"))) {

--- a/bin/charliecloud.h
+++ b/bin/charliecloud.h
@@ -74,6 +74,7 @@ struct container {
    char *join_tag;      // identifier for synchronized join
    bool private_home;
    bool private_tmp;
+   char *old_home;      // host path to user's home directory (i.e. $HOME)
    bool writable;
 };
 


### PR DESCRIPTION
Partially addresses #224.

This PR does not unset ch-run process environment variables, nor does it overwrite existing environment variables. The current thinking is that we will provide two new features to ch-run, `--set-env=FILE` and `--unset-env=[STRING]`, which give users control of the environment inside their container. Thus, this PR in addition to a future PR (to address #295) will completely resolve #224. 

This prototype of `--set-env-FILE` is dependent on a file consisting of key value pairs separated by the first occurrence of the `=` character, e.g., `KEY=value`.  Example of valid key value pairs:

```
CUDA_TOOLKIT_PATH='/usr/local/cuda'
CC_OPT_FLAGS=-march=sandybridge -mtune=broadwell
test=123
```

Invalid key value pairs:

```cpp
PATH $PATH:$HOME/bin  // no separator
=PATH=$PATH:$HOME/bin // name is empty due to separator placement
     test=$HOME/test/out // spaces before key value pair
```

The approach is simple:

1. Read a line from the FILE with `fgets()` into a buffer
2. Strip the newline in the buffer added by fegets()
3. Copy the contents of buffer into `name`
4. Replace `name` with the characters before the separator (`strsep(name, "=")`)
  4.1 If the length of `name` is the same as it was before `strsep()`, error — we did not encounter the separator
5.  Allocate memory equal to the number of characters right of the separator
6. Copy the characters right of the separator into `value`
7. Call `setenv(name, value, 0)`. 

 



