### PR TITLE
handle ARG instruction in Dockerfile

### DIFF
--- a/bin/ch-build
+++ b/bin/ch-build
@@ -79,6 +79,7 @@ case $CH_BUILDER in
                 # ignore_chown: leave unset
                 ;;
         esac
+        BUILDAH_LAYERS=true \
         buildah $ignore_chown \
                 build-using-dockerfile \
                 --build-arg HTTP_PROXY="$HTTP_PROXY" \
@@ -88,7 +89,6 @@ case $CH_BUILDER in
                 --build-arg https_proxy="$https_proxy" \
                 --build-arg no_proxy="$no_proxy" \
                 --isolation=rootless \
-                --layers=true \
                 --runtime="$runtime" \
                 "$@" < /dev/null
         ;;

--- a/bin/ch-grow
+++ b/bin/ch-grow
@@ -56,8 +56,9 @@ copy: "COPY"i ( _WS copy_chown )? ( copy_shell ) _NEWLINES
 copy_chown: "--chown" "=" /[^ \t\n]+/
 copy_shell: _WS WORD ( _WS WORD )+
 
-arg: "ARG"i _WS ( arg_set ) _NEWLINES
-arg_set: WORD
+arg: "ARG"i _WS ( arg_bare | arg_equals ) _NEWLINES
+arg_bare: WORD
+arg_equals: WORD "=" ( WORD | STRING_QUOTED )
 
 env: "ENV"i _WS ( env_space | env_equalses ) _NEWLINES
 env_space: WORD _WS LINE
