### PR TITLE
make docs build with old Sphinx

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -127,11 +127,50 @@ AC_DEFUN([CH_CHECK_VERSION], [
 AC_CHECK_FUNCS(asprintf, [], [
   AC_MSG_ERROR([asprintf() not found. Please report this bug.])])
 
-vmin_sphinx=1.4.9
+# Sphinx
+vmin_sphinx=1.2.3
 AX_WITH_PROG([SPHINX], [sphinx-build])
 AC_SUBST([SPHINX])
 CH_CHECK_VERSION([SPHINX], [$vmin_sphinx],
                  [--version | sed -E 's/sphinx-build //'])
+
+# Get the Sphinx Python
+AS_IF([test -n "$SPHINX"], [
+  AC_MSG_CHECKING([for sphinx-build Python])
+  sphinx_python=$(head -1 "$SPHINX" | sed -E 's/^..//')
+  AC_MSG_RESULT([$sphinx_python])
+])
+
+# "docutils" module
+vmin_docutils=0.14
+docutils=$sphinx_python  # FIXME: output is confusing
+AS_IF([test -n "$SPHINX"], [
+  # Sphinx requires docutils, so don't verify it's there.
+  CH_CHECK_VERSION([docutils], [$vmin_docutils],
+                   [-c 'import docutils; print(docutils.__version__)'])
+])
+
+# "sphinx-rtd-theme" module
+vmin_rtd=0.2.4
+rtd=$sphinx_python  # FIXME: output is confusing
+AS_IF([test -n "$SPHINX"], [
+  AC_MSG_CHECKING([for sphinx_rtd_theme module])
+  cat <<EOF | $sphinx_python
+import sys
+try:
+   import sphinx_rtd_theme
+except ImportError:
+   sys.exit(1)
+EOF
+  AS_IF([test $? -eq 0],
+    [have_rtd=yes],
+    [have_rtd=no])
+  AC_MSG_RESULT([$have_rtd])
+  AS_IF([test $have_rtd = yes], [
+    CH_CHECK_VERSION([rtd], [$vmin_rtd],
+      [-c 'import sphinx_rtd_theme; print(sphinx_rtd_theme.__version__)'])
+  ])
+])
 
 
 ## Feature tests - run time
@@ -262,11 +301,17 @@ CH_CHECK_VERSION([WGET], [$vmin_wget], [--version | head -1 | cut -d' ' -f3])
 
 ## Adjust build options given what we have available.
 
-AS_IF([test "$enable_html" = yes && test -z "$SPHINX"],
+AS_IF([   test -n "$SPHINX" \
+       && test -n "$docutils" \
+       && test -n "$rtd"],
+       [have_docs=yes],
+       [have_docs=no])
+
+AS_IF([test $enable_html = yes && test $have_docs = no],
       [AC_MSG_WARN([forcing --disable-html: no suitable sphinx-build])
        enable_html=no])
 
-AS_IF([test "$enable_man" = yes && test -z "$SPHINX"],
+AS_IF([test $enable_man = yes && test $have_docs = no],
       [AC_MSG_WARN([forcing --disable-man: no suitable sphinx-build])
        enable_man=no])
 
@@ -278,7 +323,7 @@ AM_CONDITIONAL([ENABLE_TEST], [test $enable_test = yes])
 AM_CONDITIONAL([ENABLE_CH_GROW], [test $enable_ch_grow = yes])
 
 
-## Prepare run-time report.
+## Prepare report.
 
 # FIXME: Should replace all these with macros?
 
@@ -402,8 +447,14 @@ thinks a version is too old, and please report back to us.
 Building Charliecloud
 ~~~~~~~~~~~~~~~~~~~~~
 
+  required:
     C99 compiler ... ${CC} ${CC_VERSION}
+
+  documentation: ${have_docs}
     sphinx-build(1) $vmin_sphinx ... ${SPHINX:-not found} ${SPHINX_VERSION}
+    sphinx-build(1) Python ... ${sphinx_python:-n/a}
+    "docutils" module $vmin_docutils ... ${docutils_VERSION:-not found}
+    "sphinx-rtd-theme" module $vmin_rtd ... ${rtd_VERSION:-not found}
 
   will build and install:
     HTML documentation ... ${enable_html}
@@ -488,6 +539,6 @@ Test suite
 
   complete test suite: ${have_tests_all}
     recommended tests with SquashFS ... ${have_tests_squash}
-    sphinx-build(1) $vmin_sphinx ... ${SPHINX_VERSION:-not found}
+    documentation ... ${have_docs}
     generic sudo ... assumed yes
 ])

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -141,13 +141,13 @@ html-local: mkdir_issue115 ../libexec/version.txt _deps.rst
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 # remove unused files that Sphinx made
 	rm -R $(BUILDDIR)/html/_sources
-	rm $(BUILDDIR)/html/_deps.html
-	rm $(BUILDDIR)/html/charliecloud.html
-	rm $(BUILDDIR)/html/ch-*.html
-	rm $(BUILDDIR)/html/bugs.html
-	rm $(BUILDDIR)/html/objects.inv
-	rm $(BUILDDIR)/html/search.html
-	rm $(BUILDDIR)/html/see_also.html
+	rm -f $(BUILDDIR)/html/_deps.html \
+	      $(BUILDDIR)/html/charliecloud.html \
+	      $(BUILDDIR)/html/ch-*.html \
+	      $(BUILDDIR)/html/bugs.html \
+	      $(BUILDDIR)/html/objects.inv \
+	      $(BUILDDIR)/html/search.html \
+	      $(BUILDDIR)/html/see_also.html
 
 # FIXME: If Sphinx builds the man pages first, the HTML docs don't get curly
 # quotes. ¯\_(ツ)_/¯ Force HTML to go first.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,7 @@ import sys, os
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.4.9'
+#needs_sphinx = '1.4.9'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -65,7 +65,15 @@ today_fmt = '%Y-%m-%d %H:%M %Z'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["charliecloud", "doctrees", "examples", "html", "man"]
+exclude_patterns = ["doctrees", "html", "man"]
+
+# FIXME: Workaround for older Sphinx that barf with:
+#
+#   WARNING: document isn't included in any toctree
+#
+# on files included via ".. include::'. I believe this was fixed in 1.4.3 and
+# the relevant issue is: https://github.com/sphinx-doc/sphinx/issues/2603
+exclude_patterns += ["*_desc.rst", "_deps.rst", "bugs.rst", "see_also.rst"]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None
@@ -93,6 +101,15 @@ exclude_patterns = ["charliecloud", "doctrees", "examples", "html", "man"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'sphinx_rtd_theme'
+
+# FIXME: Workaround for older versions of Sphinx. This is not needed in 1.8.5,
+# but it is needed in 1.2.3. I don't know where the boundary is. We embed it
+# in try/except so that "docs-sane" can import the file too.
+try:
+   import sphinx_rtd_theme
+   html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+except ImportError:
+   pass  # error caught elsewhere
 
 highlight_language = 'console'
 

--- a/doc/dev.rst
+++ b/doc/dev.rst
@@ -953,7 +953,6 @@ throwing an error. The :code:`ch-run-oci` man page documents comprehensively
 what OCI features are and are not supported.
 
 .. code-block:: javascript
-   :dedent: 0
 
    {
      "ociVersion": "1.0.0",
@@ -961,7 +960,6 @@ what OCI features are and are not supported.
 We validate that this is "1.0.0".
 
 .. code-block:: javascript
-   :dedent: 0
 
      "root": {
        "path": "/tmp/buildah115496812/mnt/rootfs"
@@ -971,7 +969,6 @@ Path to root filesystem; maps to :code:`NEWROOT`. If key :code:`readonly` is
 :code:`false` or absent, add :code:`--write`.
 
 .. code-block:: javascript
-   :dedent: 0
 
      "mounts": [
        {
@@ -1078,7 +1075,6 @@ Therefore, for now we just ignore mounts.
 We do add :code:`--no-home` in OCI mode.
 
 .. code-block:: javascript
-   :dedent: 0
 
      "process": {
        "terminal": true,
@@ -1091,14 +1087,12 @@ its standard input from :code:`/dev/null`, which is the current workaround.
 Things work fine.
 
 .. code-block:: javascript
-   :dedent: 0
 
        "cwd": "/",
 
 Maps to :code:`--cd`.
 
 .. code-block:: javascript
-   :dedent: 0
 
        "args": [
          "/bin/sh",
@@ -1110,7 +1104,6 @@ Maps to :code:`CMD [ARG ...]`. Note that we do not run :code:`ch-run` via the
 shell, so there aren't worries about shell parsing.
 
 .. code-block:: javascript
-   :dedent: 0
 
        "env": [
          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
@@ -1130,7 +1123,6 @@ We treat it as a complete environment, i.e., place the variables in a file and
 then :code:`--unset-env='*' --set-env=FILE`.
 
 .. code-block:: javascript
-   :dedent: 0
 
        "rlimits": [
          {
@@ -1143,7 +1135,6 @@ then :code:`--unset-env='*' --set-env=FILE`.
 Process limits Buildah wants us to set with :code:`setrlimit(2)`. Ignored.
 
 .. code-block:: javascript
-   :dedent: 0
 
        "capabilities": {
          ...
@@ -1153,7 +1144,6 @@ Long list of capabilities that Buildah wants. Ignored. (Charliecloud provides
 security by remaining an unprivileged process.)
 
 .. code-block:: javascript
-   :dedent: 0
 
        "user": {
          "uid": 0,
@@ -1164,7 +1154,6 @@ security by remaining an unprivileged process.)
 Maps to :code:`--uid=0 --gid=0`.
 
 .. code-block:: javascript
-   :dedent: 0
 
      "linux": {
        "namespaces": [
@@ -1185,7 +1174,6 @@ Maps to :code:`--uid=0 --gid=0`.
 Namespaces that Buildah wants. Ignored; Charliecloud just does user and mount.
 
 .. code-block:: javascript
-   :dedent: 0
 
        "uidMappings": [
          {
@@ -1217,7 +1205,6 @@ much larger than Charliecloud's single entry and asks for container root to be
 host root, which we can't do. Ignored.
 
 .. code-block:: javascript
-   :dedent: 0
 
        "maskedPaths": [
          "/proc/acpi",
@@ -1235,7 +1222,6 @@ Spec says to "mask over the provided paths ... so they cannot be read" and
 protects us.)
 
 .. code-block:: javascript
-   :dedent: 0
 
      }
    }


### PR DESCRIPTION
Addresses #565.

I tested this using the highest versions of Sphinx (1.2.3), docutils (0.14), and sphinx-rtd-theme (0.2.4) available in EPEL7, but installed using `pip3`. I have not tried it on actual CentOS or RHEL; can you please test that?

The number of changes to the `.rst` file was surprisingly small, but the results look OK.