### PR TITLE
ch-run: don't fail if UID or GID account info unavailable

### DIFF
--- a/bin/ch_core.c
+++ b/bin/ch_core.c
@@ -382,13 +382,20 @@ void setup_namespaces(struct container *c)
    LOG_IDS;
 }
 
-/* Build /etc/passwd and /etc/group files and bind-mount them into newroot. We
-   do it this way so that we capture the relevant host username and group name
-   mappings regardless of where they come from. (We used to simply bind-mount
+/* Build /etc/passwd and /etc/group files and bind-mount them into newroot.
+
+   /etc/passwd contains root, nobody, and an entry for the container UID,
+   i.e., three entries, or two if the container UID is 0 or 65534. We copy the
+   host's user data for the container UID, if that exists, and use dummy data
+   otherwise (see issue #649). /etc/group works similarly: root, nogroup, and
+   an entry for the container GID.
+
+   We build new files to capture the relevant host username and group name
+   mappings regardless of where they come from. We used to simply bind-mount
    the host's /etc/passwd and /etc/group, but this fails for LDAP at least;
-   see issue #212.) After bind-mounting, we remove them on the host side;
-   they'll persist inside the container and then disappear completely when the
-   latter exits. */
+   see issue #212. After bind-mounting, we remove the files from the host;
+   they persist inside the container and then disappear completely when the
+   container exits. */
 void setup_passwd(struct container *c)
 {
    int fd;

--- a/bin/ch_misc.c
+++ b/bin/ch_misc.c
@@ -81,8 +81,8 @@ void log_ids(const char *func, int line)
 
      0 : "error"   : always print; exit unsuccessfully afterwards
      1 : "warning" : always print
-     1 : "info"    : print if verbose >= 2
-     2 : "debug"   : print if verbose >= 3 */
+     2 : "info"    : print if verbose >= 2
+     3 : "debug"   : print if verbose >= 3 */
 void msg(int level, char *file, int line, int errno_, char *fmt, ...)
 {
    va_list ap;

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -693,3 +693,28 @@ EOF
     [[ $(find /tmp -maxdepth 1 -name 'ch-run_passwd*' | wc -l) -eq 0 ]]
     [[ $(find /tmp -maxdepth 1 -name 'ch-run_group*' | wc -l) -eq 0 ]]
 }
+
+@test 'UID and/or GID invalid on host' {
+    scope standard
+    uid_bad=8675309
+    gid_bad=8675310
+
+    # UID
+    run ch-run -v --uid=$uid_bad "$ch_timg" -- /bin/true
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *"UID ${uid_bad} not found; using dummy info"* ]]
+
+    # GID
+    run ch-run -v --gid=$gid_bad "$ch_timg" -- /bin/true
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *"GID ${gid_bad} not found; using dummy info"* ]]
+
+    # both
+    run ch-run -v --uid=$uid_bad --gid=$gid_bad "$ch_timg" -- /bin/true
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *"UID ${uid_bad} not found; using dummy info"* ]]
+    [[ $output = *"GID ${gid_bad} not found; using dummy info"* ]]
+}


### PR DESCRIPTION
`ch-run` builds `/etc/passwd` and `/etc/group` files and bind-mounts them into the container, using information in the account database. If no such information is found, it exits with an unhelpful error message (#649); i.e., it doesn't distinguish between `getpwuid(3)` and `getpwgid(3)` failing and returning no results.

This PR adds code to instead use dummy account information if there are no results, and proceed with the user command. With `--verbose`, it prints a log message to say so.

For example:

```
$ ch-run -v -u 8675309 -g 8675310 /var/tmp/images/chtest -- /bin/true
ch-run[7985]: verbosity: 2 (ch-run.c:155)
ch-run[7985]: newroot: /var/tmp/images/chtest (ch-run.c:156)
ch-run[7985]: container uid: 8675309 (ch-run.c:157)
ch-run[7985]: container gid: 8675310 (ch-run.c:158)
ch-run[7985]: join: 0 0 (null) 0 (ch-run.c:159)
ch-run[7985]: private /tmp: 0 (ch-run.c:160)
ch-run[7985]: UID 8675309 not found; using dummy info (ch_core.c:416)
ch-run[7985]: GID 8675310 not found; using dummy info (ch_core.c:441)
$ echo $?
0
```

@trophime, does this help?