### PR TITLE
Add OpenMPI to ch-fromhost --cray-mpi usage information

### DIFF
--- a/bin/ch-fromhost
+++ b/bin/ch-fromhost
@@ -55,7 +55,7 @@ Which files to inject (one or more required; can be repeated):
   -c, --cmd CMD    listed in the stdout of CMD
   -f, --file FILE  listed in file FILE
   -p, --path PATH  inject the file at PATH
-  --cray-mpi       Cray-enable an MPICH installed within the image
+  --cray-mpi       Cray-enable MPICH/OpenMPI installed within the image
   --nvidia         recommended by nVidia (via "nvidia-container-cli list")
 
 Destination within image:


### PR DESCRIPTION
Realized today the help for ch-fromhost doesn't mention it works with OpenMPI. This should also be in the documentation. I can add it to the documentation now, or I can wait for that part until after the documentation refresh.