### PR TITLE
Update spark

### DIFF
--- a/examples/other/spark/Dockerfile
+++ b/examples/other/spark/Dockerfile
@@ -9,10 +9,15 @@ RUN    apt-get update \
 # We want ch-ssh
 RUN touch /usr/bin/ch-ssh
 
-# Download and install Spark.
-# We aren't using SPARK_NO_DAEMONIZE to make sure can deakwith daemonized spark. 
-# Spark is installed to /opt/spark which is spark's new default location
-# We disapprove of spark's master/slave terminology, but it's what the scripts are called
+# Download and install Spark. Notes:
+#
+# 1. We aren't using SPARK_NO_DAEMONIZE to make sure can deal with daemonized
+#    applications.
+#
+# 2. Spark is installed to /opt/spark, which is Spark's new default location.
+#
+# 3. We disapprove of Spark's master/slave terminology, but it's what the
+#    scripts are called, so we don't see a way to avoid it currently.
 
 ENV URLPATH https://www.apache.org/dist/spark/spark-2.4.4/
 ENV DIR spark-2.4.4-bin-hadoop2.7

--- a/examples/other/spark/Dockerfile
+++ b/examples/other/spark/Dockerfile
@@ -11,20 +11,14 @@ RUN touch /usr/bin/ch-ssh
 
 # Download and install Spark.
 #
-# We're staying on Spark 2.0 because 2.1.0 introduces Hive for metadata
-# handling somehow [1]. Data for this goes in $CWD by default, which is / and
-# not writeable in Charliecloud containers. So you get thousands of lines of
-# stack trace from pyspark. Workarounds exist, including cd to /tmp first or
-# configure hive-site.xml [2], but I'm not willing to put up with that crap
-# for demo purposes. Maybe it will be fixed in a 2.1 point release.
-#
-# [1]: http://sparhttp://d3kbcqa49mib13.cloudfront.netk.apache.org/docs/latest/sql-programming-guide.html#upgrading-from-spark-sql-20-to-21
-# [2]: https://community.cloudera.com/t5/Advanced-Analytics-Apache-Spark/Spark-displays-SQLException-when-Hive-not-installed/td-p/37954
+# Updated to spark-2.4.4
+
 ENV URLPATH https://www.apache.org/dist/spark/spark-2.4.4/
 ENV DIR spark-2.4.4-bin-hadoop2.7
 ENV TAR $DIR.tgz
+# [2]: https://community.cloudera.com/t5/Advanced-Analytics-Apache-Spark/Spark-displays-SQLException-when-Hive-not-installed/td-p/37954
 RUN wget -nv $URLPATH/$TAR
-RUN tar xf $TAR && mv $DIR spark && rm $TAR
+RUN tar xf $TAR && mv $DIR /opt/spark && rm $TAR
 
 # Very basic default configuration, to make it run and not do anything stupid.
 RUN printf '\
@@ -32,8 +26,8 @@ SPARK_LOCAL_IP=127.0.0.1\n\
 SPARK_LOCAL_DIRS=/tmp\n\
 SPARK_LOG_DIR=/tmp\n\
 SPARK_WORKER_DIR=/tmp\n\
-' > /spark/conf/spark-env.sh
+' > /opt/spark/conf/spark-env.sh
 
 # Move config to /mnt/0 so we can provide a different config if we want
-RUN    mv /spark/conf /mnt/0 \
-    && ln -s /mnt/0 /spark/conf
+RUN    mv /opt/spark/conf /mnt/0 \
+    && ln -s /mnt/0 /opt/spark/conf

--- a/examples/other/spark/Dockerfile
+++ b/examples/other/spark/Dockerfile
@@ -18,10 +18,10 @@ RUN touch /usr/bin/ch-ssh
 # configure hive-site.xml [2], but I'm not willing to put up with that crap
 # for demo purposes. Maybe it will be fixed in a 2.1 point release.
 #
-# [1]: http://spark.apache.org/docs/latest/sql-programming-guide.html#upgrading-from-spark-sql-20-to-21
+# [1]: http://sparhttp://d3kbcqa49mib13.cloudfront.netk.apache.org/docs/latest/sql-programming-guide.html#upgrading-from-spark-sql-20-to-21
 # [2]: https://community.cloudera.com/t5/Advanced-Analytics-Apache-Spark/Spark-displays-SQLException-when-Hive-not-installed/td-p/37954
