### PR TITLE
add docker environment variables to image tarball at ch-docker2dir time 

### DIFF
--- a/bin/ch-docker2tar
+++ b/bin/ch-docker2tar
@@ -30,9 +30,9 @@ cid=$(docker_ create --read-only "$image")
 echo "flatting '$image' to $tar"
 docker_ export "$cid" > "${tar}"
 docker_ rm "$cid" > /dev/null
-docker_ inspect "$image" --format='{{range .Config.Env}}{{println .}}{{end}}' > docker-env
-tar -b1 -rf "$tar" docker-env
-rm docker-env
+docker_ inspect "$image" --format='{{range .Config.Env}}{{println .}}{{end}}' > environment
+tar -b1 -rf "$tar" environment
+rm environment
 echo "compressing $tar"
 gzip_ -6 -f "$tar"
 ls -lh "${tar}.gz"

--- a/bin/ch-docker2tar
+++ b/bin/ch-docker2tar
@@ -27,12 +27,12 @@ tar="$outdir"/$(echo "$image" | sed 's/\//./g').tar
 
 cid=$(docker_ create --read-only "$image")
 #docker_ ps -af "id=$cid"
+echo "flatting '$image' to $tar"
 docker_ export "$cid" > "${tar}"
 docker_ rm "$cid" > /dev/null
 docker_ inspect "$image" --format='{{range .Config.Env}}{{println .}}{{end}}' > docker-env
-tar cf docker-env.tar docker-env
+tar -b1 -rf "$tar" docker-env
 rm docker-env
-tar --concatenate --file=docker-env.tar "$tar"
-mv docker-env.tar "$tar"
+echo "compressing $tar"
 gzip_ -6 -f "$tar"
 ls -lh "${tar}.gz"

--- a/bin/ch-docker2tar
+++ b/bin/ch-docker2tar
@@ -23,16 +23,42 @@ fi
 
 image=$1
 outdir=$2
-tar="$outdir"/$(echo "$image" | sed 's/\//./g').tar
+tar=${outdir}/$(echo "$image" | sed 's/\//./g').tar
 
+# Export the image to tarball.
+echo "exporting"
 cid=$(docker_ create --read-only "$image")
+size=$(docker_ image inspect "$image" --format='{{.Size}}')
 #docker_ ps -af "id=$cid"
-echo "flatting '$image' to $tar"
-docker_ export "$cid" > "${tar}"
+docker_ export "$cid" | pv_ -s "$size" > "$tar"
 docker_ rm "$cid" > /dev/null
-docker_ inspect "$image" --format='{{range .Config.Env}}{{println .}}{{end}}' > environment
-tar -b1 -rf "$tar" environment
-rm environment
-echo "compressing $tar"
-gzip_ -6 -f "$tar"
+
+# Add the Docker environment variables in ./environment for later consumption
+# by "ch-run --set-env".
+#
+# 1. mktemp(1) isn't POSIX, but it seemed very likely to be installed if
+#    Docker is, and I couldn't find a more portable way of securely creating
+#    temporary files. (In particular, I would have preferred to pipe in the
+#    data rather than creating and deleting a temporary file.)
+#
+# 2. Blocking factor 1 (-b1) for tar is a bug workaround. Without this switch,
+#    tar 1.26, which is in RHEL, corrupts the tarball instead of appending to
+#    it. This doesn't happen in 1.29 in Debian Stretch, and building GNU tar
+#    from Git source was too hard, so I couldn't bisect a specific commit that
+#    fixed the bug to learn what exactly was going on. (See PR #371.)
+#
+# 3. This assumes that the tarball from Docker does not have a single
+#    top-level directory (i.e., is a tarbomb).
+#
+echo "adding environment"
+temp=$(mktemp ch-docker2tar.XXXXXX)
+docker_ inspect "$image" --format='{{range .Config.Env}}{{println .}}{{end}}' \
+        > "$temp"
+tar rf "$tar" -b1 --xform="s/${temp}/environment/" "$temp"
+rm "$temp"
+
+# Finish up.
+echo "compressing"
+pv_ "$tar" | gzip_ -6 > "${tar}.gz"
+rm "$tar"
 ls -lh "${tar}.gz"

