### PR TITLE
Vagrant: remove grubby because we're on CentOS 7.6 now

### DIFF
--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -129,7 +129,6 @@ Vagrant.configure("2") do |c|
                  inline: <<-EOF
     set -e
     echo 'user.max_user_namespaces = 32767' > /etc/sysctl.d/51-userns.conf
-    grubby --args='namespace.unpriv_enable=1' --update-kernel=ALL
   EOF
   c.vm.provision :reload
 


### PR DESCRIPTION
Addresses #394.

The VM passes full test suite with this change.