### PR TITLE
test suite: add output directories to Build.* script API

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -863,15 +863,16 @@ export PATH=$ch_bin:$PATH
 # we source CHTEST_DIR/common.bash.
 . "${CHTEST_DIR}/common.bash"
 
-# The distinction here is that "images" are purely for testing and have no value
-# as examples for the user, while "examples" are dual-purpose.
-images=$(find   "$CHTEST_DIR"             -name 'Build' \
-                                       -o -name 'Build.*' \
-                                       -o -name 'Dockerfile.*' | sort)
-examples=$(find "$CHTEST_EXAMPLES_DIR"    -name 'Build' \
-                                       -o -name 'Build.*' \
-                                       -o -name 'Dockerfile' \
-                                       -o -name 'Dockerfile.*' | sort)
+# The distinction here is that "images" are purely for testing and have no
+# value as examples for the user, while "examples" are dual-purpose. We call
+# "find" twice for each to preserve desired sort order.
+images=$(     find "$CHTEST_DIR"             -name 'Dockerfile.*' | sort \
+           && find "$CHTEST_DIR"             -name 'Build' \
+                                          -o -name 'Build.*' | sort)
+examples=$(   find "$CHTEST_EXAMPLES_DIR"    -name 'Dockerfile' \
+                                          -o -name 'Dockerfile.*' | sort \
+           && find "$CHTEST_EXAMPLES_DIR"    -name 'Build' \
+                                          -o -name 'Build.*' | sort)
 
 scope_int=$(scope_to_digit "$CH_TEST_SCOPE")
 

--- a/doc/dev.rst
+++ b/doc/dev.rst
@@ -334,32 +334,53 @@ Charliecloud is small enough to just rebuild everything with::
 Writing a test image using the standard workflow
 ------------------------------------------------
 
-The Charliecloud test suite has a workflow that can build images by three
+Summary
+~~~~~~~
+
+The Charliecloud test suite has a workflow that can build images by two
 methods:
 
 1. From a Dockerfile, using :code:`ch-build`.
-2. By pulling a Docker image, with :code:`docker pull`.
-3. By running a custom script.
+2. By running a custom script.
 
-To create an image that will be built, unpacked, and basic tests run within,
-create a file in :code:`test/` called
-:code:`{Dockerfile,Docker_Pull,Build}.foo`. This will create an image tagged
-:code:`foo`.
+To create an image that will be built and unpacked and/or mounted, create a
+file in :code:`examples` (if the image recipe is useful as an example) or
+:code:`test` (if not) called :code:`{Dockerfile,Build}.foo`. This will create
+an image tagged :code:`foo`. Additional tests can be added to the test suite
+Bats files.
 
 To create an image with its own tests, documentation, etc., create a directory
-in :code:`examples/*`. In this directory, place
-:code:`{Dockerfile,Docker_Pull,Build}[.foo]` to build the image and
-:code:`test.bats` with your tests. For example, the file
-:code:`examples/mpi/foo/Dockerfile` will create an image tagged :code:`foo`,
-and :code:`examples/mpi/foo/Dockerfile.bar` tagged :code:`foo-bar`. These
-images also get the basic tests.
+in :code:`examples`. In this directory, place
+:code:`{Dockerfile,Build}[.foo]` to build the image and :code:`test.bats` with
+your tests. For example, the file :code:`examples/foo/Dockerfile` will create
+an image tagged :code:`foo`, and :code:`examples/foo/Dockerfile.bar` tagged
+:code:`foo-bar`. These images also get the build and unpack/mount tests.
+
+Additional directories can be symlinked into :code:`examples` and will be
+integrated into the test suite. This allows you to create a site-specific test
+suite. :code:`ch-test` finds tests at any directory depth; e.g.
+:code:`examples/foo/bar/Dockerfile.baz` will create a test image tagged
+:code:`bar-baz`.
 
 Image tags in the test suite must be unique.
 
+Order of processing; within each item, alphabetical order:
+
+1. Dockerfiles in :code:`test`.
+2. :code:`Build` files in :code:`test`.
+3. Dockerfiles in :code:`examples`.
+4. :code:`Build` files in :code:`examples`.
+
+The purpose of doing :code:`Build` second is so they can leverage what has
+already been built by a Dockerfile, which is often more straightforward.
+
+How to specify when to include and exclude a test image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Each of these image build files must specify its scope for building and
 running, which must be greater than or equal than the scope of all tests in
