### PR TITLE
ch-grow: fix parsing bugs

### DIFF
--- a/bin/ch-grow.py.in
+++ b/bin/ch-grow.py.in
@@ -88,7 +88,7 @@ run_shell: LINE
 
 workdir: "WORKDIR"i _WS LINE _NEWLINES
 
-ID: /[A-Za-z0-9_.-]+/
+ID: /[A-Za-z0-9_.\/-]+/
 HEXID: /[a-fA-F0-9]+/
 LINE: ( LINE_CONTINUE | /[^\n]/ )+
 WORD: /[^ \t\n=]/+
@@ -558,7 +558,7 @@ def dir_images():
    return "%s/img" % cli.storage
 
 def dir_image(image):
-   return "%s/%s" % (dir_images(), image)
+   return "%s/%s" % (dir_images(), image.replace("/", "%"))
 
 def file_ensure_exists(path):
    with open(path, "a") as fp:

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -278,7 +278,7 @@ class Image:
       "Reject paths outside the tar top level by aborting the program."
       if (len(path) > 0 and path[0] == "/"):
          FATAL("rejecting absolute path: %s: %s" % (filename, path))
-      if (".." in path):
+      if (".." in path.split("/")):
          FATAL("rejecting path with up-level: %s: %s" % (filename, path))
 
    def validate_tar_link(self, filename, path, target):
@@ -288,7 +288,7 @@ class Image:
       if (len(target) > 0 and target[0] == "/"):
          FATAL("rejecting absolute hard link target: %s: %s -> %s"
                % (filename, path, target))
-      if (".." in os.path.normpath(path + "/" + target)):
+      if (".." in os.path.normpath(path + "/" + target).split("/")):
          FATAL("rejecting too many up-levels: %s: %s -> %s"
                % (filename, path, target))
 


### PR DESCRIPTION
This PR fixes a couple parsing bugs in `ch-grow` that are needed for our upcoming workshop. These quick fixes should make it work, but they are poorly tested, and we should do better later.

1. Did not accept slash in `FROM` instructions.
2. Misinterpreted opaque whiteout file (named `.wh..wh..opq`) as parent directory (`..`) when validating layers.