### PR TITLE
OpenMPI examples: downgrade libpsm2, libibverbs, UCX

### DIFF
--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -89,14 +89,14 @@ WORKDIR /usr/local/src
 # Note that libpsm2 is x86-64 only:
 #   https://packages.debian.org/buster/libpsm2-2
 #   https://lists.debian.org/debian-hpc/2017/12/msg00015.html
-ENV DEB_URL http://snapshot.debian.org/archive/debian/20181231T220010Z/pool/main
-ENV PSM2_VERSION 11.2.68-4
+ENV DEB_URL http://snapshot.debian.org/archive/debian/20181126T030749Z/pool/main
+ENV PSM2_VERSION 11.2.68-3
 RUN wget -nv ${DEB_URL}/libp/libpsm2/libpsm2-2_${PSM2_VERSION}_amd64.deb
 RUN wget -nv ${DEB_URL}/libp/libpsm2/libpsm2-dev_${PSM2_VERSION}_amd64.deb
 
-# As of 4/22/2019, this is not the newest libibverbs. However, it is the
+# As of 5/2/2019, this is not the newest libibverbs. However, it is the
 # newest that doesn't crash on our test systems.
-ENV IBVERBS_VERSION 21.0-1
+ENV IBVERBS_VERSION 20.0-1
 RUN for i in ibacm \
              ibverbs-providers \
              ibverbs-utils \

--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -114,7 +114,7 @@ RUN for i in ibacm \
 RUN dpkg --install *.deb
 
 # UCX. There is stuff to build Debian packages, but it seems not too polished.
-ENV UCX_VERSION 1.5.1
+ENV UCX_VERSION 1.3.1
 RUN git clone --branch v${UCX_VERSION} --depth 1 \
               https://github.com/openucx/ucx.git
 RUN    cd ucx \


### PR DESCRIPTION
The newer version is less compatible among systems, notably the ARM systems I have been testing on, than the previous version without offering any apparent benefits, this PR reverts it back prior to:
https://github.com/hpc/charliecloud/commit/00f630dea5e82170b0a9b67a565fc8f3d3a55432

The issue is that the current version we use is too new and there is a mismatch between it and the host drivers resulting in failures when using an ib device. 