-the corresponding :code:`test.bats`. Exactly one of the following strings must
-be in each file:
+any corresponding :code:`.bats` files. Exactly one of the following strings
+must appear:
 
 .. code-block:: none
 
@@ -369,57 +390,62 @@ be in each file:
 
 Other stuff on the line (e.g., comment syntax) is ignored.
 
-Similarly, you can exclude an architecture with e.g.:
+Optional test modification directives are:
 
-.. code-block:: none
+  :code:`ch-test-arch-exclude: ARCH`
+    If the output of :code:`uname -m` matches :code:`ARCH`, skip the file.
 
-  ch-test-arch-exclude: aarch64  # ARM not supported upstream
+  :code:`ch-test-builder-exclude: BUILDER`
+    If using :code:`BUILDER`, skip the file.
 
-Additional subdirectories can be symlinked into :code:`examples/` and will be
-integrated into the test suite. This allows you to create a site-specific test
-suite.
+  :code:`ch-test-builder-include: BUILDER`
+    If specified, run only if using :code:`BUILDER`. Can be repeated to
+    include multiple builders. If specified zero times, all builders are
+    included.
 
-:code:`Dockerfile`:
+  :code:`ch-test-need-sudo`
+    Run only if user has sudo.
 
-  * It's a Dockerfile.
+How to write a :code:`Dockerfile` recipe
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:code:`Docker_Pull`:
+It's a standard Dockerfile.
 
-  * First line states the address to pull from Docker Hub.
-  * Second line is a scope expression as described above.
-  * Examples (these refer to the same image as of this writing):
+How to write a :code:`Build` recipe
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    .. code-block:: none
+This is an arbitrary script or program that builds the image. It gets three
+command line arguments:
 
-      alpine:3.6
-      alpine@sha256:f006ecbb824d87947d0b51ab8488634bf69fe4094959d935c0c103f4820a417d
+  * :code:`$1`: Absolute path to directory containing :code:`Build`.
 
-:code:`Build`:
+  * :code:`$2`: Absolute path and name of output image, without extension.
+    This can be either:
 
-  * Script or program that builds the image.
+    * Tarball compressed with gzip or xz; append :code:`.tar.gz` or
+      :code:`.tar.xz` to :code:`$2`. If :code:`ch-test --pack-fmt=squash`,
+      then this tarball will be unpacked and repacked as a SquashFS.
+      Therefore, only use tarball output if the image build process naturally
+      produces it and you would have to unpack it to get a directory (e.g.,
+      :code:`docker export`).
 
-  * Arguments:
+    * Directory; use :code:`$2` unchanged. The contents of this directory will
+      be packed without any enclosing directory, so if you want an enclosing
+      directory, include one. Hidden (dot) files in :code:`$2` will be ignored.
 
-    * :code:`$1`: Absolute path to directory containing :code:`Build`.
+  * :code:`$3`: Absolute path to temporary directory for use by the script.
+    This can be used for whatever and need no be cleaned up; the test harness
+    will delete it.
 
-    * :code:`$2`: Absolute path and name of output archive, without extension.
-      The script should use an archive format compatible with
-      :code:`ch-tar2dir` and append the appropriate extension (e.g.,
-      :code:`.tar.gz`).
+Other requirements:
 
-    * :code:`$3`: Absolute path to appropriate temporary directory.
-
-  * The script must not write anything in the current directory.
-
-  * Temporary directory can be used for whatever and need not be cleaned up.
-    It will be deleted by the test harness.
+  * The script may write only in two directories: (a) the parent directory of
+    :code:`$2` and (b) :code:`$3`. Specifically, it may not write to the
+    current working directory. Everything written to the parent directory of
+    :code:`$2` must have a name starting with :code:`$(basename $2)`.
 
   * The first entry in :code:`$PATH` will be the Charliecloud under test,
     i.e., bare :code:`ch-*` commands will be the right ones.
-
-  * The tarball must not contain leading directory components; top-level
-    filesystem directories such as bin and usr must be at the root of the
-    tarball with no leading path (:code:`./` is acceptable).
 
   * Any programming language is permitted. To be included in the Charliecloud
     source code, a language already in the test suite dependencies is
@@ -432,7 +458,7 @@ suite.
 
   * Exit codes:
 
-    * 0: Image tarball successfully created.
+    * 0: Image successfully created.
     * 65: One or more dependencies were not met.
     * 126 or 127: No interpreter available for script language (the shell
       takes care of this).

