### PR TITLE
ch-fromhost: don't inject liblustre via hardcoded path

### DIFF
--- a/bin/ch-fromhost
+++ b/bin/ch-fromhost
@@ -322,9 +322,6 @@ if [ $cray_openmpi ]; then
     queue_files "$(  ldd "$host_libmpi" \
                    | grep -E "/usr|/opt" \
                    | sed -E 's/^.+ => (.+) \(0x.+\)$/\1/')"
-    # This appears to be the only dependency in /lib64 that we can't get from
-    # glibc in the image.
-    queue_files /lib64/liblustreapi.so
 
     # Remove libmpi.so* from image. This works around ParaView
     # dlopen(3)-related errors that we don't understand.


### PR DESCRIPTION
Addresses #682.

This PR results in `ch-fromhost --cray-mpi` only pulling .so dependencies for libmpi from `/usr` and `/opt`, if a user wants to inject something from a different location they should additionally use the `-f` or `-p` [flags](https://hpc.github.io/charliecloud/command-usage.html#ch-fromhost).

NOTE: For CLE6 systems `-p <path to liblustreapi>` is now required in addition to `--cray-mpi` if OpenMPI on the host is linked to `liblustreapi.so`