### PR TITLE
test suite: better error if test/bin symlink does not contain ch-run

### DIFF
--- a/test/common.bash
+++ b/test/common.bash
@@ -132,7 +132,7 @@ ch_runfile=$(command -v ch-run)
 # shellcheck disable=SC2034
 ch_libexec=$(ch-build --libexec-path)
 if [[ ! -x ${ch_bin}/ch-run ]]; then
-    printf 'ch-run not found in ${ch_bin} (build with "make"?).\n\n' >&2
+    printf "ch-run not found in %s (has charliecloud been built with \"make\"?).\n\n" "${ch_bin}" >&2
     exit 1
 fi
 

--- a/test/common.bash
+++ b/test/common.bash
@@ -132,7 +132,7 @@ ch_runfile=$(command -v ch-run)
 # shellcheck disable=SC2034
 ch_libexec=$(ch-build --libexec-path)
 if [[ ! -x ${ch_bin}/ch-run ]]; then
-    printf 'Must build with "make" before running tests.\n\n' >&2
+    printf 'ch-run not found in ${ch_bin} (build with "make"?).\n\n' >&2
     exit 1
 fi
 


### PR DESCRIPTION
The current error message implies that it will only be seen if a user attempts to execute the test suite before building charliecloud. However, this error can also be seen when charliecloud is built but the symlink `charliecloud/test/bin` is broken or points to the wrong directory. In that case, the error message is not helpful.