### PR TITLE
Reboot after setting up passwordless logins

### DIFF
--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -235,6 +235,8 @@ EOF2
     passwd -l root
     passwd -l vagrant
 
+    # Reboot the machine so the paswordless login takes affect
+    sudo reboot
   EOF
 
   # Test Charliecloud (optional).


### PR DESCRIPTION
Resolves #369 by removing the need for the user to restart the system. 