### PR TITLE
freshen Spack example

### DIFF
--- a/examples/serial/spack/Dockerfile
+++ b/examples/serial/spack/Dockerfile
@@ -6,32 +6,49 @@ FROM debian9
 # test suite), and those don't make sense at run time. Thus, most of what we
 # care about is here in the Dockerfile, and test.bats just has a few
 # trivialities.
+#
+# Spack does document use in Docker [2]. We do things somewhat differently,
+# but worth reviewing those docs.
+#
+# [1]: https://spack.readthedocs.io/en/latest/getting_started.html
+# [2]: https://spack.readthedocs.io/en/latest/workflows.html#using-spack-to-create-docker-images
 
-# Spack needs curl, git, make, and unzip to install.
-# The other packages are needed for Spack unit tests.
+# Packages needed to install Spack [1].
+#
+# Note: Spack claims that Python 3 works, but using python3 here fails later
+# with "/usr/bin/env: 'python': No such file or directory".
 RUN apt-get install -y \
-    curl \
-    g++ \
-    git \
-    make \
-    patch \
-    procps \
     python \
-    python-pkg-resources \
+    gcc \
+    make \
+    git \
+    curl
+
+# Packages needed to install Charliecloud with Spack. These are in Spack's
+# Docker example [2] but are not documented as prerequisites [1].
+RUN apt-get install -y \
+    g++ \
     unzip
 
 # Certain Spack packages (e.g., tar) puke if they detect themselves being
-# configured as UID 0. This is the override. See issue #540.
+# configured as UID 0. This is the override. See issue #540 and [2].
 ARG FORCE_UNSAFE_CONFIGURE=1
 
 # Install Spack. This follows the documented procedure to run it out of the
 # source directory. There apparently is no "make install" type operation to
 # place it at a standard path ("spack clone" simply clones another working
 # directory to a new path).
+#
+# Spack does have releases, but they seem pretty stale. As of 2019-09-12, the
+# most recent version is 0.12.1 dated 8 months ago, 2019-01-13; there have
+# been hundreds if not thousands of commits on the default branch "develop"
+# since then. We follow develop for this reason and also to catch problems
+# installing Charliecloud with latest Spack.
 ENV SPACK_REPO https://github.com/spack/spack
-ENV SPACK_VERSION 0.11.2
-RUN git clone --depth 1 $SPACK_REPO
+#ENV SPACK_VERSION 0.12.1
 #RUN git clone --branch v$SPACK_VERSION --depth 1 $SPACK_REPO
+RUN git clone --depth 1 $SPACK_REPO
+RUN cd spack && git status && git rev-parse --short HEAD
 
 # Set up environment to use Spack. (We can't use setup-env.sh because the
 # Dockerfile shell is sh, not Bash.)
@@ -47,13 +64,17 @@ RUN spack compiler list --scope=user
 RUN spack compilers
 RUN spack spec netcdf
 
-# Test: Install a small package.
-RUN spack spec charliecloud
-RUN spack install charliecloud
+# Test: Install Charliecloud.
+RUN spack spec charliecloud+builder
+RUN spack install charliecloud+builder
 
-# Test: Run Spack test suite.
-# FIXME: Commented out because the suite fails. It's inconsistent; the number
-# of failures seems to vary between about 1 and 3 inclusive.
+# Test: Run Spack test suite. Distro package dependencies discovered by trial
+# and error.
+#
+# FIXME: Commented out because the suite fails. Last time I tried, 6 tests
+# failed and 1 "xfailed".
+#RUN apt-get install -y \
+#    python-pkg-resources
 #RUN spack test
 
 # Clean up.


### PR DESCRIPTION
I went into this expecting a version bump along with the freshening, but it turned out that we were already using branch `develop`; it just wasn't clear. So it's a freshening and cleanup of the Spack image.

Currently this build fails because Charliecloud can't be installed:

```
==> Building go-md2man [Package]
==> Executing phase: 'install'
==> Error: ProcessError: Command exited with status 1:
    '/spack/opt/spack/linux-debian9-x86_64/gcc-6.3.0/go-1.13-2a6a7mp2ebwfihplu3jmnq325osjokya/bin/go' 'build' '-v' 'github.com/cpuguy83/go-md2man'
```

But, I think it's still worth getting feedback, especially if someone can fix the Spack problem.