### PR TITLE
fix tests for Buster

### DIFF
--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -414,7 +414,7 @@ EOF
     run ch-run --unset-env=doesnotmatch "$ch_timg" -- env
     echo "$output"
     [[ $status -eq 0 ]]
-    ex='^(_|HOME|PATH)='  # variables expected to change
+    ex='^(_|HOME|PATH|SHLVL)='  # variables expected to change
     diff -u <(env | grep -Ev "$ex") <(echo "$output" | grep -Ev "$ex")
 
     printf '\n# Everything\n\n'


### PR DESCRIPTION
Debian Buster increments `SHLVL` in more circumstances. Ignore this change to make test `ch-run --unset-env` pass on my box again.