### PR TITLE
examples: update mesa within paraview example

### DIFF
--- a/examples/mpi/paraview/Dockerfile
+++ b/examples/mpi/paraview/Dockerfile
@@ -38,7 +38,7 @@ RUN    cd llvm-${LLVM_VERSION}.build \
 RUN rm -Rf llvm-${LLVM_VERSION}*
 
 # Mesa. We need a version newer than Debian provides.
-ENV MESA_VERSION 17.3.6
+ENV MESA_VERSION 18.0.5
 RUN wget -nv https://mesa.freedesktop.org/archive/mesa-${MESA_VERSION}.tar.xz
 RUN tar xf mesa-${MESA_VERSION}.tar.xz
 RUN    cd mesa-${MESA_VERSION} \


### PR DESCRIPTION
The version of Mesa used within our example is no longer hosted on the archive. Updated the Mesa version which builds successfully and passes single node testing on my x86 machine.