### PR TITLE
examples/lustre: add missing variable, fix example grouping

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -692,6 +692,9 @@ fi
 cd "$CHTEST_DIR"
 
 export PATH=$ch_bin:$PATH
+if [[ -n $ch_lustre ]]; then
+    export CH_LUSTRE=$ch_lustre
+fi
 
 # The distinction here is that "images" are purely for testing and have no
 # value as examples for the user, while "examples" are dual-purpose.

--- a/bin/ch-test
+++ b/bin/ch-test
@@ -41,7 +41,7 @@ Additional options:
   --pack-dir DIR         packed imaged directory; same as \$CH_TEST_TARDIR
   --perm-dir DIR         permissions fixture dir, can repeat; \$CH_TEST_PERMDIRS
   --sudo                 enable tests that need sudo
-  --lustre DIR           use DIR for run-phase Lustre tests
+  --lustre DIR           run-phase Lustre test directory; \$CH_TEST_LUSTREDIR
   --version              print version and exit
 
 See the man page for important details.
@@ -579,14 +579,12 @@ while [[ $# -gt 0 ]]; do
         use_sudo=yes
         ;;
     --lustre)
-        require_unset ch_lustre
-        # shellcheck disable=SC2034
-        ch_lustre=$1; shift
+        require_unset lustredir
+        lustredir=$1; shift
         ;;
     --lustre=*)
