### PR TITLE
tests: add CH_TEST_DONT_SUDO, move no-Docker tests

### DIFF
--- a/doc-src/test.rst
+++ b/doc-src/test.rst
@@ -20,6 +20,10 @@ at the top level of the source code or installed at
 
   $ cd test
 
+If you have :code:`sudo`, the tests will make use of it by default. To skip
+the tests that use :code:`sudo` even if you have privileges, set
+:code:`CH_TEST_DONT_SUDO` to a non-empty string.
+
 The tests use a framework called `Bats <https://github.com/sstephenson/bats>`_
 (Bash Automated Testing System). To check location and version of Bats used by
 the tests::

--- a/test/common.bash
+++ b/test/common.bash
@@ -259,8 +259,9 @@ elif [[    $CH_TEST_SCOPE != quick \
     exit 1
 fi
 
-# Do we have sudo?
-if ( command -v sudo >/dev/null 2>&1 && sudo -v >/dev/null 2>&1 ); then
+# Do we have and want sudo?
+if    [[ -z $CH_TEST_DONT_SUDO ]] \
+   && ( command -v sudo >/dev/null 2>&1 && sudo -v >/dev/null 2>&1 ); then
     # This isn't super reliable; it returns true if we have *any* sudo
     # privileges, not specifically to run the commands we want to run.
     # shellcheck disable=SC2034

--- a/test/travis.sh
+++ b/test/travis.sh
@@ -54,15 +54,20 @@ fi
 cd test
 
 make where-bats
-make test
+make test-build
 
-# To test without Docker, move the binary out of the way.
-DOCKER=$(command -v docker)
-sudo mv "$DOCKER" "$DOCKER.tmp"
+if [[ $SUDO_RM_AFTER_BUILD ]]; then
+    sudo rm /etc/sudoers.d/travis
+fi
+if [[ $SUDO_AVOID_AFTER_BUILD ]]; then
+    export CH_TEST_DONT_SUDO=yes
+fi
+if ( sudo -v ); then
+    echo "have sudo"
+else
+    echo "don't have sudo"
+fi
+echo "\$CH_TEST_DONT_SUDO=$CH_TEST_DONT_SUDO"
 
-make test
-
-# For Travis, this isn't really necessary, since the VM will go away
-# immediately after this script exits. However, restore the binary to enable
-# testing this script in other environments.
-sudo mv "$DOCKER.tmp" "$DOCKER"
+make test-run
+make test-test

--- a/test/travis.yml
+++ b/test/travis.yml
@@ -19,8 +19,10 @@ compiler: gcc
 #
 # Additional options:
 #
-#   PKG_BUILD=yes     # build (but don't test) distribution packages, then exit
-#   MINIMAL_DEPS=yes  # test with a minimal dependency set (no fancy tools)
+#   MINIMAL_DEPS            # test with minimal dependencies (no fancy tools)
+#   NO_DOCKER               # remove Docker before testing
+#   SUDO_RM_AFTER_BUILD     # remove sudo privileges after build
+#   SUDO_AVOID_AFTER_BUILD  # set CH_TEST_DONT_SUDO after build
 #
 env:
 # Complete matrix of TARBALL and INSTALL.
@@ -33,7 +35,10 @@ env:
   - TARBALL=export-bats  INSTALL=
 #  - TARBALL=export-bats  INSTALL=yes
 # Extra conditions
-  - TARBALL=        INSTALL=     MINIMAL_DEPS=yes
+  - TARBALL=             INSTALL=     MINIMAL_DEPS=yes
+  - TARBALL=             INSTALL=     NO_DOCKER=yes
+  - TARBALL=             INSTALL=     SUDO_RM_AFTER_BUILD=yes
+  - TARBALL=             INSTALL=     SUDO_AVOID_AFTER_BUILD=yes
 # One full-scope test. This will finish last by a lot.
 # (Disabled because it gives a >10-minute gap in output, so Travis times out.)
 #  - TARBALL=        INSTALL=     CH_TEST_SCOPE=full
@@ -87,6 +92,9 @@ before_script:
   - for d in $CH_TEST_PERMDIRS; do sudo test/make-perms-test $d $USER nobody; done
   - sudo usermod --add-subuids 10000-65536 $USER
   - sudo usermod --add-subgids 10000-65536 $USER
+  - if [ -n "$NO_DOCKER" ]; then
+      sudo rm $(command -v docker);
+    fi
 
 script:
   - test/travis.sh


### PR DESCRIPTION
Addresses #403. This also tightens up Travis testing:

- do the no-Docker test just once instead of at the end of everything
- test without `sudo` privileges after build
- test with `sudo` turned off after build

We don't yet test without `sudo` at build time.