### PR TITLE
Update vagrant default

### DIFF
--- a/doc-src/vm.rst
+++ b/doc-src/vm.rst
@@ -153,6 +153,8 @@ In no particular order:
 * The documentation is not built. Use the web documentation instead of man
   pages.
 
+* Only the most recent release of Charliecloud is supported.
+
 Install Vagrant and plugins
 ---------------------------
 
@@ -184,18 +186,17 @@ To build the VM and install Docker, Charliecloud, etc.::
   $ cd packaging/vagrant
   $ vagrant up
 
-This takes less than 5 minutes.
-This pulls the newest tagged version of charliecloud. Prepend CH_VERSION to vagrant up for a particular version.::
+By default, this uses the newest release of Charliecloud. If you want
+something different, set the :code:`CH_VERSION` variable, e.g.::
 
-  $ CH_VERSION=0.10 vagrant up 
+  $ CH_VERSION=v0.10 vagrant up
   $ CH_VERSION=master vagrant up
 
 Then, optionally run the Charliecloud tests::
 
   $ vagrant provision --provision-with=test
 
-This runs the full Charliecloud test suite, which takes quite a while (maybe
-1–2 hours). Go have lunch, and then second lunch, and then third lunch.
+This runs the Charliecloud test suite in standard scope.
 
 Note that the test output does not have a TTY, so you will not have the tidy
 checkmarks. The last test printed is the last one that completed, not the one
@@ -222,16 +223,10 @@ Remove old virtual machine
    you're not removing it here, unless you are sure it's disposable.
 
 Each time we create a new image to distribute, we start from scratch rather
-than updating the old image. Therefore, we must remove the old image.
+than updating the old image. Therefore, we must remove the old image::
 
-1. Destroy the old virtual machine::
-
-     $ cd packaging/vagrant
-     $ vagrant destroy
-
-2. Remove deleted disk images from the VirtualBox media manager: *File* →
-   *Virtual Media Manager*. Right click on and remove any :code:`.vmdk` with a
-   red exclamation icon next to them.
+   $ cd packaging/vagrant
+   $ vagrant destroy
 
 Build and provision
 -------------------

--- a/doc-src/vm.rst
+++ b/doc-src/vm.rst
@@ -182,7 +182,7 @@ Build and provision
 To build the VM and install Docker, Charliecloud, etc.::
 
   $ cd packaging/vagrant
-  $ CH_VERSION=v0.9.1 vagrant up
+  vagrant up
 
 This takes less than 5 minutes.
 
@@ -242,7 +242,7 @@ take effect (which is done in the next step).
 
 ::
 
-   $ CH_VERSION=v0.9.1 vagrant up
+   vagrant up
    $ vagrant provision --provision-with=ova
 
 Snapshot for distribution

--- a/doc-src/vm.rst
+++ b/doc-src/vm.rst
@@ -182,11 +182,13 @@ Build and provision
 To build the VM and install Docker, Charliecloud, etc.::
 
   $ cd packaging/vagrant
-  vagrant up
+  $ vagrant up
 
 This takes less than 5 minutes.
+This pulls the newest tagged version of charliecloud. Prepend CH_VERSION to vagrant up for a particular version.::
 
-If you want the head of the master branch, omit :code:`CH_VERSION`.
+  $ CH_VERSION=0.10 vagrant up 
+  $ CH_VERSION=master vagrant up
 
 Then, optionally run the Charliecloud tests::
 
@@ -242,7 +244,7 @@ take effect (which is done in the next step).
 
 ::
 
-   vagrant up
+   $ vagrant up
    $ vagrant provision --provision-with=ova
 
 Snapshot for distribution

--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -184,6 +184,7 @@ EOF2
     cd charliecloud
     if [[ -z $CH_VERSION ]]; then
       CH_VERSION=$(git tag --sort=-version:refname --format='%(refname:strip=2)' | head -n 1)
+    fi
     echo "Checking out charliecloud-$CH_VERSION"
     git checkout $CH_VERSION
     make

--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -184,9 +184,8 @@ EOF2
     cd charliecloud
     if [[ -z $CH_VERSION ]]; then
       CH_VERSION=$(git tag --sort=-version:refname --format='%(refname:strip=2)' | head -n 1)
-    fi
+    echo "Checking out charliecloud-$CH_VERSION"
     git checkout $CH_VERSION
-
     make
     sudo make install PREFIX=/usr/local
     which ch-run

--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -182,9 +182,11 @@ EOF2
     git clone --recursive https://github.com/hpc/charliecloud.git
 
     cd charliecloud
-    if [[ $CH_VERSION ]]; then
-      git checkout $CH_VERSION
+    if [[ -z $CH_VERSION ]]; then
+      CH_VERSION=$(git tag --sort=-version:refname --format='%(refname:strip=2)' | head -n 1)
     fi
+    git checkout $CH_VERSION
+
     make
     sudo make install PREFIX=/usr/local
     which ch-run

--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -185,7 +185,7 @@ EOF2
     if [[ -z $CH_VERSION ]]; then
       CH_VERSION=$(git tag --sort=-version:refname --format='%(refname:strip=2)' | head -n 1)
     fi
-    echo "Checking out charliecloud-$CH_VERSION"
+    echo "checking out Charliecloud: $CH_VERSION"
     git checkout $CH_VERSION
     make
     sudo make install PREFIX=/usr/local

--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -84,7 +84,7 @@ Vagrant.configure("2") do |c|
     yum -y install git2u
 
     # Optional dependencies.
-    yum -y install pigz pv python36
+    yum -y install bats pigz pv python36
 
     # Add /usr/local/{bin,sbin} to $PATH.
     echo 'export PATH=/usr/local/sbin:/usr/local/bin:$PATH' > /etc/profile.d/path.sh


### PR DESCRIPTION
This PR addresses #511. It updates the default `vagrant up` behavior so that it uses the newest tagged version of charliecloud and updates the documentation to reflect that. 