-ENV URLPATH http://d3kbcqa49mib13.cloudfront.net
-ENV DIR spark-2.0.2-bin-hadoop2.7
+ENV URLPATH https://www.apache.org/dist/spark/spark-2.4.4/
+ENV DIR spark-2.4.4-bin-hadoop2.7
 ENV TAR $DIR.tgz
 RUN wget -nv $URLPATH/$TAR
 RUN tar xf $TAR && mv $DIR spark && rm $TAR

--- a/examples/other/spark/Dockerfile
+++ b/examples/other/spark/Dockerfile
@@ -10,13 +10,13 @@ RUN    apt-get update \
 RUN touch /usr/bin/ch-ssh
 
 # Download and install Spark.
-#
-# Updated to spark-2.4.4
+# We aren't using SPARK_NO_DAEMONIZE to make sure can deakwith daemonized spark. 
+# Spark is installed to /opt/spark which is spark's new default location
+# We disapprove of spark's master/slave terminology, but it's what the scripts are called
 
 ENV URLPATH https://www.apache.org/dist/spark/spark-2.4.4/
 ENV DIR spark-2.4.4-bin-hadoop2.7
 ENV TAR $DIR.tgz
-# [2]: https://community.cloudera.com/t5/Advanced-Analytics-Apache-Spark/Spark-displays-SQLException-when-Hive-not-installed/td-p/37954
 RUN wget -nv $URLPATH/$TAR
 RUN tar xf $TAR && mv $DIR /opt/spark && rm $TAR
 

--- a/examples/other/spark/test.bats
+++ b/examples/other/spark/test.bats
@@ -68,7 +68,6 @@ EOF
     # remove old master logs so new one has predictable name
     rm -Rf --one-file-system "$spark_log"
     # start the master
-    ls -lh /opt/spark/sbin/start-master.sh
     ch-run -b "$spark_config" "$ch_img" -- /opt/spark/sbin/start-master.sh
     sleep 7
     # shellcheck disable=SC2086

--- a/examples/other/spark/test.bats
+++ b/examples/other/spark/test.bats
@@ -68,7 +68,8 @@ EOF
     # remove old master logs so new one has predictable name
     rm -Rf --one-file-system "$spark_log"
     # start the master
-    ch-run -b "$spark_config" "$ch_img" -- /spark/sbin/start-master.sh
+    ls -lh /opt/spark/sbin/start-master.sh
+    ch-run -b "$spark_config" "$ch_img" -- /opt/spark/sbin/start-master.sh
     sleep 7
     # shellcheck disable=SC2086
     cat $master_log
@@ -77,7 +78,7 @@ EOF
     # start the workers
     # shellcheck disable=SC2086
     $pernode ch-run -b "$spark_config" "$ch_img" -- \
-                    /spark/sbin/start-slave.sh "$master_url"
+                    /opt/spark/sbin/start-slave.sh "$master_url"
     sleep 7
 }
 
@@ -97,8 +98,8 @@ EOF
 
 @test "${ch_tag}/pi" {
     run ch-run -b "$spark_config" "$ch_img" -- \
-               /spark/bin/spark-submit --master "$master_url" \
-               /spark/examples/src/main/python/pi.py 64
+               /opt/spark/bin/spark-submit --master "$master_url" \
+               /opt/spark/examples/src/main/python/pi.py 64
     echo "$output"
     [[ $status -eq 0 ]]
     # This computation converges quite slowly, so we only ask for two correct
@@ -107,8 +108,8 @@ EOF
 }
 
 @test "${ch_tag}/stop" {
-    $pernode ch-run -b "$spark_config" "$ch_img" -- /spark/sbin/stop-slave.sh
-    ch-run -b "$spark_config" "$ch_img" -- /spark/sbin/stop-master.sh
+    $pernode ch-run -b "$spark_config" "$ch_img" -- /opt/spark/sbin/stop-slave.sh
+    ch-run -b "$spark_config" "$ch_img" -- /opt/spark/sbin/stop-master.sh
     sleep 2
     # Any Spark processes left?
     # (Use egrep instead of fgrep so we don't match the grep process.)


### PR DESCRIPTION
Addresses #232. 

Updated the example to Spark 2.4.4. This ended up being much, much easier than it had been for Spark 2.1.0. The primary difference appears to be that the spark scripts now assume spark is installed in `/opt`.  I replaced the cloudfront link with an Apache link because the cloudfront mirror does not appear to have the most recent version. 

