### PR TITLE
Openmpi 3.1.3 build with UCX don't use HFI patch

### DIFF
--- a/examples/mpi/mpibench/test.bats
+++ b/examples/mpi/mpibench/test.bats
@@ -38,6 +38,7 @@ check_process_ct () {
 
 # one from "Single Transfer Benchmarks"
 @test "${ch_tag}/pingpong (guest launch)" {
+    unslurmify_environment_maybe
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
     run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args PingPong
@@ -61,6 +62,7 @@ check_process_ct () {
 
 # one from "Parallel Transfer Benchmarks"
 @test "${ch_tag}/sendrecv (guest launch)" {
+    unslurmify_environment_maybe
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
     run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args Sendrecv
@@ -84,6 +86,7 @@ check_process_ct () {
 
 # one from "Collective Benchmarks"
 @test "${ch_tag}/allreduce (guest launch)" {
+    unslurmify_environment_maybe
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
     run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args Allreduce

--- a/examples/mpi/mpibench/test.bats
+++ b/examples/mpi/mpibench/test.bats
@@ -40,7 +40,7 @@ check_process_ct () {
 @test "${ch_tag}/pingpong (guest launch)" {
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
-    run ch-run "$ch_img" -- mpirun --host localhost $ch_mpirun_np "$imb_mpi1" $imb_args PingPong
+    run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args PingPong
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"
@@ -63,7 +63,7 @@ check_process_ct () {
 @test "${ch_tag}/sendrecv (guest launch)" {
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
-    run ch-run "$ch_img" -- mpirun --host localhost $ch_mpirun_np "$imb_mpi1" $imb_args Sendrecv
+    run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args Sendrecv
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"
@@ -86,7 +86,7 @@ check_process_ct () {
 @test "${ch_tag}/allreduce (guest launch)" {
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
-    run ch-run "$ch_img" -- mpirun --host localhost $ch_mpirun_np "$imb_mpi1" $imb_args Allreduce
+    run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args Allreduce
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"

--- a/examples/mpi/mpibench/test.bats
+++ b/examples/mpi/mpibench/test.bats
@@ -40,7 +40,7 @@ check_process_ct () {
 @test "${ch_tag}/pingpong (guest launch)" {
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
-    run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args PingPong
+    run ch-run "$ch_img" -- mpirun --host localhost $ch_mpirun_np "$imb_mpi1" $imb_args PingPong
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"
@@ -63,7 +63,7 @@ check_process_ct () {
 @test "${ch_tag}/sendrecv (guest launch)" {
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
-    run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args Sendrecv
+    run ch-run "$ch_img" -- mpirun --host localhost $ch_mpirun_np "$imb_mpi1" $imb_args Sendrecv
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"
@@ -86,7 +86,7 @@ check_process_ct () {
 @test "${ch_tag}/allreduce (guest launch)" {
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
-    run ch-run "$ch_img" -- mpirun $ch_mpirun_np "$imb_mpi1" $imb_args Allreduce
+    run ch-run "$ch_img" -- mpirun --host localhost $ch_mpirun_np "$imb_mpi1" $imb_args Allreduce
     echo "$output"
     [[ $status -eq 0 ]]
     check_errors "$output"

--- a/examples/mpi/mpihello/test.bats
+++ b/examples/mpi/mpihello/test.bats
@@ -16,7 +16,6 @@ count_ranks () {
 }
 
 @test "${ch_tag}/MPI version" {
-    [[ $ch_mpi = openmpi ]] && skip "pending ability to drop Slurm env variables issue #226"
     run ch-run "$ch_img" -- /hello/hello
     echo "$output"
     [[ $status -eq 0 ]]
@@ -33,7 +32,6 @@ count_ranks () {
 }
 
 @test "${ch_tag}/serial" {
-    [[ $ch_mpi = openmpi ]] && skip "pending ability to drop Slurm env variables issue #226"
     # This seems to start up the MPI infrastructure (daemons, etc.) within the
     # guest even though there's no mpirun.
     run ch-run "$ch_img" -- /hello/hello
@@ -47,7 +45,7 @@ count_ranks () {
 @test "${ch_tag}/guest starts ranks" {
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
-    run ch-run "$ch_img" -- mpirun --host localhost $ch_mpirun_np /hello/hello
+    run ch-run "$ch_img" -- mpirun $ch_mpirun_np /hello/hello
     echo "$output"
     [[ $status -eq 0 ]]
     rank_ct=$(count_ranks "$output")

--- a/examples/mpi/mpihello/test.bats
+++ b/examples/mpi/mpihello/test.bats
@@ -16,6 +16,7 @@ count_ranks () {
 }
 
 @test "${ch_tag}/MPI version" {
+    [[ $ch_mpi = openmpi ]] && skip "pending ability to drop Slurm env variables issue #226"
     run ch-run "$ch_img" -- /hello/hello
     echo "$output"
     [[ $status -eq 0 ]]
@@ -32,6 +33,7 @@ count_ranks () {
 }
 
 @test "${ch_tag}/serial" {
+    [[ $ch_mpi = openmpi ]] && skip "pending ability to drop Slurm env variables issue #226"
     # This seems to start up the MPI infrastructure (daemons, etc.) within the
     # guest even though there's no mpirun.
     run ch-run "$ch_img" -- /hello/hello

--- a/examples/mpi/mpihello/test.bats
+++ b/examples/mpi/mpihello/test.bats
@@ -45,7 +45,7 @@ count_ranks () {
 @test "${ch_tag}/guest starts ranks" {
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
-    run ch-run "$ch_img" -- mpirun $ch_mpirun_np /hello/hello
+    run ch-run "$ch_img" -- mpirun --host localhost $ch_mpirun_np /hello/hello
     echo "$output"
     [[ $status -eq 0 ]]
     rank_ct=$(count_ranks "$output")

--- a/examples/mpi/mpihello/test.bats
+++ b/examples/mpi/mpihello/test.bats
@@ -16,6 +16,7 @@ count_ranks () {
 }
 
 @test "${ch_tag}/MPI version" {
+    unslurmify_environment_maybe
     run ch-run "$ch_img" -- /hello/hello
     echo "$output"
     [[ $status -eq 0 ]]
@@ -32,6 +33,7 @@ count_ranks () {
 }
 
 @test "${ch_tag}/serial" {
+    unslurmify_environment_maybe
     # This seems to start up the MPI infrastructure (daemons, etc.) within the
     # guest even though there's no mpirun.
     run ch-run "$ch_img" -- /hello/hello
@@ -43,6 +45,7 @@ count_ranks () {
 }
 
 @test "${ch_tag}/guest starts ranks" {
+    unslurmify_environment_maybe
     [[ $ch_cray && $ch_mpi = mpich ]] && skip "issue #255"
     # shellcheck disable=SC2086
     run ch-run "$ch_img" -- mpirun $ch_mpirun_np /hello/hello

--- a/examples/mpi/paraview/test.bats
+++ b/examples/mpi/paraview/test.bats
@@ -29,7 +29,6 @@ setup () {
 # collection of XML files containing binary data and it seems too hairy to me.
 
 @test "${ch_tag}/cone serial" {
-    [[ $ch_mpi = openmpi ]] && skip "pending ability to drop Slurm env variables issue #226"
     ch-run -b "$indir" -b "$outdir" "$ch_img" -- \
            pvbatch /mnt/0/cone.py /mnt/1
     ls -l "$outdir"/cone*

--- a/examples/mpi/paraview/test.bats
+++ b/examples/mpi/paraview/test.bats
@@ -29,6 +29,7 @@ setup () {
 # collection of XML files containing binary data and it seems too hairy to me.
 
 @test "${ch_tag}/cone serial" {
+    unslurmify_environment_maybe
     ch-run -b "$indir" -b "$outdir" "$ch_img" -- \
            pvbatch /mnt/0/cone.py /mnt/1
     ls -l "$outdir"/cone*

--- a/examples/mpi/paraview/test.bats
+++ b/examples/mpi/paraview/test.bats
@@ -29,6 +29,7 @@ setup () {
 # collection of XML files containing binary data and it seems too hairy to me.
 
 @test "${ch_tag}/cone serial" {
+    [[ $ch_mpi = openmpi ]] && skip "pending ability to drop Slurm env variables issue #226"
     ch-run -b "$indir" -b "$outdir" "$ch_img" -- \
            pvbatch /mnt/0/cone.py /mnt/1
     ls -l "$outdir"/cone*

--- a/test/0001-don-t-try-to-open-HFI-devices-with-UCX.patch
+++ b/test/0001-don-t-try-to-open-HFI-devices-with-UCX.patch
@@ -1,0 +1,28 @@
+From c9670b5a63ac14ad239610bde30ee61b2deee58d Mon Sep 17 00:00:00 2001
+From: Howard Pritchard <hppritcha@gmail.com>
+Date: Thu, 20 Dec 2018 14:36:53 -0700
+Subject: [PATCH] don't try to open HFI devices with UCX
+
+Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
+
+diff --git a/src/uct/ib/base/ib_device.c b/src/uct/ib/base/ib_device.c
+index feab36be..f9f0a06d 100644
+--- a/src/uct/ib/base/ib_device.c
++++ b/src/uct/ib/base/ib_device.c
+@@ -249,6 +249,13 @@ ucs_status_t uct_ib_device_init(uct_ib_device_t *dev,
+         goto err_free_context;
+     }
+ 
++    if (strstr(ibv_get_device_name(ibv_device), "hfi") != NULL) {
++        ucs_debug("skipping Intel OPA100 device %s since not supported by UCX",
++                  ibv_get_device_name(ibv_device));
++        status = UCS_ERR_IO_ERROR;
++        goto err_free_context;
++    }
++
+     /* Check device type*/
+     switch (ibv_device->node_type) {
+     case IBV_NODE_SWITCH:
+-- 
+1.8.3.1
+

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -76,6 +76,7 @@ RUN apt-get install -y --no-install-suggests \
     make \
     wget \
     udev
+
 COPY 0001-don-t-try-to-open-HFI-devices-with-UCX.patch /usr/local/src/
 WORKDIR /usr/local/src
 

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -136,6 +136,7 @@ RUN    cd openmpi-${MPI_VERSION} \
                    --with-psm2 \
                    --with-ucx \
                    --disable-pty-support \
+		   --disable-builtin-atomics \
 		   --enable-mca-no-build=btl-openib,plm-slurm \
     && make -j$(getconf _NPROCESSORS_ONLN) install
 RUN ldconfig

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -87,7 +87,6 @@ WORKDIR /usr/local/src
 #
 # Note that libpsm2 is x86_64 only:
 # https://lists.debian.org/debian-hpc/2017/12/msg00015.html
-
 ENV DEB_URL http://snapshot.debian.org/archive/debian/20180928T210119Z/pool/main
 ENV PSM2_VERSION 10.3.58-2
 RUN wget -nv ${DEB_URL}/libp/libpsm2/libpsm2-2_${PSM2_VERSION}_amd64.deb

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -137,7 +137,6 @@ RUN    cd openmpi-${MPI_VERSION} \
                    --with-psm2 \
                    --with-ucx \
                    --disable-pty-support \
-                   --enable-debug \
 		   --enable-mca-no-build=btl-openib,plm-slurm \
     && make -j$(getconf _NPROCESSORS_ONLN) install
 RUN ldconfig

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -78,7 +78,6 @@ RUN apt-get install -y --no-install-suggests \
     wget \
     udev
 
-COPY 0001-don-t-try-to-open-HFI-devices-with-UCX.patch /usr/local/src/
 WORKDIR /usr/local/src
 
 # Use the Buster versions of libpsm2 (not present in Stretch) and libibverbs
@@ -109,17 +108,30 @@ RUN for i in ibacm \
 RUN dpkg --install *.deb
 
 # UCX. There is stuff to build Debian packages, but it seems not too polished.
+#
+# Bug workaround: We patch UCX to work around UCX issue #750 [1], which causes
+# OpenMPI to crash in the presence of OPA hardware when the UCX module tries
+# and fails to initialize itself.
+#
+# [1]: https://github.com/openucx/ucx/issues/750
 ENV UCX_VERSION 1.3.1
 RUN git clone --branch v${UCX_VERSION} --depth 1 \
               https://github.com/openucx/ucx.git
-RUN mv 0001-don-t-try-to-open-HFI-devices-with-UCX.patch ucx/ \
-&& cd ucx \
-&& git apply 0001-don-t-try-to-open-HFI-devices-with-UCX.patch \
-&& ./autogen.sh \
+COPY ucx-issue-750.patch ./ucx
+RUN cd ucx && git apply ucx-issue-750.patch
+RUN    cd ucx \
+    && ./autogen.sh \
     && ./contrib/configure-release --prefix=/usr/local \
     && make -j$(getconf _NPROCESSORS_ONLN) install
 
 # OpenMPI.
+#
+# Bug workaround: Add "--disable-builtin-atomics" to avoid OpenMPI issue
+# #6014 [1], which tickles a compiler bug that causes hangs in "vader" module.
+# Debian Stretch's GCC 6.3.0 is not listed in that issue but does hang for us.
+# Remove this argument when we upgrade to OpenMPI 3.1.4 (issue #346).
+#
+# [1]: https://github.com/open-mpi/ompi/issues/6014
 ENV MPI_URL https://www.open-mpi.org/software/ompi/v3.1/downloads
 ENV MPI_VERSION 3.1.3
 RUN wget -nv ${MPI_URL}/openmpi-${MPI_VERSION}.tar.gz
@@ -135,9 +147,9 @@ RUN    cd openmpi-${MPI_VERSION} \
                    --with-pmix \
                    --with-psm2 \
                    --with-ucx \
+                   --disable-builtin-atomics \
                    --disable-pty-support \
-		   --disable-builtin-atomics \
-		   --enable-mca-no-build=btl-openib,plm-slurm \
+                   --enable-mca-no-build=btl-openib,plm-slurm \
     && make -j$(getconf _NPROCESSORS_ONLN) install
 RUN ldconfig
 RUN rm -Rf openmpi-${MPI_VERSION}*

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -1,4 +1,4 @@
-# ch-test-scope: full
+# ch-test-scope: quick
 FROM debian9
 
 # A key goal of this Dockerfile is to demonstrate best practices for building
@@ -76,7 +76,7 @@ RUN apt-get install -y --no-install-suggests \
     make \
     wget \
     udev
-
+COPY 0001-don-t-try-to-open-HFI-devices-with-UCX.patch /usr/local/src/
 WORKDIR /usr/local/src
 
 # Use the Buster versions of libpsm2 (not present in Stretch) and libibverbs
@@ -110,14 +110,16 @@ RUN dpkg --install *.deb
 ENV UCX_VERSION 1.3.1
 RUN git clone --branch v${UCX_VERSION} --depth 1 \
               https://github.com/openucx/ucx.git
-RUN    cd ucx \
-    && ./autogen.sh \
+COPY 0001-don-t-try-to-open-HFI-devices-with-UCX.patch ucx/ 
+RUN cd ucx \
+&& git apply 0001-don-t-try-to-open-HFI-devices-with-UCX.patch \
+&& ./autogen.sh \
     && ./contrib/configure-release --prefix=/usr/local \
     && make -j$(getconf _NPROCESSORS_ONLN) install
 
 # OpenMPI.
-ENV MPI_URL https://www.open-mpi.org/software/ompi/v2.1/downloads
-ENV MPI_VERSION 2.1.5
+ENV MPI_URL https://www.open-mpi.org/software/ompi/v3.1/downloads
+ENV MPI_VERSION 3.1.3
 RUN wget -nv ${MPI_URL}/openmpi-${MPI_VERSION}.tar.gz
 RUN tar xf openmpi-${MPI_VERSION}.tar.gz
 RUN    cd openmpi-${MPI_VERSION} \
@@ -125,14 +127,15 @@ RUN    cd openmpi-${MPI_VERSION} \
        CXXFLAGS=-O3 \
        ./configure --prefix=/usr/local \
                    --sysconfdir=/mnt/0 \
+		   --with-slurm \
                    --with-pmi \
                    --with-pmi-libdir=/usr/lib/x86_64-linux-gnu \
                    --with-pmix \
                    --with-psm2 \
                    --with-ucx \
                    --disable-pty-support \
-                   --enable-mca-no-build=btl-openib \
-                   --with-slurm=no \
+                   --enable-debug \
+		   --enable-mca-no-build=btl-openib,plm-slurm \
     && make -j$(getconf _NPROCESSORS_ONLN) install
 RUN ldconfig
 RUN rm -Rf openmpi-${MPI_VERSION}*

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -1,4 +1,4 @@
-# ch-test-scope: quick
+# ch-test-scope: full
 FROM debian9
 
 # A key goal of this Dockerfile is to demonstrate best practices for building

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -49,10 +49,11 @@ FROM debian9
 #   2. --disable-pty-support to avoid "pipe function call failed when
 #      setting up I/O forwarding subsystem".
 #
-#   3. --with-slurm=no so mpirun in the container doesn't try use Slurm to
-#      launch processes, which will fail in inscrutable ways e.g. if srun is
-#      not found. (If you do want Slurm launching processes, use srun or
-#      mpirun outside the container.)
+#   3. --enable-mca-no-build=plm-slurm to support launching processes using
+#      the host's srun (i.e., the container OpenMPI needs to talk to the host
+#      Slurm's PMI) but prevent OpenMPI from invoking srun itself from within
+#      the container, where srun is not installed (the error messages from
+#      this are inscrutable).
 #
 # [1]: https://github.com/open-mpi/ompi/blob/master/README
 

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -110,8 +110,8 @@ RUN dpkg --install *.deb
 ENV UCX_VERSION 1.3.1
 RUN git clone --branch v${UCX_VERSION} --depth 1 \
               https://github.com/openucx/ucx.git
-COPY 0001-don-t-try-to-open-HFI-devices-with-UCX.patch ucx/ 
-RUN cd ucx \
+RUN mv 0001-don-t-try-to-open-HFI-devices-with-UCX.patch ucx/ \
+&& cd ucx \
 && git apply 0001-don-t-try-to-open-HFI-devices-with-UCX.patch \
 && ./autogen.sh \
     && ./contrib/configure-release --prefix=/usr/local \

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -87,6 +87,7 @@ WORKDIR /usr/local/src
 #
 # Note that libpsm2 is x86_64 only:
 # https://lists.debian.org/debian-hpc/2017/12/msg00015.html
+
 ENV DEB_URL http://snapshot.debian.org/archive/debian/20180928T210119Z/pool/main
 ENV PSM2_VERSION 10.3.58-2
 RUN wget -nv ${DEB_URL}/libp/libpsm2/libpsm2-2_${PSM2_VERSION}_amd64.deb

--- a/test/common.bash
+++ b/test/common.bash
@@ -104,6 +104,16 @@ tarball_ok () {
     test -s "$1"
 }
 
+unslurmify_environment_maybe () {
+    # OpenMPI 3.1 pukes when guest-launched and Slurm environment variables
+    # are present. Work around this by fooling OpenMPI into believing it's not
+    # in a Slurm allocation. Better to remove this function and use
+    # --unset-env when available (#345)?
+    if [[ -n $SLURM_JOBID && $ch_mpi = openmpi ]]; then
+        unset SLURM_JOBID SLURM_NODELIST
+    fi
+}
+
 # Predictable sorting and collation
 export LC_ALL=C
 

--- a/test/ucx-issue-750.patch
+++ b/test/ucx-issue-750.patch
@@ -1,9 +1,4 @@
-From c9670b5a63ac14ad239610bde30ee61b2deee58d Mon Sep 17 00:00:00 2001
-From: Howard Pritchard <hppritcha@gmail.com>
-Date: Thu, 20 Dec 2018 14:36:53 -0700
-Subject: [PATCH] don't try to open HFI devices with UCX
-
-Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
+This patch is used in Dockerfile.openmpi. See there for documentation.
 
 diff --git a/src/uct/ib/base/ib_device.c b/src/uct/ib/base/ib_device.c
 index feab36be..f9f0a06d 100644
@@ -23,6 +18,4 @@ index feab36be..f9f0a06d 100644
      /* Check device type*/
      switch (ibv_device->node_type) {
      case IBV_NODE_SWITCH:
--- 
-1.8.3.1
 


### PR DESCRIPTION
This PR should resolve issues with host launches and guest launches within the test suite while skipping serial launches of mpi applications pending issue 295. Guest launches require the command line option "--host localhost" to prevent Openmpi attempting to startup on remote hosts within a multinode allocation. 
Dockerfile.openmpi likely needs some clean up. The current way I'm lugging around the patch file and applying it may need to be changed as well.