### PR TITLE
ch-fromhost: proper error if no path from ldconfig

### DIFF
--- a/bin/ch-fromhost
+++ b/bin/ch-fromhost
@@ -233,8 +233,15 @@ if [ $lib_found ]; then
     # searches, so that we can override (or overwrite) any of the same library
     # that may already be in the image.
     debug "asking ldconfig for shared library destination"
-    lib_dest=$(  "${ch_bin}/ch-run" "$image" -- /sbin/ldconfig -Nv 2> /dev/null \
-               | grep -E '^/' | cut -d: -f1 | head -1)
+    # "ldconfig -Nv" gives some pointless warnings on stderr even if
+    # successful; we don't want to show those to users. However, we don't want
+    # to simply pipe stderr to /dev/null because this hides real errors. Thus,
+    # use the following abomination to pipe stdout and stderr to *separate
+    # grep commands*. See: https://stackoverflow.com/a/31151808
+    lib_dest=$( { "${ch_bin}/ch-run" "$image" -- /sbin/ldconfig -Nv \
+                  2>&1 1>&3 3>&- | grep -Ev '(^|dynamic linker, ignoring|given more than once)$' ; } \
+                3>&1 1>&2 | grep -E '^/' | cut -d: -f1 | head -1 )
+    [ -n "$lib_dest" ] || fatal 'empty path from ldconfig'
     [ -z "${lib_dest%%/*}" ] || fatal "bad path from ldconfig: ${lib_dest}"
     debug "shared library destination: ${lib_dest}"
 fi

--- a/test/run/ch-fromhost.bats
+++ b/test/run/ch-fromhost.bats
@@ -261,6 +261,19 @@ fromhost_ls () {
     [[ $status -eq 1 ]]
     [[ $output = *'duplicate image'* ]]
     fromhost_clean_p "$img"
+
+    # ldconfig gives no shared library path (#324)
+    #
+    # (I don't think this is the best way to get ldconfig to fail, but I
+    # couldn't come up with anything better. E.g., bad ld.so.conf or broken
+    # .so's seem to produce only warnings.)
+    mv "${img}/sbin/ldconfig" "${img}/sbin/ldconfig.foo"
+    run ch-fromhost --lib-path "$img"
+    mv "${img}/sbin/ldconfig.foo" "${img}/sbin/ldconfig"
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'empty path from ldconfig'* ]]
+    fromhost_clean_p "$img"
 }
 
 @test 'ch-fromhost --cray-mpi not on a Cray' {


### PR DESCRIPTION
Addresses #324.

This involves some pretty bonkers shell code, so @mej I'd love your opinion on whether we've gone too far.

@samcmill, any opinions on this solution for your bug? Thanks again for reporting it.