### PR TITLE
configure: be more clear that non-Linux is unsupported

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -15,17 +15,12 @@ AC_CONFIG_SRCDIR([bin/ch-run.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIRS([misc/m4])
 
-
 AC_CANONICAL_HOST
-# Only Linux is supported at the moment
-# see: https://github.com/hpc/charliecloud/issues/42
-case "${host_os}" in
-        linux*)
-        ;;
-        *)
-        AC_MSG_ERROR(["Linux is currently the only supported platform"])
-        ;;
-esac
+AS_CASE([$host_os],
+  [linux*], [],
+  [*],      [AC_MSG_ERROR([Linux is the only supported OS; see issue @%:@42.])]
+)
+
 AM_INIT_AUTOMAKE([1.13 -Wall -Werror foreign subdir-objects])
 
 AC_CONFIG_HEADERS([bin/config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,17 @@ AC_CONFIG_SRCDIR([bin/ch-run.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIRS([misc/m4])
 
+
+AC_CANONICAL_HOST
+# Only Linux is supported at the moment
+# see: https://github.com/hpc/charliecloud/issues/42
+case "${host_os}" in
+        linux*)
+        ;;
+        *)
+        AC_MSG_ERROR(["Linux is currently the only supported platform"])
+        ;;
+esac
 AM_INIT_AUTOMAKE([1.13 -Wall -Werror foreign subdir-objects])
 
 AC_CONFIG_HEADERS([bin/config.h])


### PR DESCRIPTION
Based on recent discussion: https://github.com/hpc/charliecloud/issues/42#issuecomment-613617506

* adjust the `autotools`-related code to raise
a helpful error message when attempting to build
Charliecloud from a `git` checkout on a non-Linux
platform

Using this build sequence with this feature branch:

```
/autogen.sh 
./configure 
```

Produces on MacOS:

```
checking build system type... x86_64-apple-darwin19.4.0
checking host system type... x86_64-apple-darwin19.4.0
configure: error: "Linux is currently the only supported platform"
```

For the same feature branch on a native Linux box I did just a superficial check

```
./autogen.sh
./configure
make
./bin/ch-run -V
```

```
0.16~pre+treddyconfignonlinux.43606ef
```


cc @junghans 