### PR TITLE
ch-test: change version mismatch from error to warning

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -8,6 +8,10 @@ fatal () {
     exit 1
 }
 
+warning () {
+    printf 'warning: %s\n' "$1" 1>&2
+}
+
 libexec=$(cd "$(dirname "$0")" && pwd)/../libexec/charliecloud
 if [[ ! -f ${libexec}/base.sh ]]; then
     fatal "install or build problem: not found: ${libexec}/base.sh"
@@ -573,8 +577,6 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-printf "ch-test version %s\n" "$ch_version"
-printf '\n'
 printf 'ch-run:       %s\n' "${ch_bin}/ch-run"
 printf 'bats:         %s (%s)\n' "$bats" "$bats_version"
 printf 'tests:        %s\n' "$CHTEST_DIR"
@@ -615,22 +617,22 @@ if [[ $phase == *'perm'* ]] && [[ $CH_TEST_PERMDIRS == skip ]]; then
 fi
 
 # Check that different sources of version number are consistent.
-printf 'checking version numbers ...\n'
+printf 'ch-test version: %s\n' "$ch_version"
 ch_run_version=$("${ch_bin}/ch-run" --version 2>&1)
 if [[ $ch_version != "$ch_run_version" ]]; then
-    fatal "inconsistent ch-run version: ${ch_run_version}"
+    warning "inconsistent ch-run version: ${ch_run_version}"
 fi
 if [[ -z $CHTEST_INSTALLED ]]; then
     cf_version=$("${ch_base}/configure" --version | head -1 | cut -d' ' -f3)
     if [[ $ch_version != "$cf_version" ]]; then
-        fatal "inconsistent configure version: ${cf_version}"
+        warning "inconsistent configure version: ${cf_version}"
     fi
     src_version=$("${ch_base}/misc/version")
     if [[ $ch_version != "$src_version" ]]; then
-        fatal "inconsistent source version: ${src_version}"
+        warning "inconsistent source version: ${src_version}"
     fi
 fi
-printf 'ok\n\n'
+printf '\n'
 
 # Ensure BATS_TMPDIR is set to /tmp (issue #278).
 if [[ -n $BATS_TMPDIR && $BATS_TMPDIR != '/tmp' ]]; then


### PR DESCRIPTION
Version mismatch being an error is way too overzealous, but we've also been burned a number of times by inconsistent versions, so don't hide it. Relax it to a warning.