--- a/examples/Dockerfile.alpine39
+++ b/examples/Dockerfile.alpine39
@@ -1,5 +1,5 @@
-# ch-test-scope: quick
-FROM alpine:3.9
+# ch-test-scope: standard
+FROM 00_tiny
 
 RUN apk add --no-cache bc
 

--- a/examples/Dockerfile.alpine39
+++ b/examples/Dockerfile.alpine39
@@ -1,7 +1,0 @@
-# ch-test-scope: standard
-FROM 00_tiny
-
-RUN apk add --no-cache bc
-
-# Base image has no default command; we need one to build.
-CMD ["true"]

--- a/examples/Dockerfile.exhaustive
+++ b/examples/Dockerfile.exhaustive
@@ -8,8 +8,8 @@
 
 #FROM alpine
 #FROM alpine@cdf98d1859c1  # skopeo pukes on this
-FROM alpine:3.9
-#FROM alpine:3.9 AS stage1
+FROM 00_tiny
+#FROM 00_tiny AS stage1
 
 # FIXME: These should maybe be moved into Dockerfile.argenv?
 ENV chse_1 value1 with spaces and trailing space 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -10,7 +10,6 @@ chtest/signal_out.py \
 hello/hello.sh
 
 noexecs = \
-Dockerfile.alpine39 \
 Dockerfile.alpineedge \
 Dockerfile.centos6 \
 Dockerfile.centos7 \

--- a/examples/chtest/Build
+++ b/examples/chtest/Build
@@ -9,6 +9,11 @@
 # common and we'd prefer not to introduce another dependency. For example,
 # it's a standard tool on Debian but only in EPEL for CentOS.
 #
+# FIXME: Despite the guidance in the Build script API docs, this produces a
+# tarball even though the process does not naturally produce one. This is
+# because we are also creating some rather bizarre tar edge cases. These
+# should be moved to a separate script.
+#
 # ch-test-scope: quick
 
 set -ex

--- a/test/Build.ch-build2dir
+++ b/test/Build.ch-build2dir
@@ -4,16 +4,16 @@
 
 # Generate image directory using ch-build2dir and stage it for testing.
 
-set -e
+set -ex
 
 srcdir=$1
-tarball_gz=${2}.tar.gz
-workdir=$3
+outdir=$2
+#workdir=$3  # unused
 
-tag=build2dir
+tag=$(basename "$outdir")
+outdir_parent=$(dirname "$outdir")
 
 cd "$srcdir"
-ch-build2dir -t $tag --file=Dockerfile.build2dir . "$workdir"
-cd "$workdir"
-tar czf ${tag}.tar.gz $tag
-mv ${tag}.tar.gz "$tarball_gz"
+
+ch-build2dir -t "$tag" --file=./Dockerfile.build2dir . "$outdir_parent"
+[[ -d $outdir ]]

--- a/test/Build.skopeo-umoci
+++ b/test/Build.skopeo-umoci
@@ -17,7 +17,7 @@
 set -ex
 
 #srcdir=$1  # unused
-tarball_gz=${2}.tar.gz
+outdir=$2
 workdir=$3
 
 cd "$workdir"
@@ -31,7 +31,6 @@ if ( ! command -v umoci >/dev/null 2>&1 ); then
     exit 65
 fi
 
-skopeo copy docker://alpine:3.9 oci:./oci:alpine
-umoci unpack --rootless --image ./oci:alpine ./img
-
-( cd img && tar czf "$tarball_gz" -- rootfs )
+skopeo copy docker://alpine:3.9 oci:./oci:img
+umoci unpack --rootless --image ./oci:img ./img
+mv img/rootfs "$outdir"

--- a/test/Dockerfile.00_tiny
+++ b/test/Dockerfile.00_tiny
@@ -1,0 +1,8 @@
+# Minimal image useful for later tests.
+
+# ch-test-scope: quick
+
+FROM alpine:3.9
+
+# Base image has no default command; we need one to build.
+CMD ["true"]

--- a/test/Dockerfile.argenv
+++ b/test/Dockerfile.argenv
@@ -1,7 +1,7 @@
 # Test ARG and ENV handling.
 
 # ch-test-scope: standard
-FROM alpine:3.9
+FROM 00_tiny
 
 ARG chse_arg1_df
 ARG chse_arg2_df=arg2
