### PR TITLE
Add missing CFLAGS, CPPFLAGS and LDFLAGS for some examples/tests

### DIFF
--- a/examples/syscalls/Makefile
+++ b/examples/syscalls/Makefile
@@ -10,4 +10,4 @@ clean:
 $(BINS): Makefile
 
 %: %.c
-	gcc $(CFLAGS) $< -o $@
+	gcc $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $< -o $@

--- a/test/Makefile
+++ b/test/Makefile
@@ -81,8 +81,8 @@ sotest/lib/libsotest.so.1.0: sotest/libsotest.so.1.0
 # the container. (Issue #227.)
 
 sotest/sotest: sotest/sotest.c sotest/libsotest.so.1.0
-	gcc -o $@ -L./sotest -lsotest $^
+	gcc -o $@ $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -L./sotest -lsotest $^
 sotest/libsotest.so.1.0: sotest/libsotest.c
-	gcc -o $@ -shared -fPIC -Wl,-soname,libsotest.so.1 -lc $^
+	gcc -o $@ $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -fPIC -Wl,-soname,libsotest.so.1 -lc $^
 	ln -f -s libsotest.so.1.0 sotest/libsotest.so
 	ln -f -s libsotest.so.1.0 sotest/libsotest.so.1


### PR DESCRIPTION
This patch ensures that CFLAGS, CPPFLAGS and LDFLAGS settings are
respected when compiling/linking (lib)sotest, pivot_root and userns.

I was kindly made aware of this issue by the [blhc](https://ruderich.org/simon/blhc) tool.