### PR TITLE
test/chtest/printns: reimplement in Python

### DIFF
--- a/test/chtest/printns
+++ b/test/chtest/printns
@@ -1,12 +1,29 @@
-#!/bin/sh
+#!/usr/bin/env python3
 
 # Print out my namespace IDs, to stdout or (if specified) the path in $2.
-# Then, if $1 is specified, wait that number of seconds before existing.
+# Then, if $1 is specified, wait that number of seconds before exiting.
 
-set -e
+import glob
+import os
+import socket
+import sys
+import time
 
-pause=${1:-0}
-out=${2:-/dev/stdout}
+if (len(sys.argv) > 1):
+   pause = float(sys.argv[1])
+else:
+   pause = 0
 
-stat -L -c %n:$(hostname -s):%i /proc/self/ns/* > $out
-sleep $pause
+if (len(sys.argv) > 2):
+   out = open(sys.argv[2], "wt")
+else:
+   out = sys.stdout
+
+hostname = socket.gethostname()
+
+for ns in glob.glob("/proc/self/ns/*"):
+   stat = os.stat(ns)
+   print("%s:%s:%d" % (ns, hostname, stat.st_ino), file=out, flush=True)
+
+if (pause):
+   time.sleep(pause)

--- a/test/run/ch-run_join.bats
+++ b/test/run/ch-run_join.bats
@@ -200,6 +200,7 @@ unset_vars () {
     ch-run -v --join-ct=3 --join-tag=foo "$ch_timg" -- \
            /test/printns 0 "${BATS_TMPDIR}/join.3.ns" \
            >& "${BATS_TMPDIR}/join.3.err" &
+    sleep 1
     cat "${BATS_TMPDIR}/join.3.err"
     cat "${BATS_TMPDIR}/join.3.ns"
       grep -Fq 'join: 1 3' "${BATS_TMPDIR}/join.3.err"


### PR DESCRIPTION
Addresses #410, which is an intermittent failure that's hard to test. I ran `make test-run` several times and didn't see the issue again, but who knows if it's really fixed.

This reimplements `printns` in Python to shake things up a bit and so we have more control over buffering.