### PR TITLE
add warning about no user namespaces in a chroot

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -288,6 +288,12 @@ AC_CHECK_PROG([UMOCI], [umoci], [umoci])
 CH_CHECK_VERSION([UMOCI], [$vmin_umoci], [--version | cut -d' ' -f3])
 
 # User namespaces
+AC_MSG_CHECKING([if in chroot])  # https://unix.stackexchange.com/a/14346
+AS_IF([test    "$(awk '$5=="/" {print $1}' </proc/1/mountinfo)" \
+            != "$(awk '$5=="/" {print $1}' </proc/$$/mountinfo)" ],
+      [chrooted=yes],
+      [chrooted=no])
+AC_MSG_RESULT($chrooted)
 AC_MSG_CHECKING([if user+mount namespaces work])
 AC_RUN_IFELSE([AC_LANG_SOURCE([[
     #define _GNU_SOURCE
@@ -440,6 +446,18 @@ AC_OUTPUT
 
 ## Print report
 
+AS_IF([   test $have_userns = no \
+       && test $chrooted = yes], [
+  chroot_warning=$(cat <<'EOF'
+
+
+    Warning: configure is running in a chroot, but user namespaces cannot be
+    created in a chroot; see the man page unshare(2). Therefore, the above may
+    be a false negative.
+EOF
+)
+])
+
 AC_MSG_NOTICE([
 
 Dependencies report
@@ -517,7 +535,7 @@ Running containers
 ~~~~~~~~~~~~~~~~~~
 
   ch-run(1): ${have_ch_run}
-    user+mount namespaces ... ${have_userns}
+    user+mount namespaces ... ${have_userns}$chroot_warning
 
   unpack image tarballs: ${have_unpack_tar}
     tar(1) ... ${TAR:-not found}

--- a/configure.ac
+++ b/configure.ac
@@ -453,7 +453,8 @@ AS_IF([   test $have_userns = no \
 
     Warning: configure is running in a chroot, but user namespaces cannot be
     created in a chroot; see the man page unshare(2). Therefore, the above may
-    be a false negative.
+    be a false negative. However, note that like all the run-time configure
+    tests, this is informational only and does not affect the build.
 EOF
 )
 ])

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -167,7 +167,8 @@ Note: User namespaces `always fail in a chroot
 <http://man7.org/linux/man-pages/man2/unshare.2.html>`_ with :code:`EPERM`. If
 :code:`configure` detects that it's in a chroot, it will print a warning in
 its report. One common scenario where this comes up is packaging, where builds
-often happen in a chroot.
+often happen in a chroot. However, like all the run-time :code:`configure`
+tests, this is informational only and does not affect the build.
 
 Supported architectures
 -----------------------

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -158,12 +158,16 @@ Some distributions need configuration changes. For example:
 
 * RHEL/CentOS 7.4 and 7.5 need both a `kernel command line option and a sysctl
   <https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html-single/getting_started_with_containers/#user_namespaces_options>`_.
-  RHEL/CentOS 7.6 and up need only the sysctl.
-
-  *Note:* Docker does not work with user namespaces, so skip step 4 of the Red
-  Hat instructions, i.e., don't add :code:`--userns-remap` to the Docker
-  configuration (see `issue #97
+  RHEL/CentOS 7.6 and up need only the sysctl. Note that Docker does not work
+  with user namespaces, so skip step 4 of the Red Hat instructions, i.e.,
+  don't add :code:`--userns-remap` to the Docker configuration (see `issue #97
   <https://github.com/hpc/charliecloud/issues/97>`_).
+
+Note: User namespaces `always fail in a chroot
+<http://man7.org/linux/man-pages/man2/unshare.2.html>`_ with :code:`EPERM`. If
+:code:`configure` detects that it's in a chroot, it will print a warning in
+its report. One common scenario where this comes up is packaging, where builds
+often happen in a chroot.
 
 Supported architectures
 -----------------------

--- a/doc/make-deps-overview
+++ b/doc/make-deps-overview
@@ -19,13 +19,15 @@
 #   1. Remove everything before "Building Charliecloud" (inclusive) to the
 #      next log section (exclusive).
 #   2. Remove "will build and install" paragraph.
-#   3. Remove results of tests: " ..." to EOL, ": yes", ": no".
-#   4. Convert indentation to bullet lists.
-#   5. Convert "foo(1)" to ":code:`foo`".
+#   3. Remove any "Warning:" paragraphs.
+#   4. Remove results of tests: " ..." to EOL, ": yes", ": no".
+#   5. Convert indentation to bullet lists.
+#   6. Convert "foo(1)" to ":code:`foo`".
 
 # shellcheck disable=SC2016
   awk '/^Building Charliecloud/,/^##/' | head -n-2 \
 | awk -v RS='' '{gsub(/^  will build.*/, ""); print; print ""}' \
+| awk -v RS='' '{gsub(/^ +Warning:.*/, ""); print; print ""}' \
 | sed -r -e 's/ \.\.\..*$//' -e 's/ (yes|no)$//' \
          -e 's/^  //' -e 's/(^(  )+)/\1* /' -e 's/:$/:\n/' \
          -e 's/([a-zA-Z0-9-]+)\(1\)/:code:`\1`/g'


### PR DESCRIPTION
This hopefully addresses #638, but I don't have good enough chroot-fu to test it properly. @wiene, does this address the problem?