### PR TITLE
ch-test: accept long options with arg separated by equals

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -535,6 +535,7 @@ while [[ $# -gt 0 ]]; do
     --pack-dir=*)
         require_unset tardir
         tardir=${opt#*=}
+        ;;
     --pedantic)
         pedantic=$1; shift
         ;;

--- a/bin/ch-test
+++ b/bin/ch-test
@@ -403,6 +403,10 @@ while [[ $# -gt 0 ]]; do
         require_unset builder
         builder=$1; shift
         ;;
+    --builder=*)
+        require_unset builder
+        builder=${opt#*=}
+        ;;
     --dry-run)
         dry=true
         ;;
@@ -413,18 +417,36 @@ while [[ $# -gt 0 ]]; do
         require_unset imgdir
         imgdir=$1; shift
         ;;
+    --img-dir=*)
+        require_unset imgdir
+        imgdir=${opt#*=}
+        ;;
     --pack-dir)
         require_unset tardir
         tardir=$1; shift
+        ;;
+    --pack-dir=*)
+        require_unset tardir
+        tardir=${opt#*=}
         ;;
     --perm-dir)
         use_sudo=yes
         permdirs+=("$1"); shift
         ;;
+    --perm-dir=*)
+        use_sudo=yes
+        permdirs+=("${opt#*=}")
+        ;;
     -s|--scope)
         require_unset scope
         scope_check "$1"
         scope=$1; shift
+        ;;
+    --scope=*)
+        require_unset scope
+        arg=${opt#*=}
+        scope_check "$arg"
+        scope=$arg
         ;;
     --sudo)
         use_sudo=yes


### PR DESCRIPTION
I keep typing `ch-test` options with an equals separator (`ch-test --scope=full`) rather than whitespace (`ch-test --scope full`). This makes it work.