### PR TITLE
Fix Vagrantfile to reflect change in charliecloud test location

### DIFF
--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -83,8 +83,8 @@ Vagrant.configure("2") do |c|
     rpm --install ius-release.rpm
     yum -y install git2u
 
-    # Utilities to make the shell scripts faster and more usable.
-    yum -y install pigz pv
+    # Optional dependencies.
+    yum -y install pigz pv python36
 
     # Add /usr/local/{bin,sbin} to $PATH.
     echo 'export PATH=/usr/local/sbin:/usr/local/bin:$PATH' > /etc/profile.d/path.sh
@@ -262,7 +262,7 @@ EOF2
   # Note: This will grow the image quite a bit. Don't run it before taking the
   # snapshot to be distributed to end users.
   c.vm.provision "test", type: "shell", run: "never", privileged: false,
-                 env: { "CH_TEST_SCOPE" => "full", "CH_VERSION" => "0.10"},
+                 env: { "CH_TEST_SCOPE" => "full" },
                  inline: <<-EOF
     set -e
     if ( id -u charlie 2>/dev/null ); then  # issue #309
@@ -270,10 +270,12 @@ EOF2
     else
         user=vagrant
     fi
+    echo "scope:      $CH_TEST_SCOPE"
     echo "testing as: $user"
-    sudo -iu $user -- sh -c "\
-   cd /usr/local/libexec/charliecloud-$CH_VERSION/test \
-&& CH_TEST_SCOPE=$CH_TEST_SCOPE make test"
+    version=$(cat /usr/local/src/charliecloud/VERSION.full)
+    test_path=/usr/local/libexec/charliecloud-${version}/test
+    echo "testing in: $test_path"
+    sudo -iu $user -- sh -c "cd $test_path && make test"
   EOF
 
 end

--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -262,7 +262,7 @@ EOF2
   # Note: This will grow the image quite a bit. Don't run it before taking the
   # snapshot to be distributed to end users.
   c.vm.provision "test", type: "shell", run: "never", privileged: false,
-                 env: { "CH_TEST_SCOPE" => "full" },
+                 env: { "CH_TEST_SCOPE" => "full", "CH_VERSION" => "0.10"},
                  inline: <<-EOF
     set -e
     if ( id -u charlie 2>/dev/null ); then  # issue #309
@@ -272,7 +272,7 @@ EOF2
     fi
     echo "testing as: $user"
     sudo -iu $user -- sh -c "\
-   cd /usr/local/libexec/charliecloud/test \
+   cd /usr/local/libexec/charliecloud-$CH_VERSION/test \
 && CH_TEST_SCOPE=$CH_TEST_SCOPE make test"
   EOF
 


### PR DESCRIPTION
The location of the test suite in vagrant images has been changed from `/usr/local/libexec/charliecloud` to `/usr/local/libexec/charliecloud-<version>`. The Vagrantfile has not been updated to reflect this change. I would prefer this solution to draw the version from `VERSION` in the root directory so it will not need to be updated with each new release, but I've been unable to find a suitable way to do that. 