### PR TITLE
ch-test: fix silent do-nothing with e-mail problems

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -473,6 +473,8 @@ if [[ ! -d $CHTEST_EXAMPLES_DIR ]]; then
     fatal "examples not found: $CHTEST_EXAMPLES_DIR"
 fi
 
+set +e
+
 # Is the user a contributor?
 email=
 # First, ask Git for the configured e-mail address.
@@ -489,6 +491,8 @@ for i in "${ch_contributors[@]}"; do
         ch_contributor=yes
     fi
 done
+
+set -e
 
 # Ensure Bats is installed.
 if (command -v bats &> /dev/null); then

--- a/bin/ch-test
+++ b/bin/ch-test
@@ -473,13 +473,11 @@ if [[ ! -d $CHTEST_EXAMPLES_DIR ]]; then
     fatal "examples not found: $CHTEST_EXAMPLES_DIR"
 fi
 
-set +e
-
 # Is the user a contributor?
 email=
 # First, ask Git for the configured e-mail address.
 if ( command -v git > /dev/null 2>&1 ); then
-    email="$(git config --get user.email)"
+    email="$(git config --get user.email || true)"
 fi
 # If that doesn't work, construct it from the environment.
 if [[ -z $email ]]; then
@@ -491,8 +489,6 @@ for i in "${ch_contributors[@]}"; do
         ch_contributor=yes
     fi
 done
-
-set -e
 
 # Ensure Bats is installed.
 if (command -v bats &> /dev/null); then


### PR DESCRIPTION
If command -v returns nonzero ch-test just exits.