### PR TITLE
ch-fromhost enhancements to inject "regular" files and handle image permission issues

### DIFF
--- a/bin/ch-fromhost
+++ b/bin/ch-fromhost
@@ -64,6 +64,7 @@ Destination within image:
 
 Options:
 
+  --force          modify permissions in the image directory when needed
   --lib-path       print the inferred destination for shared libraries
   --no-ldconfig    don't run ldconfig even if we injected shared libraries
   -h, --help       print this help and exit
@@ -76,6 +77,7 @@ cray_mpi=          # Cray fixups requested
 #cray_openmpi=     # ... for OpenMPI
 cray_mpich=        # ... for MPICH
 dest=
+force=false
 image=
 newline='
 '
@@ -190,6 +192,9 @@ while [ $# -gt 0 ]; do
             queue_files "$out"
             shift
             ;;
+        --force)
+            force=true
+            ;;
         --lib-path)
             # Note: If this is specified along with one of the file
             # specification options, all the file gathering and checking work
@@ -235,6 +240,7 @@ if [ $lib_found ]; then
     debug "asking ldconfig for shared library destination"
     lib_dest=$(  "${ch_bin}/ch-run" "$image" -- /sbin/ldconfig -Nv 2> /dev/null \
                | grep -E '^/' | cut -d: -f1 | head -1)
+    [ -n "${lib_dest}" ] || fatal "destination path from ldconfig is empty"
     [ -z "${lib_dest%%/*}" ] || fatal "bad path from ldconfig: ${lib_dest}"
     debug "shared library destination: ${lib_dest}"
 fi
@@ -338,11 +344,16 @@ for file in $inject_files; do
     elif is_so "$f" && [ -z "$d" ]; then
         d=$lib_dest
         infer=" (inferred)"
+    else
+        d="${f%/*}"
     fi
     debug "  ${f} -> ${d}${infer}"
     [ "$d" ] || fatal "no destination for: ${f}"
     [ -z "${d%%/*}" ] || fatal "not an absolute path: ${d}"
     [ -d "${image}${d}" ] || fatal "not a directory: ${image}${d}"
+    [ ! -w "${image}${d}" ] && ${force} && chmod u+w "${image}${d}" \
+    && debug "  modifying permissions on ${image}${d}"
+    [ -w "${image}${d}" ] || info "directory not writable: ${image}${d}"
        cp --dereference --preserve=all "$f" "${image}${d}" \
     || fatal "cannot inject: ${f}"
 done


### PR DESCRIPTION
Adds `ch-fromhost --force` command line option to set the write bit on image directories when needed.  The option is disabled by default, but a new, more descriptive warning message has also been added to better identify the problem. 

Also adds a failure mode if the destination path returned by `ldconfig` is empty.  For instance, if `ch-run` isn't working properly because a bind path is not defined in the image.

Without this PR:

```
$ skopeo --insecure-policy copy docker://nvidia/cuda:9.0-base-centos7 oci:cuda:9.0-base-centos7
$ umoci unpack --rootless --image cuda:9.0-base-centos7 ex3

$ ch-fromhost -v -p /etc/resolv.conf ex3/rootfs
injecting into image: ex3/rootfs
  /etc/resolv.conf -> 
ch-fromhost: no destination for: /etc/resolv.conf

$ touch ex3/rootfs/etc/resolv.conf

$ ch-fromhost -v --nvidia ex3/rootfs 
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libcuda.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-fatbinaryloader.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-compiler.so.396.44
asking ldconfig for shared library destination
shared library destination: /usr/local/cuda-9.0/targets/x86_64-linux/lib
injecting into image: ex3/rootfs
  /usr/bin/nvidia-smi -> /usr/bin (inferred)
cp: cannot create regular file 'ex3/rootfs/usr/bin/nvidia-smi': Permission denied
ch-fromhost: cannot inject: /usr/bin/nvidia-smi
```

With this PR:

```
$ skopeo --insecure-policy copy docker://nvidia/cuda:9.0-base-centos7 oci:cuda:9.0-base-centos7
$ umoci unpack --rootless --image cuda:9.0-base-centos7 ex3

$ ch-fromhost -v -p /etc/resolv.conf ex3/rootfs 
injecting into image: ex3/rootfs
  /etc/resolv.conf -> /etc
not running ldconfig

$ ch-fromhost -v --nvidia ex3/rootfs 
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libcuda.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-fatbinaryloader.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-compiler.so.396.44
asking ldconfig for shared library destination
shared library destination: /usr/local/cuda-9.0/targets/x86_64-linux/lib
injecting into image: ex3/rootfs
  /usr/bin/nvidia-smi -> /usr/bin (inferred)
ch-fromhost: directory not writable: ex3/rootfs/usr/bin
cp: cannot create regular file 'ex3/rootfs/usr/bin/nvidia-smi': Permission denied
ch-fromhost: cannot inject: /usr/bin/nvidia-smi

$ ch-fromhost -v --nvidia --force ex3/rootfs
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libcuda.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-fatbinaryloader.so.396.44
found shared library: /usr/lib/x86_64-linux-gnu/libnvidia-compiler.so.396.44
asking ldconfig for shared library destination
shared library destination: /usr/local/cuda-9.0/targets/x86_64-linux/lib
injecting into image: ex3/rootfs
  /usr/bin/nvidia-smi -> /usr/bin (inferred)
  modifying permissions on ex3/rootfs/usr/bin
  /usr/bin/nvidia-debugdump -> /usr/bin (inferred)
  /usr/bin/nvidia-persistenced -> /usr/bin (inferred)
  /usr/bin/nvidia-cuda-mps-control -> /usr/bin (inferred)
  /usr/bin/nvidia-cuda-mps-server -> /usr/bin (inferred)
  /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.396.44 -> /usr/local/cuda-9.0/targets/x86_64-linux/lib (inferred)
  /usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.396.44 -> /usr/local/cuda-9.0/targets/x86_64-linux/lib (inferred)
  /usr/lib/x86_64-linux-gnu/libcuda.so.396.44 -> /usr/local/cuda-9.0/targets/x86_64-linux/lib (inferred)
  /usr/lib/x86_64-linux-gnu/libnvidia-opencl.so.396.44 -> /usr/local/cuda-9.0/targets/x86_64-linux/lib (inferred)
  /usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.396.44 -> /usr/local/cuda-9.0/targets/x86_64-linux/lib (inferred)
  /usr/lib/x86_64-linux-gnu/libnvidia-fatbinaryloader.so.396.44 -> /usr/local/cuda-9.0/targets/x86_64-linux/lib (inferred)
  /usr/lib/x86_64-linux-gnu/libnvidia-compiler.so.396.44 -> /usr/local/cuda-9.0/targets/x86_64-linux/lib (inferred)
running ldconfig
```