--- a/bin/ch-docker2tar
+++ b/bin/ch-docker2tar
@@ -23,11 +23,19 @@ fi
 
 image=$1
 outdir=$2
-tar="$outdir"/$(echo "$image" | sed 's/\//./g').tar.gz
+tar="$outdir"/$(echo "$image" | sed 's/\//./g').tar
 
 cid=$(docker_ create --read-only "$image")
-size=$(docker_ image inspect "$image" --format='{{.Size}}')
 #docker_ ps -af "id=$cid"
-docker_ export "$cid" | pv_ -s "$size" | gzip_ -6 > "$tar"
+docker_ export "$cid" > "${tar}"
 docker_ rm "$cid" > /dev/null
-ls -lh "$tar"
+
+# Experimenting with tar archive file appension and archive concatenation has
+# revealed some rather quirkly behavior with tar. See (#TODO: add PR #)
+docker_ inspect "$image" --format='{{range .Config.Env}}{{println .}}{{end}}' > docker-env
+tar cf docker-env.tar docker-env
+rm docker-env
+tar --concatenate --file=docker-env.tar "$tar"
+mv docker-env.tar "$tar"
+gzip_ -6 -f "$tar"
+ls -lh "${tar}.gz"

--- a/bin/ch-docker2tar
+++ b/bin/ch-docker2tar
@@ -51,10 +51,10 @@ docker_ rm "$cid" > /dev/null
 #    top-level directory (i.e., is a tarbomb).
 #
 echo "adding environment"
-temp=$(mktemp ch-docker2tar.XXXXXX)
+temp=$(mktemp --tmpdir ch-docker2tar.XXXXXX)
 docker_ inspect "$image" --format='{{range .Config.Env}}{{println .}}{{end}}' \
         > "$temp"
-tar rf "$tar" -b1 --xform="s/${temp}/environment/" "$temp"
+tar rf "$tar" -b1 -P --xform="s|${temp}|environment|" "$temp"
 rm "$temp"
 
 # Finish up.

--- a/bin/ch-docker2tar
+++ b/bin/ch-docker2tar
@@ -59,6 +59,6 @@ rm "$temp"
 
 # Finish up.
 echo "compressing"
-pv_ "$tar" | gzip_ -6 > "${tar}.gz"
+cat "$tar" | pv_ -s "$size" | gzip_ -6 > "${tar}.gz"
 rm "$tar"
 ls -lh "${tar}.gz"

--- a/bin/ch-docker2tar
+++ b/bin/ch-docker2tar
@@ -29,9 +29,6 @@ cid=$(docker_ create --read-only "$image")
 #docker_ ps -af "id=$cid"
 docker_ export "$cid" > "${tar}"
 docker_ rm "$cid" > /dev/null
-
-# Experimenting with tar archive file appension and archive concatenation has
-# revealed some rather quirkly behavior with tar. See (#TODO: add PR #)
 docker_ inspect "$image" --format='{{range .Config.Env}}{{println .}}{{end}}' > docker-env
 tar cf docker-env.tar docker-env
 rm docker-env

--- a/doc-src/ch-docker2tar_desc.rst
+++ b/doc-src/ch-docker2tar_desc.rst
@@ -11,6 +11,10 @@ Description
 Flattens the Docker image tagged :code:`IMAGE` into a Charliecloud tarball in
 directory :code:`OUTDIR`.
 
+The Docker environment (e.g., :code:`ENV` statements) is placed in a file in
+the tarball at :code:`./environment`, in a form suitable for :code:`ch-run
+--set-env`.
+
 Sudo privileges are required to run :code:`docker export`.
 
 Additional arguments:

--- a/doc-src/ch-run_desc.rst
+++ b/doc-src/ch-run_desc.rst
@@ -42,9 +42,8 @@ unpacked image directory located at :code:`NEWROOT`.
     use container-private :code:`/tmp` (by default, :code:`/tmp` is shared with
     the host)
 
