### PR TITLE
add docker requirement for docker pull tests

### DIFF
--- a/test/Build.ch-pull2dir
+++ b/test/Build.ch-pull2dir
@@ -1,5 +1,9 @@
 #!/bin/bash
 # ch-test-scope: standard
+# ch-test-builder-exclude: buildah
+# ch-test-builder-exclude: buildah-runc
+# ch-test-builder-exclude: buildah-setuid
+# ch-test-builder-exclude: ch-grow
 
 # Generate image directory using ch-pull2dir and stage it for testing.
 

--- a/test/Build.ch-pull2tar
+++ b/test/Build.ch-pull2tar
@@ -1,5 +1,9 @@
 #!/bin/bash
 # ch-test-scope: standard
+# ch-test-builder-exclude: buildah
+# ch-test-builder-exclude: buildah-runc
+# ch-test-builder-exclude: buildah-setuid
+# ch-test-builder-exclude: ch-grow
 
 # Generate a flattened image tarball using ch-pull2tar and stage it for
 # testing.


### PR DESCRIPTION
Require docker for the `Build.ch-pull2[dir|tar]` logic.