### PR TITLE
Update copyright dates to 2020

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ We are friendly and welcoming of diversity on all dimensions.
 Copyright and license
 ---------------------
 
-Charliecloud is copyright © 2014–2019 Triad National Security, LLC.
+Charliecloud is copyright © 2014–2020 Triad National Security, LLC.
 
 This software was produced under U.S. Government contract 89233218CNA000001
 for Los Alamos National Laboratory (LANL), which is operated by Triad National

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,7 +42,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Charliecloud'
-copyright = u'2014–2019, Triad National Security, LLC'
+copyright = u'2014–2020, Triad National Security, LLC'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -5,7 +5,7 @@ Source: https://github.com/hpc/charliecloud
 Files-Excluded: debian
 
 Files: *
-Copyright: 2014–2019 Triad National Security, LLC
+Copyright: 2014–2020 Triad National Security, LLC
 License: Apache-2.0
 
 Files: debian/*


### PR DESCRIPTION
This pull request updates the three instances of "2019" in copyright lines in the source tree to say "2020".

Addresses #717.