### PR TITLE
don't try to build docs if RTD theme is missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,8 @@ EOF
   AS_IF([test $have_rtd = yes], [
     CH_CHECK_VERSION([rtd], [$vmin_rtd],
       [-c 'import sphinx_rtd_theme; print(sphinx_rtd_theme.__version__)'])
+  ], [
+    rtd=
   ])
 ])
 


### PR DESCRIPTION
If Sphinx is installed but the RTD theme isn't, we get a false positive from `configure`:

```
  documentation: yes
    sphinx-build(1) 1.2.3 ... /usr/local/bin/sphinx-build 1.8.5
    sphinx-build(1) Python ... /usr/bin/python3
    "docutils" module 0.14 ... 0.16
    "sphinx-rtd-theme" module 0.2.4 ... not found
```

Then `make` fails.

Expected behavior:

```
  documentation: no
    sphinx-build(1) 1.2.3 ... /usr/local/bin/sphinx-build 1.8.5
    sphinx-build(1) Python ... /usr/bin/python3
    "docutils" module 0.14 ... 0.16
    "sphinx-rtd-theme" module 0.2.4 ... not found
```

Note that this very simple patch is too coarse. If you don't have `sphinx-rtd-theme` module, you can in fact build the man pages; with this patch, `configure` will disable both the HTML docs and the man page if the module is missing. If that's a problem, IMO we can clean it up in a future PR.

Thanks to @pagrubel for reporting this bug!