@@ -9,6 +9,3 @@ ARG chse_arg3_df="arg3 ${chse_arg2_df}"
 ENV chse_env1_df env1
 ENV chse_env2_df="env2 ${chse_env1_df}"
 RUN env | egrep '^chse_' | sort
-
-# Base image has no default command; we need one to build.
-CMD ["true"]

--- a/test/Dockerfile.build2dir
+++ b/test/Dockerfile.build2dir
@@ -1,1 +1,1 @@
-../examples/Dockerfile.alpine39
+Dockerfile.00_tiny

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -2,6 +2,7 @@ testdir = $(pkglibexecdir)/test
 
 # These test files require no special handling.
 testfiles = \
+Dockerfile.00_tiny \
 Dockerfile.argenv \
 Dockerfile.build2dir \
 build.bats \

--- a/test/make-auto.d/build_custom.bats.in
+++ b/test/make-auto.d/build_custom.bats.in
@@ -29,7 +29,7 @@
         fi
         rm -Rf --one-file-system "$out"
     else
-        false  # no tarball or directory
+        [[ $status -ne 0 ]]  # no tarball or directory; script should fail
     fi
     # Clean up.
     rm -Rf --one-file-system "$workdir"

--- a/test/make-auto.d/build_custom.bats.in
+++ b/test/make-auto.d/build_custom.bats.in
@@ -1,16 +1,41 @@
 @test 'custom build %(tag)s' {
     scope %(scope)s
-    tarball="${ch_tardir}/%(tag)s"
+    out="${ch_tardir}/%(tag)s"
     pq="${ch_tardir}/%(tag)s.pq_missing"
     workdir="${ch_tardir}/%(tag)s.tmp"
     rm -f "$pq"
     mkdir "$workdir"
     cd "%(dirname)s"
-    run ./%(basename)s "$PWD" "$tarball" "$workdir"
+    run ./%(basename)s "$PWD" "$out" "$workdir"
     echo "$output"
-    rm -Rf "$workdir"
+    # Pack image into appropriate format.
+    if [[ -f ${out}.tar.gz || -f ${out}.tar.xz ]]; then
+        tarballs=( "$out".tar.* )
+        [[ ${#tarballs[@]} -eq 1 ]]  # fail if both extensions were provided
+        tarball=${tarballs[0]}
+        if [[ $CH_PACK_FMT = squash ]]; then
+            # Tarball provided but pack format is SquashFS; repack.
+            ch-tar2dir "$tarball" "$workdir"
+            ch-dir2squash "${workdir}/%(tag)s" "$ch_tardir"
+            rm "$tarball"
+        fi
+    elif [[ -d $out ]]; then
+        if [[ $CH_PACK_FMT = tar ]]; then
+            ( cd "$out" && tar czf "${out}.tar.gz" -- * )
+        elif [[ $CH_PACK_FMT = squash ]]; then
+            ch-dir2squash "$out" "$ch_tardir"
+        else
+            false  # unknown pack format
+        fi
+        rm -Rf --one-file-system "$out"
+    else
+        false  # no tarball or directory
+    fi
+    # Clean up.
+    rm -Rf --one-file-system "$workdir"
     if [[ $status -eq 65 ]]; then
          touch "$pq"
+         rm -Rf --one-file-system "$out" "$out".tar.{gz,xz}
          skip 'prerequisites not met'
     fi
     [[ $status -eq 0 ]]

--- a/test/run/ch-tar2dir.bats
+++ b/test/run/ch-tar2dir.bats
@@ -2,6 +2,7 @@ load ../common
 
 @test 'ch-tar2dir: unpack image' {
     scope standard
+    [[ $CH_PACK_FMT = tar ]] || skip 'issue #693'
     if ( image_ok "$ch_timg" ); then
         # image exists, remove so we can test new unpack
         rm -Rf --one-file-system "$ch_timg"
@@ -18,6 +19,7 @@ load ../common
 
 @test 'ch-tar2dir: /dev cleaning' {  # issue #157
     scope standard
+    [[ $CH_PACK_FMT = tar ]] || skip 'issue #693'
     # Are all fixtures present in tarball?
     present=$(tar tf "$ch_ttar" | grep -F deleteme)
     [[ $(echo "$present" | wc -l) -eq 4 ]]


### PR DESCRIPTION
Addresses #692.

Note this is a little incomplete; e.g., `examples/chtest/Build` still produces a tarball even though it mostly doesn't need to. But, I wanted to get this out without getting bogged down. We will need a fair number of changes in that area for #693, so I thought it OK to put them off.