@@ -114,6 +115,9 @@ def main():
 environment variables:
   CH_GROW_STORAGE       default for --storage
 """)
+   ap.add_argument("--build-arg", action="append", default=None,
+                   metavar="KEY=VALUE",
+                   help="set build-time variables")
    ap.add_argument("-f", "--file", metavar="DOCKERFILE",
                    help="Dockerfile to use (default: CONTEXT/Dockerfile)")
    ap.add_argument("-n", "--dry-run", action="store_true",
@@ -128,8 +132,6 @@ environment variables:
                    help="state and images directory (default: /var/tmp/ch-grow)")
    ap.add_argument("-t", "--tag", metavar="TAG",
                    help="name of image to create (default: inferred)")
-   ap.add_argument("--build-arg", action="append", nargs="+", metavar="ARG=VALUE",
-                   help="set build-time variables")
    ap.add_argument("--verbose", action="store_true",
                    help="print extra debugging chatter")
    ap.add_argument("--version", action=Version,
@@ -152,11 +154,18 @@ environment variables:
             cli.tag = m.group(2)
    if (":" not in cli.tag):
       cli.tag += ":latest"
-   if (cli.build_arg is not None):
-       cli.build_arg = {arg.split("=")[0] : arg.split("=")[1]
-                        for arg in itertools.chain.from_iterable(cli.build_arg)}
-   else:
-       cli.build_arg = {}
+   def build_arg_get(arg):
+      kv = arg.split("=")
+      if (len(kv) == 2):
+         return kv
+      else:
+         v = os.getenv(kv[0])
+         if (v is None):
+            FATAL("--build-arg: %s: no value and not in environment" % kv[0])
+         return (kv[0], v)
+   if (cli.build_arg is None):
+      cli.build_arg = list()
+   cli.build_arg = dict( build_arg_get(i) for i in cli.build_arg )
 
    try:
       import lark
@@ -182,6 +191,9 @@ environment variables:
       sys.exit(0)
 
    Main_Loop().visit(tree)
+
+   if (len(cli.build_arg) != 0):
+      FATAL("--build-arg: not consumed: " + " ".join(cli.build_arg.keys()))
 
 
 class Main_Loop(lark.Visitor):
@@ -287,18 +299,45 @@ class I_copy_shell(Copy):
 
 class Arg(Instruction):
 
-   def str_(self):
-      return "%s='%s'" % (self.key, self.value)
-
-   def execute_(self):
-      state.arg[self.key] = self.value
-
-class I_arg_set(Arg):
-
    def __init__(self, *args):
       super().__init__(*args)
       self.key = self.terminal("WORD", 0)
-      self.value = cli.build_arg[self.key]
+      if (self.key in cli.build_arg):
+         self.value = cli.build_arg[self.key]
+         del cli.build_arg[self.key]
+      else:
+         self.value = self.value_default()
+      if (self.value is not None):
+         self.value = variables_sub(self.value, state.env_build)
+
+   def str_(self):
+      if (self.value is None):
+         return self.key
+      else:
+         return "%s='%s'" % (self.key, self.value)
+
+   def execute_(self):
+      if (self.value is not None):
+         state.arg[self.key] = self.value
+
+class I_arg_bare(Arg):
+
+   def __init__(self, *args):
+      super().__init__(*args)
+
+   def value_default(self):
+      return None
+
+class I_arg_equals(Arg):
+
+   def __init__(self, *args):
+      super().__init__(*args)
+
+   def value_default(self):
+      v = self.terminal("WORD", 1)
+      if (v is None):
+         v = unescape(self.terminal("STRING_QUOTED"))
+      return v
 
 class Env(Instruction):
 
@@ -319,7 +358,7 @@ class I_env_equals(Env):
       self.key = self.terminal("WORD", 0)
       self.value = self.terminal("WORD", 1)
       if (self.value is None):
-         self.value = self.terminal("STRING_QUOTED")
+         self.value = unescape(self.terminal("STRING_QUOTED"))
       self.value = variables_sub(self.value, state.env_build)
 
 
@@ -489,14 +528,14 @@ class Version(argparse.Action):
 
 def DEBUG(*args, **kwargs):
    if (cli.verbose):
-      print("\033[36m", file=sys.stderr, flush=True, end="")
+      color("36m", sys.stderr)
       print(flush=True, file=sys.stderr, *args, **kwargs)
-      print("\033[0m", file=sys.stderr, flush=True, end="")
+      color("0m", sys.stderr)
 
 def FATAL(*args, **kwargs):
-   print("\033[31m", file=sys.stderr, flush=True, end="")
+   color("31m", sys.stderr)
    print(flush=True, file=sys.stderr, *args, **kwargs)
-   print("\033[0m", file=sys.stderr, flush=True, end="")
+   color("0m", sys.stderr)
    sys.exit(1)
 
 def INFO(*args, **kwargs):
@@ -505,11 +544,15 @@ def INFO(*args, **kwargs):
 def cmd(args, env=None):
    DEBUG("environment: %s" % env)
    DEBUG("executing: %s" % args)
-   INFO("\033[33m", end="")
+   color("33m", sys.stdout)
    cp = subprocess.run(args, env=env, stdin=subprocess.DEVNULL)
-   INFO("\033[0m", end="")
+   color("0m", sys.stdout)
    if (cp.returncode):
       FATAL("%s failed with return code %d" % (args[0], cp.returncode))
+
+def color(color, fp):
+   if (fp.isatty()):
+      print("\033[" + color, end="", flush=True, file=fp)
 
 def cp(src, dst):
    DEBUG("copying: %s -> %s" % (src, dst))

--- a/bin/ch-grow
+++ b/bin/ch-grow
@@ -122,6 +122,8 @@ environment variables:
                    help="Dockerfile to use (default: CONTEXT/Dockerfile)")
    ap.add_argument("-n", "--dry-run", action="store_true",
                    help="don't execute instructions")
+   ap.add_argument("--no-cache", action="store_true",
+                   help="ignored (layer caching not yet supported)")
    ap.add_argument("--parse-only", action="store_true",
                    help="stop after parsing the Dockerfile")
    ap.add_argument("--print-storage", action="store_true",

--- a/bin/ch-grow
+++ b/bin/ch-grow
@@ -48,13 +48,16 @@ ENV_DEFAULTS = { }
 GRAMMAR = r"""
 ?start: ( instruction | _COMMENT )+
 
-?instruction: _WS? ( cmd | copy | env | from_ | run | workdir )
+?instruction: _WS? ( cmd | copy | arg | env | from_ | run | workdir )
 
 cmd: "CMD"i _WS LINE _NEWLINES
 
 copy: "COPY"i ( _WS copy_chown )? ( copy_shell ) _NEWLINES
 copy_chown: "--chown" "=" /[^ \t\n]+/
 copy_shell: _WS WORD ( _WS WORD )+
