### PR TITLE
Remove existing test directories in test make clean

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -60,6 +60,8 @@ clean:
 	rm -f *_auto.bats
 	rm -f sotest/sotest sotest/libsotest.so*
 	rm -f sotest/bin/sotest sotest/lib/libsotest.so*
+	[ -d "${CH_TEST_TARDIR}" ] && rm -rf "${CH_TEST_TARDIR}" || :
+	[ -d "${CH_TEST_IMGDIR}" ] && rm -rf "${CH_TEST_IMGDIR}" || :
 
 .PHONY: where-bats
 where-bats:


### PR DESCRIPTION
This prevents a failure due to an existing directory if you run the tests twice with clean in between.