-  :code:`--set-env[=FILE]`
-    set environment variables as specified in host path :code:`FILE` 
-    (default: code:`IMAGE_ROOT/docker-env`)
+  :code:`--set-env=FILE`
+    set environment variables as specified in host path :code:`FILE`
 
   :code:`-u`, :code:`--uid=UID`
     run as user :code:`UID` within container
@@ -209,7 +208,7 @@ By default, :code:`ch-run` makes the following environment variable changes:
 Setting variables with :code:`--set-env`
 ----------------------------------------
 
-The purpose of :code:`--set-env[=FILE]` is to set environment variables that
+The purpose of :code:`--set-env=FILE` is to set environment variables that
 cannot be inherited from the host shell, e.g. Dockerfile :code:`ENV`
 directives or other build-time configuration. :code:`FILE` is a host path to
 provide the greatest flexibility; guest paths can be specified by prepending
@@ -303,9 +302,6 @@ Example valid lines that are probably not what you want:
 Example Docker command to produce a valid :code:`FILE`::
 
   $ docker inspect $TAG --format='{{range .Config.Env}}{{println .}}{{end}}'
-
-If a code:`FILE` is not provided, code:`--set-env` will default to the 
-code:`docker-env` file located in the top-level directory of the image path.
 
 Removing variables with :code:`--unset-env`
 -------------------------------------------

--- a/doc-src/ch-run_desc.rst
+++ b/doc-src/ch-run_desc.rst
@@ -42,8 +42,9 @@ unpacked image directory located at :code:`NEWROOT`.
     use container-private :code:`/tmp` (by default, :code:`/tmp` is shared with
     the host)
 
-  :code:`--set-env=FILE`
-    set environment variables as specified in host path :code:`FILE`
+  :code:`--set-env[=FILE]`
+    set environment variables as specified in host path :code:`FILE` 
+    (default: code:`IMAGE_ROOT/docker-env`)
 
   :code:`-u`, :code:`--uid=UID`
     run as user :code:`UID` within container
@@ -208,7 +209,7 @@ By default, :code:`ch-run` makes the following environment variable changes:
 Setting variables with :code:`--set-env`
 ----------------------------------------
 
-The purpose of :code:`--set-env=FILE` is to set environment variables that
+The purpose of :code:`--set-env[=FILE]` is to set environment variables that
 cannot be inherited from the host shell, e.g. Dockerfile :code:`ENV`
 directives or other build-time configuration. :code:`FILE` is a host path to
 provide the greatest flexibility; guest paths can be specified by prepending
@@ -302,6 +303,9 @@ Example valid lines that are probably not what you want:
 Example Docker command to produce a valid :code:`FILE`::
 
   $ docker inspect $TAG --format='{{range .Config.Env}}{{println .}}{{end}}'
+
+If a code:`FILE` is not provided, code:`--set-env` will default to the 
+code:`docker-env` file located in the top-level directory of the image path.
 
 Removing variables with :code:`--unset-env`
 -------------------------------------------

--- a/doc-src/ch-run_desc.rst
+++ b/doc-src/ch-run_desc.rst
@@ -214,6 +214,10 @@ directives or other build-time configuration. :code:`FILE` is a host path to
 provide the greatest flexibility; guest paths can be specified by prepending
 the image path.
 
+:code:`ch-docker2tar(1)` lists variables specified at build time in
+Dockerfiles in the image in file :code:`/environment`. To set these variables:
+:code:`--set-env=$IMG/environment`.
+
 Variable values in :code:`FILE` replace any already set. If a variable is
 repeated, the last value wins.
 
@@ -298,10 +302,6 @@ Example valid lines that are probably not what you want:
      - :code:`FOO`
      - :code:`​ bar`
      - leading space in value
-
-Example Docker command to produce a valid :code:`FILE`::
-
-  $ docker inspect $TAG --format='{{range .Config.Env}}{{println .}}{{end}}'
 
 Removing variables with :code:`--unset-env`
 -------------------------------------------

