### PR TITLE
Update UCX to 1.6.1 and enable multithreading

### DIFF
--- a/test/Dockerfile.openmpi
+++ b/test/Dockerfile.openmpi
@@ -116,12 +116,12 @@ RUN for i in ibacm \
 RUN dpkg --install *.deb
 
 # UCX. There is stuff to build Debian packages, but it seems not too polished.
-ENV UCX_VERSION 1.3.1
+ENV UCX_VERSION 1.6.1
 RUN git clone --branch v${UCX_VERSION} --depth 1 \
               https://github.com/openucx/ucx.git
 RUN    cd ucx \
     && ./autogen.sh \
-    && ./contrib/configure-release --prefix=/usr/local \
+    && ./contrib/configure-release-mt --prefix=/usr/local \
     && make -j$(getconf _NPROCESSORS_ONLN) install
 
 # OpenMPI.


### PR DESCRIPTION
This addresses #518 . This also enables mulithreading support for UCX which I believe we should do unless it causes issues in build/testing, something I did not see. The UCX folks test multi-threaded UCX+MPI as part of their regular tests so I believe this should stable. I tested this PR on the platforms I thought would be impacted (Cray/CTS/ARM).