-        require_unset ch_lustre
-        # shellcheck disable=SC2034
-        ch_lustre=${opt#*=}
+        require_unset lustredir
+        lustredir=${opt#*=}
         ;;
     --version)
         version; exit 0
@@ -630,6 +628,8 @@ vset CH_TEST_TARDIR   "$tardir"        "$CH_TEST_TARDIR"   /var/tmp/tar \
                       21 'packed images dir'
 vset CH_TEST_PERMDIRS "${permdirs[*]}" "$CH_TEST_PERMDIRS" skip \
                       21 'fs permissions dirs'
+vset CH_TEST_LUSTREDIR "$lustredir"    "$CH_TEST_LUSTREDIR" skip \
+                      21 'Lustre test dir'
 printf '\n'
 
 if [[ $phase == *'perm'* ]] && [[ $CH_TEST_PERMDIRS == skip ]]; then
@@ -692,9 +692,6 @@ fi
 cd "$CHTEST_DIR"
 
 export PATH=$ch_bin:$PATH
-if [[ -n $ch_lustre ]]; then
-    export CH_LUSTRE=$ch_lustre
-fi
 
 # The distinction here is that "images" are purely for testing and have no
 # value as examples for the user, while "examples" are dual-purpose.

--- a/doc/ch-test_desc.rst
+++ b/doc/ch-test_desc.rst
@@ -138,7 +138,11 @@ Additional arguments:
     :code:`sudo docker` even without this option.
 
   :code:`--lustre DIR`
-    Use :code:`DIR` for run-phase Lustre tests
+    Use :code:`DIR` for run-phase Lustre tests. Default:
+    :code:`CH_TEST_LUSTREDIR` if set; otherwise skip them.
+
+    The tests will create, populate, and delete a new subdirectory under
+    :code:`DIR`, leaving everything else in :code:`DIR` untouched.
 
 Exit status
 ===========

--- a/examples/lustre/test.bats
+++ b/examples/lustre/test.bats
@@ -9,18 +9,18 @@ setup () {
     prerequisites_ok lustre
 
     if [[ $SLURM_JOB_ID ]]; then
-        if [[ -z $ch_lustre ]]; then
+        if [[ -z $CH_LUSTRE ]]; then
             pedantic_fail 'no lustre to bind mount'
         fi
     else
-        if [[ -z $ch_lustre ]]; then
+        if [[ -z $CH_LUSTRE ]]; then
             skip 'no lustre to bind mount'
         fi
     fi
 
     # Check lustre directory is a directory
-    if [[ ! -d $ch_lustre ]]; then
-        echo "${ch_lustre} is not a directory"
+    if [[ ! -d $CH_LUSTRE ]]; then
+        echo "${CH_LUSTRE} is not a directory"
         exit 1
     fi
 }
@@ -36,12 +36,12 @@ tidy_run () {
     ch-run -b "$binds" "$ch_img" -- "$@"
 }
 
-binds=${ch_lustre}:/mnt/0
+binds=${CH_LUSTRE}:/mnt/0
 work_dir=/mnt/0/charliecloud_test
 
 @test "${ch_tag}/start clean" {
-    clean_dir "${ch_lustre}/charliecloud_test" || true
-    mkdir -p "${ch_lustre}/charliecloud_test"
+    clean_dir "${CH_LUSTRE}/charliecloud_test" || true
+    mkdir -p "${CH_LUSTRE}/charliecloud_test"
 }
 
 @test "${ch_tag}/create directory" {
@@ -87,5 +87,5 @@ EOF
 }
 
 @test "${ch_tag}/clean up" {
-    clean_dir "${ch_lustre}/charliecloud_test"
+    clean_dir "${CH_LUSTRE}/charliecloud_test"
 }

--- a/examples/lustre/test.bats
+++ b/examples/lustre/test.bats
@@ -8,19 +8,17 @@ setup () {
     scope full
     prerequisites_ok lustre
 
-    if [[ $SLURM_JOB_ID ]]; then
-        if [[ -z $CH_LUSTRE ]]; then
-            pedantic_fail 'no lustre to bind mount'
+    if [[ $CH_TEST_LUSTREDIR = skip ]]; then
+        # Assume that in a Slurm allocation, even if one node, Lustre should
+        # be available for testing.
+        msg='no Lustre test directory to bind mount'
+        if [[ $SLURM_JOB_ID ]]; then
+            pedantic_fail "$msg"
+        else
+            skip "$msg"
         fi
-    else
-        if [[ -z $CH_LUSTRE ]]; then
-            skip 'no lustre to bind mount'
-        fi
-    fi
-
-    # Check lustre directory is a directory
-    if [[ ! -d $CH_LUSTRE ]]; then
-        echo "${CH_LUSTRE} is not a directory"
+    elif [[ ! -d $CH_TEST_LUSTREDIR ]]; then
+        echo "'${CH_TEST_LUSTREDIR}' is not a directory"
         exit 1
     fi
 }
@@ -36,12 +34,12 @@ tidy_run () {
     ch-run -b "$binds" "$ch_img" -- "$@"
 }
 
-binds=${CH_LUSTRE}:/mnt/0
+binds=${CH_TEST_LUSTREDIR}:/mnt/0
 work_dir=/mnt/0/charliecloud_test
 
 @test "${ch_tag}/start clean" {
-    clean_dir "${CH_LUSTRE}/charliecloud_test" || true
-    mkdir -p "${CH_LUSTRE}/charliecloud_test"
+    clean_dir "${CH_TEST_LUSTREDIR}/charliecloud_test" || true
+    mkdir "${CH_TEST_LUSTREDIR}/charliecloud_test"  # fail if not cleaned up
 }
 
 @test "${ch_tag}/create directory" {
@@ -87,5 +85,5 @@ EOF
 }
 
 @test "${ch_tag}/clean up" {
-    clean_dir "${CH_LUSTRE}/charliecloud_test"
+    clean_dir "${CH_TEST_LUSTREDIR}/charliecloud_test"
 }

--- a/examples/lustre/test.bats
+++ b/examples/lustre/test.bats
@@ -1,3 +1,7 @@
+true
+# shellcheck disable=SC2034
+CH_TEST_TAG=%ch_test_tag%
+
 load "${CHTEST_DIR}/common.bash"
 
 setup () {


### PR DESCRIPTION
Adds the example grouping header. This should probably be documented in a FAQ or the developers guide.

It appears that `ch_lustre` will also need to be exported, the pendantic_fail trips otherwise (`ch_lustre` is empty at the test.bat file level).