--- a/doc-src/install.rst
+++ b/doc-src/install.rst
@@ -65,6 +65,7 @@ and optionally:
 * `Docker <https://www.docker.com/>`_ 17.03+
 * internet access or Docker configured for a local Docker hub
 * root access using :code:`sudo`
+* :code:`mktemp(1)`
 
 Older versions of Docker may work but are untested. We know that 1.7.1 does
 not work.

--- a/test/Dockerfile.debian9
+++ b/test/Dockerfile.debian9
@@ -1,6 +1,7 @@
 # ch-test-scope: standard
 FROM debian:stretch
 
+ENV chse_dockerfile foo
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN    apt-get update \

--- a/test/build.bats
+++ b/test/build.bats
@@ -58,12 +58,12 @@ load common
     for i in "$ch_bin"/ch-*; do
         echo "shellcheck: ${i}"
         [[ ! $(file "$i") = *'shell script'* ]] && continue
-        shellcheck -e SC1090,SC2154 "$i"
+        shellcheck -e SC1090,SC2002,SC2154 "$i"
     done
     # libraries for user executables
     for i in "$ch_libexec"/*.sh; do
         echo "shellcheck: ${i}"
-        shellcheck -s sh -e SC1090 "$i"
+        shellcheck -s sh -e SC1090,SC2002 "$i"
     done
     # BATS scripts
     #
@@ -76,14 +76,14 @@ load common
         | shellcheck -s bash -e SC1090,SC2002,SC2154,SC2164 -
     done < <( find . ../examples -name bats -prune -o -name '*.bats' -print0 )
     # libraries for BATS scripts
-    shellcheck -s bash -e SC2034 ./common.bash
+    shellcheck -s bash -e SC2002,SC2034 ./common.bash
     # misc shell scripts
     if [[ -e ../packaging ]]; then
         misc=". ../examples ../packaging"
     else
         misc=". ../examples"
     fi
-    shellcheck -e SC2034 chtest/Build
+    shellcheck -e SC2002,SC2034 chtest/Build
     # shellcheck disable=SC2086
     while IFS= read -r -d '' i; do
         echo "shellcheck: ${i}"

--- a/test/make-auto
+++ b/test/make-auto
@@ -99,7 +99,7 @@ for path in sys.argv[2:]:
     need_docker
     tarball="$ch_tardir/%(tag)s.tar.gz"
     ch-docker2tar %(tag)s "$ch_tardir"
-    tar -tf "$tarball" | grep -F docker-env
+    tar -tf "$tarball" | grep -F environment
     tarball_ok "$tarball"
 }"""
       else:

--- a/test/make-auto
+++ b/test/make-auto
@@ -99,6 +99,7 @@ for path in sys.argv[2:]:
     need_docker
     tarball="$ch_tardir/%(tag)s.tar.gz"
     ch-docker2tar %(tag)s "$ch_tardir"
+    tar -tf "$tarball" | grep -F docker-env
     tarball_ok "$tarball"
 }"""
       else:

--- a/test/make-auto
+++ b/test/make-auto
@@ -99,7 +99,7 @@ for path in sys.argv[2:]:
     need_docker
     tarball="$ch_tardir/%(tag)s.tar.gz"
     ch-docker2tar %(tag)s "$ch_tardir"
-    tar -tf "$tarball" | grep -F environment
+    tar -tf "$tarball" | grep -E '^environment$'
     tarball_ok "$tarball"
 }"""
       else:

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -354,6 +354,23 @@ EOF
     diff -u <(echo "$output_expected") <(echo "$output")
 }
 
+@test 'ch-run --set-env from Dockerfile' {
+    scope standard
+    prerequisites_ok debian9
+    img=${ch_imgdir}/debian9
+
+    output_expected=$(cat <<'EOF'
+chse_dockerfile=foo
+EOF
+)
+
+    run ch-run --set-env="${img}/environment" "$img" -- \
+               sh -c 'env | grep -E "^chse_"'
+    echo "$output"
+    [[ $status -eq 0 ]]
+    diff -u <(echo "$output_expected") <(echo "$output")
+}
+
 @test 'ch-run --set-env errors' {
     scope standard
     f_in=${BATS_TMPDIR}/env.txt


### PR DESCRIPTION
Re. #224. 

Experimenting with appending a file to a tar and archive concatenation has revealed some rather quirky tar behavior.  See below for details.

**Concatenating `docker-env.tar` (src) to `${image}.tar` (dst):**
<details>

```
$ ls -lh
total 279M
-rw-rw-r--. 1 jogas jogas 140M Feb 28 15:13 nvidia.tar
-rw-rw-r--. 1 jogas jogas 140M Feb 28 15:13 nvidia.tar.bak
```
Create `docker-env.tar` file:
```
$ sudo docker inspect nvidia --format='{{range .Config.Env}}{{println .}}{{end}}' > docker-env
$ ls -lh
total 279M
-rw-rw-r--. 1 jogas jogas   67 Feb 28 15:18 docker-env
-rw-rw-r--. 1 jogas jogas 140M Feb 28 15:13 nvidia.tar
$ tar cf docker-env.tar docker-env
$ ls -lh docker-env.tar
-rw-rw-r--. 1 jogas jogas 10K Feb 28 15:19 docker-env.tar
$ file docker-env.tar
docker-env.tar: POSIX tar archive (GNU)
```
Before concatenation:
```
$ file nvidia.tar
nvidia.tar: POSIX tar archive
$ tar tf nvidia.tar | tail
var/log/fsck/checkfs
var/log/fsck/checkroot
var/log/lastlog
var/log/wtmp
var/mail/
var/opt/
var/run
var/spool/
var/spool/mail
var/tmp/
$ tar tf docker-env.tar | tail
docker-env
```
Post concatenation:
```
$ tar -A --file=nvidia.tar docker-env.tar
$ file nvidia.tar
nvidia.tar: POSIX tar archive
$ tar tf nvidia.tar | tail
var/log/apt/history.log
var/log/bootstrap.log
var/log/btmp
var/log/dmesg
var/log/dpkg.log
var/log/faillog
var/log/fsck/
var/log/fsck/checkfs
var/log/fsck/checkroot
var/log/lastlog
$ tar tf nvidia.tar | grep docker-env
$
```
Not only is the `${image}.tar` corrupt (e.g. missing files), the `docker-env` file does not exist.

</details>
    
**Appending docker-env to ${image}/nvidia.tar**
<details foo>

```
$ ls -lh
total 279M
-rw-rw-r--. 1 jogas jogas 140M Feb 28 15:24 nvidia.tar
-rw-rw-r--. 1 jogas jogas 140M Feb 28 15:13 nvidia.tar.bak
$ sudo docker inspect nvidia --format='{{range .Config.Env}}{{println .}}{{end}}' > docker-env
$ ls -lh 
total 279M
-rw-rw-r--. 1 jogas jogas   67 Feb 28 15:27 docker-env
-rw-rw-r--. 1 jogas jogas 140M Feb 28 15:24 nvidia.tar
-rw-rw-r--. 1 jogas jogas 140M Feb 28 15:13 nvidia.tar.bak
```

Before appending:
```
$ tar tf nvidia.tar | tail
var/log/fsck/checkfs
var/log/fsck/checkroot
var/log/lastlog
var/log/wtmp
var/mail/
var/opt/
var/run
var/spool/
var/spool/mail
var/tmp/
```
After appending:
```
$ tar rf nvidia.tar docker-env
$ file nvidia.tar
nvidia.tar: POSIX tar archive
$ tar tf nvidia.tar | grep docker-env
$ tar tf nvidia.tar | tail
var/log/apt/history.log
var/log/bootstrap.log
var/log/btmp
var/log/dmesg
var/log/dpkg.log
var/log/faillog
var/log/fsck/
var/log/fsck/checkfs
var/log/fsck/checkroot
var/log/lastlog
```
The resulting `${image}/tar` is corrupt (missing original files) and missing the the `docker-env` file.

</details>
