### PR TITLE
Handle ARG instruction in Dockerfile.

### DIFF
--- a/bin/ch-grow
+++ b/bin/ch-grow
@@ -48,13 +48,16 @@ ENV_DEFAULTS = { }
 GRAMMAR = r"""
 ?start: ( instruction | _COMMENT )+
 
-?instruction: _WS? ( cmd | copy | env | from_ | run | workdir )
+?instruction: _WS? ( cmd | copy | arg | env | from_ | run | workdir )
 
 cmd: "CMD"i _WS LINE _NEWLINES
 
 copy: "COPY"i ( _WS copy_chown )? ( copy_shell ) _NEWLINES
 copy_chown: "--chown" "=" /[^ \t\n]+/
 copy_shell: _WS WORD ( _WS WORD )+
+
+arg: "ARG"i _WS ( arg_set ) _NEWLINES
+arg_set: WORD
 
 env: "ENV"i _WS ( env_space | env_equalses ) _NEWLINES
 env_space: WORD _WS LINE
@@ -125,6 +128,8 @@ environment variables:
                    help="state and images directory (default: /var/tmp/ch-grow)")
    ap.add_argument("-t", "--tag", metavar="TAG",
                    help="name of image to create (default: inferred)")
+   ap.add_argument("--build-arg", action="append", nargs="+", metavar="ARG=VALUE",
+                   help="set build-time variables")
    ap.add_argument("--verbose", action="store_true",
                    help="print extra debugging chatter")
    ap.add_argument("--version", action=Version,
@@ -147,6 +152,8 @@ environment variables:
             cli.tag = m.group(2)
    if (":" not in cli.tag):
       cli.tag += ":latest"
+   cli.build_arg = {arg.split("=")[0] : arg.split("=")[1]
+                    for arg in itertools.chain.from_iterable(cli.build_arg)}
 
    try:
       import lark
@@ -275,6 +282,20 @@ class I_copy_shell(Copy):
       self.srcs = paths[:-1]
       self.dst = paths[-1]
 
+class Arg(Instruction):
+
+   def str_(self):
+      return "%s='%s'" % (self.key, self.value)
+
+   def execute_(self):
+      state.arg[self.key] = self.value
+
+class I_arg_set(Arg):
+
+   def __init__(self, *args):
+      super().__init__(*args)
+      self.key = self.terminal("WORD", 0)
+      self.value = cli.build_arg[self.key]
 
 class Env(Instruction):
 
@@ -447,7 +468,6 @@ class State(object):
       self.workdir = "/"
       self.arg = { k: v for (k, v) in ARG_DEFAULTS.items() if v is not None }
       self.env = { k: v for (k, v) in ENV_DEFAULTS.items() if v is not None }
-
 
 class Version(argparse.Action):
 

--- a/bin/ch-grow
+++ b/bin/ch-grow
@@ -152,8 +152,11 @@ environment variables:
             cli.tag = m.group(2)
    if (":" not in cli.tag):
       cli.tag += ":latest"
-   cli.build_arg = {arg.split("=")[0] : arg.split("=")[1]
-                    for arg in itertools.chain.from_iterable(cli.build_arg)}
+   if (cli_build_arg is not None):
+       cli.build_arg = {arg.split("=")[0] : arg.split("=")[1]
+                        for arg in itertools.chain.from_iterable(cli.build_arg)}
+   else:
+       cli.build_arg = {}
 
    try:
       import lark

--- a/bin/ch-grow
+++ b/bin/ch-grow
@@ -152,7 +152,7 @@ environment variables:
             cli.tag = m.group(2)
    if (":" not in cli.tag):
       cli.tag += ":latest"
-   if (cli_build_arg is not None):
+   if (cli.build_arg is not None):
        cli.build_arg = {arg.split("=")[0] : arg.split("=")[1]
                         for arg in itertools.chain.from_iterable(cli.build_arg)}
    else:


### PR DESCRIPTION
This PR allows `ch-grow` to parse the `ARG` instruction in a `Dockerfile`.

An example `Dockerfile`:
```
FROM centos:7
ARG TEST_MSG
RUN echo My test message is: ${TEST_MSG}
```

This will echo the message if built with: `docker build --build-arg TEST_MSG="ONE TWO THREE" --file Dockerfile .`

Now with `ch-grow` can do the same with: `ch-grow --build-arg TEST_MSG="ONE TWO THREE" --file Dockerfile .`

Follows the same appending CLI format as `docker build`, i.e. can do `ch-grow --build-arg ARG1=A --build-arg ARG2=b --build-arg ARG3=c` and so on.