### PR TITLE
Makefile: Allow to override DOCDIR.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ endif
 VERSION := $(shell cat VERSION.full)
 INSTALL_PREFIX := $(if $(DESTDIR),$(DESTDIR)/$(PREFIX),$(PREFIX))
 BIN := $(INSTALL_PREFIX)/bin
-DOC := $(INSTALL_PREFIX)/share/doc/charliecloud-$(VERSION)
+DOCDIR ?= $(INSTALL_PREFIX)/share/doc/charliecloud-$(VERSION)
 # LIBEXEC_DIR is modeled after FHS 3.0 and
 # https://www.gnu.org/prep/standards/html_node/Directory-Variables.html. It
 # contains any executable helpers that are not needed in PATH. Default is
@@ -138,16 +138,16 @@ install: all
 	    install -pm 644 -t $(INSTALL_PREFIX)/share/man/man1 man/*.1; \
 	fi
 #       license and readme
-	install -d $(DOC)
-	install -pm 644 -t $(DOC) LICENSE README.rst
+	install -d $(DOCDIR)
+	install -pm 644 -t $(DOCDIR) LICENSE README.rst
 #	html files if they were built
 	if [ -f doc/index.html ]; then \
-		cp -r doc $(DOC)/html; \
-		rm -f $(DOC)/html/.nojekyll; \
-		for i in $$(find $(DOC)/html -type d); do \
+		cp -r doc $(DOCDIR)/html; \
+		rm -f $(DOCDIR)/html/.nojekyll; \
+		for i in $$(find $(DOCDIR)/html -type d); do \
 			chmod 755 $$i; \
 		done; \
-		for i in $$(find $(DOC)/html -type f); do \
+		for i in $$(find $(DOCDIR)/html -type f); do \
 			chmod 644 $$i; \
 		done; \
 	fi


### PR DESCRIPTION
This is needed to enforce a naming scheme
e.g. from a package manager on this path
(may contain downstream revisions for example).
Default unchanged.

Proposed at:
https://github.com/gentoo/gentoo/pull/12084