+
+arg: "ARG"i _WS ( arg_set ) _NEWLINES
+arg_set: WORD
 
 env: "ENV"i _WS ( env_space | env_equalses ) _NEWLINES
 env_space: WORD _WS LINE
@@ -125,6 +128,8 @@ environment variables:
                    help="state and images directory (default: /var/tmp/ch-grow)")
    ap.add_argument("-t", "--tag", metavar="TAG",
                    help="name of image to create (default: inferred)")
+   ap.add_argument("--build-arg", action="append", nargs="+", metavar="ARG=VALUE",
+                   help="set build-time variables")
    ap.add_argument("--verbose", action="store_true",
                    help="print extra debugging chatter")
    ap.add_argument("--version", action=Version,
@@ -147,6 +152,8 @@ environment variables:
             cli.tag = m.group(2)
    if (":" not in cli.tag):
       cli.tag += ":latest"
+   cli.build_arg = {arg.split("=")[0] : arg.split("=")[1]
+                    for arg in itertools.chain.from_iterable(cli.build_arg)}
 
    try:
       import lark
@@ -275,6 +282,20 @@ class I_copy_shell(Copy):
       self.srcs = paths[:-1]
       self.dst = paths[-1]
 
+class Arg(Instruction):
+
+   def str_(self):
+      return "%s='%s'" % (self.key, self.value)
+
+   def execute_(self):
+      state.arg[self.key] = self.value
+
+class I_arg_set(Arg):
+
+   def __init__(self, *args):
+      super().__init__(*args)
+      self.key = self.terminal("WORD", 0)
+      self.value = cli.build_arg[self.key]
 
 class Env(Instruction):
 
@@ -447,7 +468,6 @@ class State(object):
       self.workdir = "/"
       self.arg = { k: v for (k, v) in ARG_DEFAULTS.items() if v is not None }
       self.env = { k: v for (k, v) in ENV_DEFAULTS.items() if v is not None }
-
 
 class Version(argparse.Action):
 

--- a/bin/ch-grow
+++ b/bin/ch-grow
@@ -152,8 +152,11 @@ environment variables:
             cli.tag = m.group(2)
    if (":" not in cli.tag):
       cli.tag += ":latest"
-   cli.build_arg = {arg.split("=")[0] : arg.split("=")[1]
-                    for arg in itertools.chain.from_iterable(cli.build_arg)}
+   if (cli_build_arg is not None):
+       cli.build_arg = {arg.split("=")[0] : arg.split("=")[1]
+                        for arg in itertools.chain.from_iterable(cli.build_arg)}
+   else:
+       cli.build_arg = {}
 
    try:
       import lark

--- a/bin/ch-grow
+++ b/bin/ch-grow
@@ -152,7 +152,7 @@ environment variables:
             cli.tag = m.group(2)
    if (":" not in cli.tag):
       cli.tag += ":latest"
-   if (cli_build_arg is not None):
+   if (cli.build_arg is not None):
        cli.build_arg = {arg.split("=")[0] : arg.split("=")[1]
                         for arg in itertools.chain.from_iterable(cli.build_arg)}
    else:

--- a/doc-src/ch-grow_desc.rst
+++ b/doc-src/ch-grow_desc.rst
@@ -57,6 +57,9 @@ Other arguments:
   :code:`-n`, :code:`--dry-run`
     Do not actually excute any Dockerfile instructions.
 
+  :code:`--no-cache`
+    Ignored (:code:`ch-grow` does not yet support layer caching).
+
   :code:`--parse-only`
     Stop after parsing the Dockerfile.
 

--- a/doc-src/ch-grow_desc.rst
+++ b/doc-src/ch-grow_desc.rst
@@ -43,6 +43,11 @@ Other arguments:
     Context directory; this is the root of :code:`COPY` and :code:`ADD`
     instructions in the Dockerfile.
 
+  :code:`--build-arg KEY[=VALUE]`
+    Set build-time variable :code:`KEY` defined by :code:`ARG` instruction
+    to :code:`VALUE`. If :code:`VALUE` not specified, use the value of
+    environment variable :code:`KEY`.
+
   :code:`-f`, :code:`--file DOCKERFILE`
     Use :code:`DOCKERFILE` instead of :code:`CONTEXT/Dockerfile`.
 

--- a/test/Dockerfile.argenv
+++ b/test/Dockerfile.argenv
@@ -1,0 +1,14 @@
+# Test ARG and ENV handling.
+
+# ch-test-scope: standard
+FROM alpine:3.9
+
+ARG chse_arg1_df
+ARG chse_arg2_df=arg2
+ARG chse_arg3_df="arg3 ${chse_arg2_df}"
+ENV chse_env1_df env1
+ENV chse_env2_df="env2 ${chse_env1_df}"
+RUN env | egrep '^chse_' | sort
+
+# Base image has no default command; we need one to build.
+CMD ["true"]

--- a/test/Dockerfile.debian9
+++ b/test/Dockerfile.debian9
@@ -1,8 +1,5 @@
 # ch-test-scope: standard
 FROM debian:stretch
 
-ENV chse_dockerfile foo
-ENV DEBIAN_FRONTEND noninteractive
-
 RUN    apt-get update \
     && apt-get install -y apt-utils

--- a/test/Dockerfile.exhaustive
+++ b/test/Dockerfile.exhaustive
@@ -14,6 +14,7 @@
 FROM alpine:3.9
 #FROM alpine:3.9 AS stage1
 
+# FIXME: These should maybe be moved into Dockerfile.argenv?
 ENV chse_1 value1 with spaces and trailing space 
 ENV chse_2 "value2"
 ENV chse_2a chse2: ${chse_2}

--- a/test/build_post.bats
+++ b/test/build_post.bats
@@ -1,10 +1,23 @@
 load common
 
 @test 'ARG and ENV' {
-    scope standard
+
+    # We use full scope for everything except ch-grow because (1) with
+    # ch-grow, we are responsible for --build-arg being implemented correctly
+    # and (2) Docker and Buildah take a full minute for this test, vs. three
+    # seconds for ch-grow.
+    if [[ $CH_BUILDER = ch-grow ]]; then
+        scope standard
+    else
+        scope full
+    fi
     prerequisites_ok argenv
 
-    # default (no --build-arg)
+    # Note that this test illustrates a number of behavior differences between
+    # the builders. For most of these, but not all, Docker and Buildah have
+    # the same behavior and ch-grow differs.
+
+    echo '*** default (no --build-arg)'
     env_expected=$(cat <<'EOF'
 chse_arg2_df=arg2
 chse_arg3_df=arg3 arg2
@@ -12,13 +25,13 @@ chse_env1_df=env1
 chse_env2_df=env2 env1
 EOF
 )
-    run ch-build -t argenv -f ./Dockerfile.argenv .
+    run ch-build --no-cache -t argenv -f ./Dockerfile.argenv .
     echo "$output"
     [[ $status -eq 0 ]]
     env_actual=$(echo "$output" | grep -E '^chse_')
     diff -u <(echo "$env_expected") <(echo "$env_actual")
 
-    # one --build-arg, has no default
+    echo '*** one --build-arg, has no default'
     env_expected=$(cat <<'EOF'
 chse_arg1_df=foo1
 chse_arg2_df=arg2
@@ -28,13 +41,13 @@ chse_env2_df=env2 env1
 EOF
 )
     run ch-build --build-arg chse_arg1_df=foo1 \
-                 -t argenv -f ./Dockerfile.argenv .
+                 --no-cache -t argenv -f ./Dockerfile.argenv .
     echo "$output"
     [[ $status -eq 0 ]]
     env_actual=$(echo "$output" | grep -E '^chse_')
     diff -u <(echo "$env_expected") <(echo "$env_actual")
 
-    # one --build-arg, has default
+    echo '*** one --build-arg, has default'
     env_expected=$(cat <<'EOF'
 chse_arg2_df=foo2
 chse_arg3_df=arg3 foo2
@@ -43,14 +56,15 @@ chse_env2_df=env2 env1
 EOF
 )
     run ch-build --build-arg chse_arg2_df=foo2 \
-                 -t argenv -f ./Dockerfile.argenv .
+                 --no-cache -t argenv -f ./Dockerfile.argenv .
     echo "$output"
     [[ $status -eq 0 ]]
     env_actual=$(echo "$output" | grep -E '^chse_')
     diff -u <(echo "$env_expected") <(echo "$env_actual")
 
-    # one --build-arg from environment
-    env_expected=$(cat <<'EOF'
+    echo '*** one --build-arg from environment'
+    if [[ $CH_BUILDER == ch-grow ]]; then
+        env_expected=$(cat <<'EOF'
 chse_arg1_df=foo1
 chse_arg2_df=arg2
 chse_arg3_df=arg3 arg2
@@ -58,15 +72,28 @@ chse_env1_df=env1
 chse_env2_df=env2 env1
 EOF
 )
+    else
+        # Docker and Buildah do not appear to take --build-arg values from the
+        # environment. This is contrary to the "docker build" documentation;
+        # "buildah bud" does not mention it either way. Tested on 18.09.7 and
+        # 1.9.1-dev, respectively.
+        env_expected=$(cat <<'EOF'
+chse_arg2_df=arg2
+chse_arg3_df=arg3 arg2
+chse_env1_df=env1
+chse_env2_df=env2 env1
+EOF
+)
+    fi
     chse_arg1_df=foo1 \
     run ch-build --build-arg chse_arg1_df \
-                 -t argenv -f ./Dockerfile.argenv .
+                 --no-cache -t argenv -f ./Dockerfile.argenv .
     echo "$output"
     [[ $status -eq 0 ]]
     env_actual=$(echo "$output" | grep -E '^chse_')
     diff -u <(echo "$env_expected") <(echo "$env_actual")
 
-    # one --build-arg set to empty string
+    echo '*** one --build-arg set to empty string'
     env_expected=$(cat <<'EOF'
 chse_arg1_df=
 chse_arg2_df=arg2
@@ -77,13 +104,13 @@ EOF
 )
     chse_arg1_df=foo1 \
     run ch-build --build-arg chse_arg1_df= \
-                 -t argenv -f ./Dockerfile.argenv .
+                 --no-cache -t argenv -f ./Dockerfile.argenv .
     echo "$output"
     [[ $status -eq 0 ]]
     env_actual=$(echo "$output" | grep -E '^chse_')
     diff -u <(echo "$env_expected") <(echo "$env_actual")
 
-    # two --build-arg
+    echo '*** two --build-arg'
     env_expected=$(cat <<'EOF'
 chse_arg2_df=bar2
 chse_arg3_df=bar3
@@ -93,42 +120,80 @@ EOF
 )
     run ch-build --build-arg chse_arg2_df=bar2 \
                  --build-arg chse_arg3_df=bar3 \
-                 -t argenv -f ./Dockerfile.argenv .
+                 --no-cache -t argenv -f ./Dockerfile.argenv .
     echo "$output"
     [[ $status -eq 0 ]]
     env_actual=$(echo "$output" | grep -E '^chse_')
     diff -u <(echo "$env_expected") <(echo "$env_actual")
 
-    # two --build-arg with substitution
+    echo '*** repeated --build-arg'
     env_expected=$(cat <<'EOF'
+chse_arg2_df=bar2
+chse_arg3_df=arg3 bar2
+chse_env1_df=env1
+chse_env2_df=env2 env1
+EOF
+)
+    run ch-build --build-arg chse_arg2_df=FOO \
+                 --build-arg chse_arg2_df=bar2 \
+                 --no-cache -t argenv -f ./Dockerfile.argenv .
+    echo "$output"
+    [[ $status -eq 0 ]]
+    env_actual=$(echo "$output" | grep -E '^chse_')
+    diff -u <(echo "$env_expected") <(echo "$env_actual")
+
+    echo '*** two --build-arg with substitution'
+    if [[ $CH_BUILDER == ch-grow ]]; then
+        env_expected=$(cat <<'EOF'
 chse_arg2_df=bar2
 chse_arg3_df=bar3 bar2
 chse_env1_df=env1
 chse_env2_df=env2 env1
 EOF
 )
+    else
+        # Docker and Buildah don't substitute provided values.
+        env_expected=$(cat <<'EOF'
+chse_arg2_df=bar2
+chse_arg3_df=bar3 ${chse_arg2_df}
+chse_env1_df=env1
+chse_env2_df=env2 env1
+EOF
+)
+    fi
     # shellcheck disable=SC2016
     run ch-build --build-arg chse_arg2_df=bar2 \
                  --build-arg chse_arg3_df='bar3 ${chse_arg2_df}' \
-                 -t argenv -f ./Dockerfile.argenv .
+                 --no-cache -t argenv -f ./Dockerfile.argenv .
     echo "$output"
     [[ $status -eq 0 ]]
     env_actual=$(echo "$output" | grep -E '^chse_')
     diff -u <(echo "$env_expected") <(echo "$env_actual")
 
-    # ARG not in Dockerfile
+    echo '*** ARG not in Dockerfile'
+    # Note: We don't test it, but for Buildah, the variable does show up in
+    # the build environment.
     run ch-build --build-arg chse_doesnotexist=foo \
-                 -t argenv -f ./Dockerfile.argenv .
+                 --no-cache -t argenv -f ./Dockerfile.argenv .
     echo "$output"
-    [[ $status -eq 1 ]]
-    [[ $output = *'--build-arg: not consumed: chse_doesnotexist'* ]]
+    if [[ $CH_BUILDER = ch-grow ]]; then
+        [[ $status -eq 1 ]]
+    else
+        [[ $status -eq 0 ]]
+    fi
+    [[ $output = *'not consumed'* ]]
+    [[ $output = *'chse_doesnotexist'* ]]
 
-    # ARG not in environment
+    echo '*** ARG not in environment'
     run ch-build --build-arg chse_arg1_df \
-                 -t argenv -f ./Dockerfile.argenv .
+                 --no-cache -t argenv -f ./Dockerfile.argenv .
     echo "$output"
-    [[ $status -eq 1 ]]
-    [[ $output = *'--build-arg: chse_arg1_df: no value and not in environment'* ]]
+    if [[ $CH_BUILDER = ch-grow ]]; then
+        [[ $status -eq 1 ]]
+        [[ $output = *'--build-arg: chse_arg1_df: no value and not in environment'* ]]
+    else
+        [[ $status -eq 0 ]]
+    fi
 }
 
 @test 'nothing unexpected in tarball directory' {

--- a/test/build_post.bats
+++ b/test/build_post.bats
@@ -1,5 +1,136 @@
 load common
 
+@test 'ARG and ENV' {
+    scope standard
+    prerequisites_ok argenv
+
+    # default (no --build-arg)
+    env_expected=$(cat <<'EOF'
+chse_arg2_df=arg2
+chse_arg3_df=arg3 arg2
+chse_env1_df=env1
+chse_env2_df=env2 env1
+EOF
+)
+    run ch-build -t argenv -f ./Dockerfile.argenv .
+    echo "$output"
+    [[ $status -eq 0 ]]
+    env_actual=$(echo "$output" | grep -E '^chse_')
+    diff -u <(echo "$env_expected") <(echo "$env_actual")
+
+    # one --build-arg, has no default
+    env_expected=$(cat <<'EOF'
+chse_arg1_df=foo1
+chse_arg2_df=arg2
+chse_arg3_df=arg3 arg2
+chse_env1_df=env1
+chse_env2_df=env2 env1
+EOF
+)
+    run ch-build --build-arg chse_arg1_df=foo1 \
+                 -t argenv -f ./Dockerfile.argenv .
+    echo "$output"
+    [[ $status -eq 0 ]]
+    env_actual=$(echo "$output" | grep -E '^chse_')
+    diff -u <(echo "$env_expected") <(echo "$env_actual")
+
+    # one --build-arg, has default
+    env_expected=$(cat <<'EOF'
+chse_arg2_df=foo2
+chse_arg3_df=arg3 foo2
+chse_env1_df=env1
+chse_env2_df=env2 env1
+EOF
+)
+    run ch-build --build-arg chse_arg2_df=foo2 \
+                 -t argenv -f ./Dockerfile.argenv .
+    echo "$output"
+    [[ $status -eq 0 ]]
+    env_actual=$(echo "$output" | grep -E '^chse_')
+    diff -u <(echo "$env_expected") <(echo "$env_actual")
+
+    # one --build-arg from environment
+    env_expected=$(cat <<'EOF'
+chse_arg1_df=foo1
+chse_arg2_df=arg2
+chse_arg3_df=arg3 arg2
+chse_env1_df=env1
+chse_env2_df=env2 env1
+EOF
+)
+    chse_arg1_df=foo1 \
+    run ch-build --build-arg chse_arg1_df \
+                 -t argenv -f ./Dockerfile.argenv .
+    echo "$output"
+    [[ $status -eq 0 ]]
+    env_actual=$(echo "$output" | grep -E '^chse_')
+    diff -u <(echo "$env_expected") <(echo "$env_actual")
+
+    # one --build-arg set to empty string
+    env_expected=$(cat <<'EOF'
+chse_arg1_df=
+chse_arg2_df=arg2
+chse_arg3_df=arg3 arg2
+chse_env1_df=env1
+chse_env2_df=env2 env1
+EOF
+)
+    chse_arg1_df=foo1 \
+    run ch-build --build-arg chse_arg1_df= \
+                 -t argenv -f ./Dockerfile.argenv .
+    echo "$output"
+    [[ $status -eq 0 ]]
+    env_actual=$(echo "$output" | grep -E '^chse_')
+    diff -u <(echo "$env_expected") <(echo "$env_actual")
+
+    # two --build-arg
+    env_expected=$(cat <<'EOF'
+chse_arg2_df=bar2
+chse_arg3_df=bar3
+chse_env1_df=env1
+chse_env2_df=env2 env1
+EOF
+)
+    run ch-build --build-arg chse_arg2_df=bar2 \
+                 --build-arg chse_arg3_df=bar3 \
+                 -t argenv -f ./Dockerfile.argenv .
+    echo "$output"
+    [[ $status -eq 0 ]]
+    env_actual=$(echo "$output" | grep -E '^chse_')
+    diff -u <(echo "$env_expected") <(echo "$env_actual")
+
+    # two --build-arg with substitution
+    env_expected=$(cat <<'EOF'
+chse_arg2_df=bar2
+chse_arg3_df=bar3 bar2
+chse_env1_df=env1
+chse_env2_df=env2 env1
+EOF
+)
+    # shellcheck disable=SC2016
+    run ch-build --build-arg chse_arg2_df=bar2 \
+                 --build-arg chse_arg3_df='bar3 ${chse_arg2_df}' \
+                 -t argenv -f ./Dockerfile.argenv .
+    echo "$output"
+    [[ $status -eq 0 ]]
+    env_actual=$(echo "$output" | grep -E '^chse_')
+    diff -u <(echo "$env_expected") <(echo "$env_actual")
+
+    # ARG not in Dockerfile
+    run ch-build --build-arg chse_doesnotexist=foo \
+                 -t argenv -f ./Dockerfile.argenv .
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'--build-arg: not consumed: chse_doesnotexist'* ]]
+
+    # ARG not in environment
+    run ch-build --build-arg chse_arg1_df \
+                 -t argenv -f ./Dockerfile.argenv .
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'--build-arg: chse_arg1_df: no value and not in environment'* ]]
+}
+
 @test 'nothing unexpected in tarball directory' {
     scope quick
     run find "$ch_tardir" -mindepth 1 -maxdepth 1 \

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -359,11 +359,12 @@ EOF
 
 @test 'ch-run --set-env from Dockerfile' {
     scope standard
-    prerequisites_ok debian9
-    img=${ch_imgdir}/debian9
+    prerequisites_ok argenv
+    img=${ch_imgdir}/argenv
 
     output_expected=$(cat <<'EOF'
-chse_dockerfile=foo
+chse_env1_df=env1
+chse_env2_df=env2 env1
 EOF
 )
 


### PR DESCRIPTION
This extends PR #490 by @cmbiwer and also addresses issue #501.

The extensions are:

* generalize `ARG` and `--build-arg` syntax per Docker and Buildah documentation
* add tests
* document `--build-arg`

The one reduction in functionality is to accept exactly one `KEY[=VALUE]` per `--build-arg`. My reading of both the Docker and Buildah docs is that they have this behavior. Also, if we consume any number of variables, constructions like `ch-grow [...] --build-arg foo=bar baz` will consume `baz` as a build argument when it's intended as the context directory.

@cmbiwer, does this extended PR meet your needs? I apologize for creating a duplicate PR; I can't push to your branch.