### PR TITLE
ch-test: add pedantic mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ a.out
 /doc/html/
 /doc/man/*.1
 /libexec/charliecloud
+/libexec/contributors.bash
 /libexec/version.py
 /libexec/version.sh
 /libexec/version.txt

--- a/bin/ch-test
+++ b/bin/ch-test
@@ -160,7 +160,7 @@ pedantry_set () {
     if [[ -n $ch_contributor || -n $TRAVIS ]]; then
         default=yes
     fi
-    vset ch_pedantic "$pedantic" '' $default $width 'pedantic mode'
+    vset ch_pedantic "$pedantic" '' $default "$width" 'pedantic mode'
     if [[ $ch_pedantic == no ]]; then
         ch_pedantic=  # proper boolean
     fi
@@ -415,8 +415,8 @@ fi
 # but it works at Los Alamos, where the team is based.)
 email="$USER@$(hostname --domain)"
 ch_contributor=
-for i in ${ch_contributors[@]}; do
-    if [[ $i == $email ]]; then
+for i in "${ch_contributors[@]}"; do
+    if [[ $i == "$email" ]]; then
         ch_contributor=yes
     fi
 done
@@ -504,7 +504,7 @@ vset CH_TEST_SCOPE    "$scope"         "$CH_TEST_SCOPE"    standard \
                       21 'scope'
 builder_set 21
 pedantry_set 21
-vset CH_TEST_SUDO     "$use_sudo"      "$CH_TEST_SUDO"     $use_sudo_default \
+vset CH_TEST_SUDO     "$use_sudo"      "$CH_TEST_SUDO"     "$use_sudo_default" \
                       21 'use generic sudo'
 vset CH_TEST_IMGDIR   "$imgdir"        "$CH_TEST_IMGDIR"   /var/tmp/img \
                       21 'unpacked images dir'

--- a/bin/ch-test
+++ b/bin/ch-test
@@ -13,6 +13,7 @@ if [[ ! -f ${libexec}/base.sh ]]; then
     fatal "install or build problem: not found: ${libexec}/base.sh"
 fi
 . "${libexec}/base.sh"
+. "${libexec}/contributors.bash"
 
 export ch_bin
 
@@ -150,6 +151,33 @@ dirs_unpriv_rm () {
     rm -rf --one-file-system "$CH_TEST_TARDIR"
     echo "removing $CH_TEST_IMGDIR"
     rm -rf --one-file-system "$CH_TEST_IMGDIR"
+}
+
+pedantry_set () {
+    width=$1
+    default=no
+    # Default to pedantic on CI or if user is a contributor.
+    if [[ -n $ch_contributor || -n $TRAVIS ]]; then
+        default=yes
+    fi
+    vset ch_pedantic "$pedantic" '' $default $width 'pedantic mode'
+    if [[ $ch_pedantic == no ]]; then
+        ch_pedantic=  # proper boolean
+    fi
+    # The motivation here is that in pedantic mode, we want to run all the
+    # tests we reasonably can. So, if the user *has* sudo, then default --sudo
+    # to yes. What is a little awkward is that "sudo -v" can generate a
+    # password prompt in the middle of the status output. An alternative is
+    # "sudo -nv", which doesn't; drawbacks are that you have to analyze the
+    # output (not exit code) and it generates a failed password log message if
+    # there is not already a sudo session going.
+    if    [[ -n $ch_pedantic ]] \
+       && (command -v sudo > /dev/null) \
+       && (sudo -v > /dev/null 2>&1); then
+        use_sudo_default=yes
+    else
+        use_sudo_default=
+    fi
 }
 
 require_unset () {
@@ -383,6 +411,16 @@ if [[ ! -d $CHTEST_EXAMPLES_DIR ]]; then
     fatal "examples not found: $CHTEST_EXAMPLES_DIR"
 fi
 
+# Is the user a contributor? (Obtaining an e-mail address this way is flaky,
+# but it works at Los Alamos, where the team is based.)
+email="$USER@$(hostname --domain)"
+ch_contributor=
+for i in ${ch_contributors[@]}; do
+    if [[ $i == $email ]]; then
+        ch_contributor=yes
+    fi
+done
+
 # Ensure Bats is installed.
 if (command -v bats &> /dev/null); then
     bats=$(command -v bats)
@@ -417,6 +455,9 @@ while [[ $# -gt 0 ]]; do
         require_unset tardir
         tardir=$1; shift
         ;;
+    --pedantic)
+        pedantic=$1; shift
+        ;;
     --perm-dir)
         use_sudo=yes
         permdirs+=("$1"); shift
@@ -438,10 +479,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-printf "ch-test version %s\n\n" "$ch_version"
-printf 'ch-run: %s\n' "${ch_bin}/ch-run"
-printf 'bats:   %s (%s)\n' "$bats" "$bats_version"
-printf 'tests:  %s\n\n' "$CHTEST_DIR"
+printf "ch-test version %s\n" "$ch_version"
+printf '\n'
+printf 'ch-run:       %s\n' "${ch_bin}/ch-run"
+printf 'bats:         %s (%s)\n' "$bats" "$bats_version"
+printf 'tests:        %s\n' "$CHTEST_DIR"
+if [[ -n $ch_contributor ]]; then
+    ch_contributor_note="yes; $email in README.rst"
+else
+    ch_contributor_note="no; $email not in README.rst"
+fi
+printf 'contributor:  %s\n\n' "$ch_contributor_note"
 
 printf "%-21s %s" 'phase:' "$phase"
 if [[ -z $phase ]]; then
@@ -455,7 +503,8 @@ printf '\n'
 vset CH_TEST_SCOPE    "$scope"         "$CH_TEST_SCOPE"    standard \
                       21 'scope'
 builder_set 21
-vset CH_TEST_SUDO     "$use_sudo"      "$CH_TEST_SUDO"     '' \
+pedantry_set 21
+vset CH_TEST_SUDO     "$use_sudo"      "$CH_TEST_SUDO"     $use_sudo_default \
                       21 'use generic sudo'
 vset CH_TEST_IMGDIR   "$imgdir"        "$CH_TEST_IMGDIR"   /var/tmp/img \
                       21 'unpacked images dir'
@@ -465,7 +514,7 @@ vset CH_TEST_PERMDIRS "${permdirs[*]}" "$CH_TEST_PERMDIRS" skip \
                       21 'fs permissions dirs'
 printf '\n'
 
-if [[ $phase == *'perm'* ]] && [[ ${CH_TEST_PERMDIRS[*]} == skip ]]; then
+if [[ $phase == *'perm'* ]] && [[ $CH_TEST_PERMDIRS == skip ]]; then
     fatal "phase $phase: CH_TEST_PERMDIRS: can't be 'skip'"
 fi
 

--- a/bin/ch-test
+++ b/bin/ch-test
@@ -390,16 +390,23 @@ fi
 if [[ -d ${ch_base}/share ]]; then
     # installed
     CHTEST_INSTALLED=yes
+    CHTEST_GITWD=
     CHTEST_DIR=${ch_base}/libexec/charliecloud/test
     CHTEST_EXAMPLES_DIR=${ch_base}/share/doc/charliecloud/examples
 else
     # build dir
     CHTEST_INSTALLED=
+    if [[ -d ${ch_base}/.git ]]; then
+        CHTEST_GITWD=yes
+    else
+        CHTEST_GITWD=
+    fi
     CHTEST_DIR=${ch_base}/test
     CHTEST_EXAMPLES_DIR=${ch_base}/examples
 fi
 export ch_base
 export CHTEST_INSTALLED
+export CHTEST_GITWD
 export CHTEST_DIR
 export CHTEST_EXAMPLES_DIR
 
@@ -411,9 +418,16 @@ if [[ ! -d $CHTEST_EXAMPLES_DIR ]]; then
     fatal "examples not found: $CHTEST_EXAMPLES_DIR"
 fi
 
-# Is the user a contributor? (Obtaining an e-mail address this way is flaky,
-# but it works at Los Alamos, where the team is based.)
-email="$USER@$(hostname --domain)"
+# Is the user a contributor?
+email=
+# First, ask Git for the configured e-mail address.
+if ( command -v git > /dev/null 2>&1 ); then
+    email="$(git config --get user.email)"
+fi
+# If that doesn't work, construct it from the environment.
+if [[ -z $email ]]; then
+    email="$USER@$(hostname --domain)"
+fi
 ch_contributor=
 for i in "${ch_contributors[@]}"; do
     if [[ $i == "$email" ]]; then
@@ -484,6 +498,8 @@ printf '\n'
 printf 'ch-run:       %s\n' "${ch_bin}/ch-run"
 printf 'bats:         %s (%s)\n' "$bats" "$bats_version"
 printf 'tests:        %s\n' "$CHTEST_DIR"
+printf 'installed:    %s\n' "${CHTEST_INSTALLED:-no}"
+printf 'git workdir:  %s\n' "${CHTEST_GITWD:-no}"
 if [[ -n $ch_contributor ]]; then
     ch_contributor_note="yes; $email in README.rst"
 else

--- a/doc/ch-test_desc.rst
+++ b/doc/ch-test_desc.rst
@@ -112,6 +112,15 @@ Additional arguments:
     Set packed images directory to :code:`DIR`. Default:
     :code:`$CH_TEST_TARDIR` if set; otherwise :code:`/var/tmp/pack`.
 
+  :code:`--pedantic (yes|no)`
+    Some tests require configurations that are very specific (e.g., being a
+    member of at least two groups) or unusual (e.g., sudo to a non-root
+    group). If :code:`yes`, then fail if the requirement is not met; if
+    :code:`no`, then skip. The default is :code:`yes` for CI environments or
+    people listed in :code:`README.md`, :code:`no` otherwise.
+
+    If :code:`yes` and sudo seems to be available, implies :code:`--sudo`.
+
   :code:`--perm-dir DIR`
     Add :code:`DIR` to filesystem permission fixture directories; can be
     specified multiple times. We recommend one such directory per mounted

--- a/examples/mpibench/test.bats
+++ b/examples/mpibench/test.bats
@@ -88,7 +88,7 @@ check_process_ct () {
     [[ $ch_cray ]] && skip "Cray doesn't support running on tcp"
     # Verify we have known HSN devices present. (Note that -d tests for
     # directory, not device.)
-    [[ ! -d /dev/infiniband ]] && skip "No high speed network detected"
+    [[ ! -d /dev/infiniband ]] && pedantic_fail "no high speed network detected"
     # shellcheck disable=SC2086
     hsn_enabled_bw=$($ch_mpirun_2_2node ch-run "$ch_img" -- \
                      "$imb_mpi1" $imb_perf_args Sendrecv | tail -n +35 \

--- a/examples/spark/test.bats
+++ b/examples/spark/test.bats
@@ -32,7 +32,7 @@ setup () {
                     | sed -r 's/^.+inet ([0-9.]+).+/\1/')
         # Start Spark workers using pdsh. We would really prefer to do this
         # using srun, but that doesn't work; see issue #230.
-        command -v pdsh >/dev/null 2>&1 || skip "pdsh not in path"
+        command -v pdsh >/dev/null 2>&1 || pedantic_fail "pdsh not in path"
         pernode="pdsh -R ssh -w ${SLURM_NODELIST} -- PATH='${PATH}'"
     else
         master_ip=127.0.0.1

--- a/libexec/Makefile.am
+++ b/libexec/Makefile.am
@@ -16,6 +16,7 @@ charliecloud:
 
 contributors.bash: ../README.rst
 	rm -f $@
+	printf '# shellcheck shell=bash\n' >> $@
 	printf 'declare -a ch_contributors\n' >> $@
 	sed -En 's/^\*.+<(.+@.+)>.*$$/ch_contributors+=('"'"'\1'"'"')/p' < $< >> $@
 

--- a/libexec/Makefile.am
+++ b/libexec/Makefile.am
@@ -5,7 +5,7 @@
 
 dist_pkglibexec_SCRIPTS = base.sh
 noinst_DATA = charliecloud
-pkglibexec_SCRIPTS = version.py version.sh version.txt
+pkglibexec_SCRIPTS = contributors.bash version.py version.sh version.txt
 
 CLEANFILES = $(pkglibexec_SCRIPTS) $(noinst_DATA)
 
@@ -13,6 +13,11 @@ CLEANFILES = $(pkglibexec_SCRIPTS) $(noinst_DATA)
 # installed or not.
 charliecloud:
 	ln -s . charliecloud
+
+contributors.bash: ../README.rst
+	rm -f $@
+	printf 'declare -a ch_contributors\n' >> $@
+	sed -En 's/^\*.+<(.+@.+)>.*$$/ch_contributors+=('"'"'\1'"'"')/p' < $< >> $@
 
 version.txt: ../configure
 	printf '@PACKAGE_VERSION@\n' > $@

--- a/test/build.bats
+++ b/test/build.bats
@@ -2,12 +2,14 @@ load common
 
 @test 'documentation seems sane' {
     scope standard
-    command -v sphinx-build > /dev/null 2>&1 || skip 'Sphinx is not installed'
+    if ( ! command -v sphinx-build > /dev/null 2>&1 ); then
+        pedantic_fail 'Sphinx is not installed'
+    fi
     if [[ ! -d ../doc ]]; then
         skip 'documentation source code absent'
     fi
     if [[ ! -f ../doc/html/index.html || ! -f ../doc/man/ch-run.1 ]]; then
-        skip 'documentation not all built'
+        skip 'documentation not built'
     fi
     (cd ../doc && make -j "$(getconf _NPROCESSORS_ONLN)")
     ./docs-sane
@@ -85,21 +87,9 @@ load common
     if [[ $CHTEST_INSTALLED ]]; then
         skip 'only in build directory'
     fi
-    # Are we on Travis or at LANL?
-    if [[ $TRAVIS || $(hostname --fqdn) = *'.lanl.gov' ]]; then
-        pedantic=yes
-    else
-        pedantic=
-    fi
     # ShellCheck present?
     if ( ! command -v shellcheck >/dev/null 2>&1 ); then
-        error='no shellcheck found'
-        if [[ $pedantic ]]; then
-             echo "$error"
-             false
-        else
-             skip "$error"
-        fi
+        pedantic_fail 'no ShellCheck found'
     fi
     # ShellCheck minimum version?
     version=$(shellcheck --version | grep -E '^version:' | cut -d' ' -f2)
@@ -109,14 +99,8 @@ load common
     echo "shellcheck: version '${version}', major '${major}', minor '${minor}'"
     minor_needed=6
     if [[ $minor -lt $minor_needed ]]; then
-        # no need to check major because minimum is 0
-        error="shellcheck ${version} older than 0.${minor_needed}.0"
-        if [[ $pedantic ]]; then
-            echo "$error"
-            false
-        else
-            skip "$error"
-        fi
+        # No need to check major because minimum is 0.
+        pedantic_fail "shellcheck ${version} older than 0.${minor_needed}.0"
     fi
     # Shell scripts and libraries: appropriate extension or shebang.
     # For awk program, see: https://unix.stackexchange.com/a/66099

--- a/test/build.bats
+++ b/test/build.bats
@@ -3,7 +3,7 @@ load common
 @test 'documentation seems sane' {
     scope standard
     if ( ! command -v sphinx-build > /dev/null 2>&1 ); then
-        pedantic_fail 'Sphinx is not installed'
+        skip 'Sphinx is not installed'
     fi
     if [[ ! -d ../doc ]]; then
         skip 'documentation source code absent'

--- a/test/common.bash
+++ b/test/common.bash
@@ -95,6 +95,16 @@ need_squashfs () {
     ( command -v squashfuse >/dev/null 2>&1 ) || skip "no squashfuse found"
 }
 
+pedantic_fail () {
+    msg=$1
+    if [[ -n $ch_pedantic ]]; then
+        echo "$msg" 1>&2
+        return 1
+    else
+        skip "$msg"
+    fi
+}
+
 prerequisites_ok () {
     if [[ -f $CH_TEST_TARDIR/${1}.pq_missing ]]; then
         skip 'build prerequisites not met'

--- a/test/run/build-rpms.bats
+++ b/test/run/build-rpms.bats
@@ -5,7 +5,9 @@ load ../common
     scope standard
     prerequisites_ok centos7
     [[ -d ../.git ]] || skip "not in Git working directory"
-    command -v sphinx-build > /dev/null 2>&1 || skip 'Sphinx is not installed'
+    if ( ! command -v sphinx-build > /dev/null 2>&1 ); then
+        pedantic_fail 'Sphinx is not installed'
+    fi
     img=${ch_imgdir}/centos7
 
     # Build and install RPMs into CentOS 7 image.

--- a/test/run/build-rpms.bats
+++ b/test/run/build-rpms.bats
@@ -4,7 +4,7 @@ load ../common
     skip 'issue #594'
     scope standard
     prerequisites_ok centos7
-    [[ -d ../.git ]] || skip "not in Git working directory"
+    [[ $CHTEST_GITWD ]] || skip "not in Git working directory"
     if ( ! command -v sphinx-build > /dev/null 2>&1 ); then
         pedantic_fail 'Sphinx is not installed'
     fi

--- a/test/run/ch-run_escalated.bats
+++ b/test/run/ch-run_escalated.bats
@@ -63,17 +63,11 @@ load ../common
 @test 'ch-run as root: root with non-zero gid refused' {
     scope standard
     [[ -n $ch_have_sudo ]] || skip 'sudo not available'
-    [[ -z $TRAVIS ]] || skip 'not permitted on Travis'
-    # Allowing sudo to user root but group non-root is an unusual
-    # configuration. You need e.g. "%foo ALL=(ALL:ALL)" instead of the more
-    # common "%foo ALL=(ALL)". Because this is a rather esoteric test, we want
-    # to skip in the common configuration but still be reliably tested.
-    # Because Travis doesn't do this, he best I could come up with is to
-    # insist the test run at LANL (and fail if sudo is not configured
-    # correctly). See issue #485.
-    if    ! (sudo -u root -g "$(id -gn)" true) \
-       && [[ $(hostname --fqdn) != *'.lanl.gov' ]]; then
-        skip "sudo not configured for user root and group non-root"
+    if ! (sudo -u root -g "$(id -gn)" true); then
+        # Allowing sudo to user root but group non-root is an unusual
+        # configuration. You need e.g. "%foo ALL=(ALL:ALL)" instead of the
+        # more common "%foo ALL=(ALL)". See issue #485.
+        pedantic_fail 'sudo not configured for user root and group non-root'
     fi
     run sudo -u root -g "$(id -gn)" "$ch_runfile" -v --version
     echo "$output"

--- a/test/run/ch-run_isolation.bats
+++ b/test/run/ch-run_isolation.bats
@@ -29,7 +29,7 @@ load ../common
     guest_expected='Alpine Linux v3.9'
     echo "guest expected: ${guest_expected}"
     if [[ $host_distro = "$guest_expected" ]]; then
-        skip 'host matches expected guest distro'
+        pedantic_fail 'host matches expected guest distro'
     fi
     guest_distro=$(ch-run "$ch_timg" -- \
                           cat /etc/os-release \

--- a/test/run/ch-run_uidgid.bats
+++ b/test/run/ch-run_uidgid.bats
@@ -138,6 +138,6 @@ setup () {
 
 @test 'signal process outside container' {
     # Send a signal to a process we shouldn't be able to signal.
-    [[ $(pgrep -c getty) -eq 0 ]] && skip 'no getty process found'
+    [[ $(pgrep -c getty) -eq 0 ]] && pedantic_fail 'no getty process found'
     ch-run $uid_args $gid_args "$ch_timg" -- /test/signal_out.py
 }

--- a/test/travis-install.bash
+++ b/test/travis-install.bash
@@ -9,6 +9,7 @@ sudo chmod 1777 /usr/local/src
 sudo rm /usr/local/bin/bats
 
 # Allow sudo to user root, group non-root.
+sudo sed -Ei 's/=\(ALL\)/=(ALL:ALL)/g' /etc/sudoers.d/travis
 sudo cat /etc/sudoers.d/travis
 
 # Install conditional packages.

--- a/test/travis-install.bash
+++ b/test/travis-install.bash
@@ -8,6 +8,9 @@ sudo chmod 1777 /usr/local/src
 # Remove Travis Bats. We need buggy version provided by Ubuntu (issue #552).
 sudo rm /usr/local/bin/bats
 
+# Allow sudo to user root, group non-root.
+sudo cat /etc/sudoers.d/travis
+
 # Install conditional packages.
 if [[ -z "$MINIMAL_DEPS" ]]; then
     sudo apt-get install pigz pv skopeo squashfuse


### PR DESCRIPTION
This PR adds an option `--pedantic` to `ch-test`. In pedantic mode, we try hard to run all the tests we can, and fail instead of skipping. Pedantic mode defaults to yes if the user is listed in `README.rst` or we are in a CI environment.

One thing we don't insist on is `CH_TEST_PERMDIRS != skip`. I'm not thrilled about this, but some contributors may not have root, and in order to be effective with permissions fixtures, you need root.