### PR TITLE
constify

### DIFF
--- a/bin/ch-checkns.c
+++ b/bin/ch-checkns.c
@@ -66,7 +66,7 @@ Example:\n\
 #define TRY(x) if (x) fatal_(__FILE__, __LINE__, errno, #x)
 
 
-void fatal_(char *file, int line, int errno_, char *str)
+void fatal_(const char *file, int line, int errno_, const char *str)
 {
    char *url = "https://github.com/hpc/charliecloud/blob/master/bin/ch-checkns.c";
    printf("error: %s: %d: %s\n", file, line, str);

--- a/bin/ch_core.c
+++ b/bin/ch_core.c
@@ -68,26 +68,29 @@ struct {
 
 /** Function prototypes (private) **/
 
-void bind_mount(char *src, char *dst, char *newroot,
-                enum bind_dep dep, unsigned long flags);
-void bind_mounts(struct bind *binds, char *newroot,
+void bind_mount(char const * const src, char const * const dst,
+                char const * const newroot, enum bind_dep dep,
+                unsigned long flags);
+void bind_mounts(struct bind const * const binds, char const * const newroot,
                  enum bind_dep dep, unsigned long flags);
-void enter_udss(struct container *c);
-void join_begin(int join_ct, char *join_tag);
-void join_namespace(pid_t pid, char *ns);
+void enter_udss(struct container * const c);
+void join_begin(int join_ct, char const * const join_tag);
+void join_namespace(pid_t pid, char const * const ns);
 void join_namespaces(pid_t pid);
 void join_end();
-void sem_timedwait_relative(sem_t *sem, int timeout);
-void setup_namespaces(struct container *c);
-void setup_passwd(struct container *c);
-void tmpfs_mount(char *dst, char *newroot, char *data);
+void sem_timedwait_relative(sem_t * const sem, int const timeout);
+void setup_namespaces(struct container const * const c);
+void setup_passwd(struct container const * const c);
+void tmpfs_mount(char const * const dst, char const * const newroot,
+                 char const * const data);
 
 
 /** Functions **/
 
 /* Bind-mount the given path into the container image. */
-void bind_mount(char *src, char *dst, char *newroot,
-                enum bind_dep dep, unsigned long flags)
+void bind_mount(char const * const src, char const * const dst,
+                char const * const newroot, enum bind_dep dep,
+                unsigned long flags)
 {
    char *dst_full = cat(newroot, dst);
 
@@ -106,7 +109,7 @@ void bind_mount(char *src, char *dst, char *newroot,
 }
 
 /* Bind-mount a null-terminated array of struct bind objects. */
-void bind_mounts(struct bind *binds, char * newroot,
+void bind_mounts(struct bind const * const binds, char const * const newroot,
                  enum bind_dep dep, unsigned long flags)
 {
    for (int i = 0; binds[i].src != NULL; i++)
@@ -114,7 +117,7 @@ void bind_mounts(struct bind *binds, char * newroot,
 }
 
 /* Set up new namespaces or join existing namespaces. */
-void containerize(struct container *c)
+void containerize(struct container * const c)
 {
    if (c->join_pid) {
       join_namespaces(c->join_pid);
@@ -137,7 +140,7 @@ void containerize(struct container *c)
    Note that pivot_root(2) requires a complex dance to work, i.e., to avoid
    multiple undocumented error conditions. This dance is explained in detail
    in bin/ch-checkns.c. */
-void enter_udss(struct container *c)
+void enter_udss(struct container * const c)
 {
    char *newroot_parent, *newroot_base;
 
@@ -213,7 +216,7 @@ void enter_udss(struct container *c)
 }
 
 /* Begin coordinated section of namespace joining. */
-void join_begin(int join_ct, char *join_tag)
+void join_begin(int join_ct, char const * const join_tag)
 {
    int fd;
 
@@ -283,7 +286,7 @@ void join_end()
 }
 
 /* Join a specific namespace. */
-void join_namespace(pid_t pid, char *ns)
+void join_namespace(pid_t pid, char const * const ns)
 {
    char *path;
    int fd;
@@ -309,7 +312,7 @@ void join_namespaces(pid_t pid)
 }
 
 /* Replace the current process with user command and arguments. */
-void run_user_command(char *argv[], char *initial_dir)
+void run_user_command(char *argv[], char const * const initial_dir)
 {
    LOG_IDS;
 
@@ -330,7 +333,7 @@ void run_user_command(char *argv[], char *initial_dir)
 
 /* Wait for semaphore sem for up to timeout seconds. If timeout or an error,
    exit unsuccessfully. */
-void sem_timedwait_relative(sem_t *sem, int timeout)
+void sem_timedwait_relative(sem_t * const sem, int const timeout)
 {
    struct timespec deadline;
 
@@ -345,7 +348,7 @@ void sem_timedwait_relative(sem_t *sem, int timeout)
 }
 
 /* Activate the desired isolation namespaces. */
-void setup_namespaces(struct container *c)
+void setup_namespaces(struct container const * const c)
 {
    int fd;
    uid_t euid = -1;
@@ -396,16 +399,16 @@ void setup_namespaces(struct container *c)
    see issue #212. After bind-mounting, we remove the files from the host;
    they persist inside the container and then disappear completely when the
    container exits. */
-void setup_passwd(struct container *c)
+void setup_passwd(struct container const * const c)
 {
    int fd;
-   char *path;
-   struct group *g;
-   struct passwd *p;
+   char * path;
+   struct group const *g;
+   struct passwd const *p;
 
    // /etc/passwd
    T_ (path = strdup("/tmp/ch-run_passwd.XXXXXX"));
-   T_ (-1 != (fd = mkstemp(path)));
+   T_ (-1 != (fd = mkstemp(path)));  // mkstemp(3) writes path
    if (c->container_uid != 0)
       T_ (1 <= dprintf(fd, "root:x:0:0:root:/root:/bin/sh\n"));
    if (c->container_uid != 65534)
@@ -455,7 +458,8 @@ void setup_passwd(struct container *c)
 }
 
 /* Mount a tmpfs at the given path. */
-void tmpfs_mount(char *dst, char *newroot, char *data)
+void tmpfs_mount(char const * const dst, char const * const newroot,
+                 char const * const data)
 {
    char *dst_full = cat(newroot, dst);
 

--- a/bin/ch_core.c
+++ b/bin/ch_core.c
@@ -68,29 +68,26 @@ struct {
 
 /** Function prototypes (private) **/
 
-void bind_mount(char const * const src, char const * const dst,
-                char const * const newroot, enum bind_dep dep,
-                unsigned long flags);
-void bind_mounts(struct bind const * const binds, char const * const newroot,
+void bind_mount(const char *src, const char *dst, const char *newroot,
+                enum bind_dep dep, unsigned long flags);
+void bind_mounts(const struct bind *binds, const char *newroot,
                  enum bind_dep dep, unsigned long flags);
-void enter_udss(struct container * const c);
-void join_begin(int join_ct, char const * const join_tag);
-void join_namespace(pid_t pid, char const * const ns);
+void enter_udss(struct container *c);
+void join_begin(int join_ct, const char *join_tag);
+void join_namespace(pid_t pid, const char *ns);
 void join_namespaces(pid_t pid);
 void join_end();
-void sem_timedwait_relative(sem_t * const sem, int const timeout);
-void setup_namespaces(struct container const * const c);
-void setup_passwd(struct container const * const c);
-void tmpfs_mount(char const * const dst, char const * const newroot,
-                 char const * const data);
+void sem_timedwait_relative(sem_t *sem, int timeout);
+void setup_namespaces(const struct container *c);
+void setup_passwd(const struct container *c);
+void tmpfs_mount(const char *dst, const char *newroot, const char *data);
 
 
 /** Functions **/
 
 /* Bind-mount the given path into the container image. */
-void bind_mount(char const * const src, char const * const dst,
-                char const * const newroot, enum bind_dep dep,
-                unsigned long flags)
+void bind_mount(const char *src, const char *dst, const char *newroot,
+                enum bind_dep dep, unsigned long flags)
 {
    char *dst_full = cat(newroot, dst);
 
@@ -109,7 +106,7 @@ void bind_mount(char const * const src, char const * const dst,
 }
 
 /* Bind-mount a null-terminated array of struct bind objects. */
-void bind_mounts(struct bind const * const binds, char const * const newroot,
+void bind_mounts(const struct bind *binds, const char *newroot,
                  enum bind_dep dep, unsigned long flags)
 {
    for (int i = 0; binds[i].src != NULL; i++)
@@ -117,7 +114,7 @@ void bind_mounts(struct bind const * const binds, char const * const newroot,
 }
 
 /* Set up new namespaces or join existing namespaces. */
-void containerize(struct container * const c)
+void containerize(struct container *c)
 {
    if (c->join_pid) {
       join_namespaces(c->join_pid);
@@ -140,7 +137,7 @@ void containerize(struct container * const c)
    Note that pivot_root(2) requires a complex dance to work, i.e., to avoid
    multiple undocumented error conditions. This dance is explained in detail
    in bin/ch-checkns.c. */
-void enter_udss(struct container * const c)
+void enter_udss(struct container *c)
 {
    char *newroot_parent, *newroot_base;
 
@@ -216,7 +213,7 @@ void enter_udss(struct container * const c)
 }
 
 /* Begin coordinated section of namespace joining. */
-void join_begin(int join_ct, char const * const join_tag)
+void join_begin(int join_ct, const char *join_tag)
 {
    int fd;
 
@@ -286,7 +283,7 @@ void join_end()
 }
 
 /* Join a specific namespace. */
-void join_namespace(pid_t pid, char const * const ns)
+void join_namespace(pid_t pid, const char *ns)
 {
    char *path;
    int fd;
@@ -312,7 +309,7 @@ void join_namespaces(pid_t pid)
 }
 
 /* Replace the current process with user command and arguments. */
-void run_user_command(char *argv[], char const * const initial_dir)
+void run_user_command(char *argv[], const char *initial_dir)
 {
    LOG_IDS;
 
@@ -333,7 +330,7 @@ void run_user_command(char *argv[], char const * const initial_dir)
 
 /* Wait for semaphore sem for up to timeout seconds. If timeout or an error,
    exit unsuccessfully. */
-void sem_timedwait_relative(sem_t * const sem, int const timeout)
+void sem_timedwait_relative(sem_t *sem, int timeout)
 {
    struct timespec deadline;
 
@@ -348,7 +345,7 @@ void sem_timedwait_relative(sem_t * const sem, int const timeout)
 }
 
 /* Activate the desired isolation namespaces. */
-void setup_namespaces(struct container const * const c)
+void setup_namespaces(const struct container *c)
 {
    int fd;
    uid_t euid = -1;
@@ -399,7 +396,7 @@ void setup_namespaces(struct container const * const c)
    see issue #212. After bind-mounting, we remove the files from the host;
    they persist inside the container and then disappear completely when the
    container exits. */
-void setup_passwd(struct container const * const c)
+void setup_passwd(const struct container *c)
 {
    int fd;
    char * path;
@@ -458,8 +455,7 @@ void setup_passwd(struct container const * const c)
 }
 
 /* Mount a tmpfs at the given path. */
-void tmpfs_mount(char const * const dst, char const * const newroot,
-                 char const * const data)
+void tmpfs_mount(const char *dst, const char *newroot, const char *data)
 {
    char *dst_full = cat(newroot, dst);
 

--- a/bin/ch_core.c
+++ b/bin/ch_core.c
@@ -399,9 +399,9 @@ void setup_namespaces(const struct container *c)
 void setup_passwd(const struct container *c)
 {
    int fd;
-   char * path;
-   struct group const *g;
-   struct passwd const *p;
+   char *path;
+   struct group *g;
+   struct passwd *p;
 
    // /etc/passwd
    T_ (path = strdup("/tmp/ch-run_passwd.XXXXXX"));

--- a/bin/ch_core.h
+++ b/bin/ch_core.h
@@ -38,5 +38,5 @@ struct container {
 
 /** Function prototypes **/
 
-void containerize(struct container *c);
-void run_user_command(char *argv[], char *initial_dir);
+void containerize(struct container * const c);
+void run_user_command(char *argv[], char const * const initial_dir);

--- a/bin/ch_core.h
+++ b/bin/ch_core.h
@@ -38,5 +38,5 @@ struct container {
 
 /** Function prototypes **/
 
-void containerize(struct container * const c);
-void run_user_command(char *argv[], char const * const initial_dir);
+void containerize(struct container *c);
+void run_user_command(char *argv[], const char *initial_dir);

--- a/bin/ch_misc.c
+++ b/bin/ch_misc.c
@@ -42,7 +42,7 @@ int verbose;
 /** Functions **/
 
 /* Concatenate strings a and b, then return the result. */
-char *cat(char *a, char *b)
+char *cat(char const * const a, char const * const b)
 {
    char *ret;
 
@@ -51,7 +51,7 @@ char *cat(char *a, char *b)
 }
 
 /* If verbose, print uids and gids on stderr prefixed with where. */
-void log_ids(const char *func, int line)
+void log_ids(char const * const func, int const line)
 {
    uid_t ruid, euid, suid;
    gid_t rgid, egid, sgid;
@@ -83,7 +83,8 @@ void log_ids(const char *func, int line)
      1 : "warning" : always print
      2 : "info"    : print if verbose >= 2
      3 : "debug"   : print if verbose >= 3 */
-void msg(int level, char *file, int line, int errno_, char *fmt, ...)
+void msg(int const level, char const * const file, int const line,
+         int const errno_, char const * const fmt, ...)
 {
    va_list ap;
 
@@ -111,7 +112,7 @@ void msg(int level, char *file, int line, int errno_, char *fmt, ...)
 }
 
 /* Return true if the given path exists, false otherwise. On error, exit. */
-bool path_exists(char *path)
+bool path_exists(char const * const path)
 {
    struct stat sb;
 
@@ -132,7 +133,7 @@ bool path_exists(char *path)
    Also, the kernel contains a test "unprivileged-remount-test.c" that
    manually translates the flags. Thus, I wasn't comfortable simply passing
    the output of statvfs(3) to mount(2). */
-unsigned long path_mount_flags(char *path)
+unsigned long path_mount_flags(char const * const path)
 {
    struct statvfs sv;
    unsigned long known_flags =   ST_MANDLOCK   | ST_NOATIME  | ST_NODEV
@@ -155,7 +156,8 @@ unsigned long path_mount_flags(char *path)
 }
 
 /* Split path into dirname and basename. */
-void path_split(char *path, char **dir, char **base)
+void path_split(char const * const path,
+                char ** const dir, char ** const base)
 {
    char *path2;
 
@@ -171,13 +173,19 @@ void path_split(char *path, char **dir, char **base)
    point into a new buffer allocated with malloc(3). This has two
    implications: (1) the caller must free(3) *a but not *b, and (2) the parts
    can be rejoined by setting *(*b-1) to del. The point here is to provide an
-   easier wrapper for strsep(3). */
-void split(char **a, char **b, char *str, char del)
+   easier wrapper for strsep(3).
+
+   FIXME (reidpr 2020-04-23): I feel like I should be able to add another
+   const to a and b, but it won't build. I don't understand what the
+   difference from path_split() is.*/
+void split(char ** const a, char ** const b,
+           char const * const str, char del)
 {
-   char delstr[2] = { del, 0 };
+   char *tmp;
+   char const delstr[2] = { del, 0 };
    T_ (str != NULL);
-   str = strdup(str);
-   *b = str;
+   tmp = strdup(str);
+   *b = tmp;
    *a = strsep(b, delstr);
    if (*b == NULL)
       *a = NULL;

--- a/bin/ch_misc.c
+++ b/bin/ch_misc.c
@@ -42,7 +42,7 @@ int verbose;
 /** Functions **/
 
 /* Concatenate strings a and b, then return the result. */
-char *cat(char const * const a, char const * const b)
+char *cat(const char *a, const char *b)
 {
    char *ret;
 
@@ -51,7 +51,7 @@ char *cat(char const * const a, char const * const b)
 }
 
 /* If verbose, print uids and gids on stderr prefixed with where. */
-void log_ids(char const *func, int line)
+void log_ids(const char *func, int line)
 {
    uid_t ruid, euid, suid;
    gid_t rgid, egid, sgid;
@@ -83,8 +83,8 @@ void log_ids(char const *func, int line)
      1 : "warning" : always print
      2 : "info"    : print if verbose >= 2
      3 : "debug"   : print if verbose >= 3 */
-void msg(int const level, char const * const file, int const line,
-         int const errno_, char const * const fmt, ...)
+void msg(int level, const char *file, int line, int errno_,
+         const char *fmt, ...)
 {
    va_list ap;
 
@@ -112,7 +112,7 @@ void msg(int const level, char const * const file, int const line,
 }
 
 /* Return true if the given path exists, false otherwise. On error, exit. */
-bool path_exists(char const * const path)
+bool path_exists(const char *path)
 {
    struct stat sb;
 
@@ -133,7 +133,7 @@ bool path_exists(char const * const path)
    Also, the kernel contains a test "unprivileged-remount-test.c" that
    manually translates the flags. Thus, I wasn't comfortable simply passing
    the output of statvfs(3) to mount(2). */
-unsigned long path_mount_flags(char const * const path)
+unsigned long path_mount_flags(const char *path)
 {
    struct statvfs sv;
    unsigned long known_flags =   ST_MANDLOCK   | ST_NOATIME  | ST_NODEV
@@ -156,8 +156,7 @@ unsigned long path_mount_flags(char const * const path)
 }
 
 /* Split path into dirname and basename. */
-void path_split(char const * const path,
-                char ** const dir, char ** const base)
+void path_split(const char *path, char **dir, char **base)
 {
    char *path2;
 
@@ -178,8 +177,7 @@ void path_split(char const * const path,
    FIXME (reidpr 2020-04-23): I feel like I should be able to add another
    const to a and b, but it won't build. I don't understand what the
    difference from path_split() is.*/
-void split(char ** const a, char ** const b,
-           char const * const str, char del)
+void split(char **a, char **b, const char *str, char del)
 {
    char *tmp;
    char const delstr[2] = { del, 0 };

--- a/bin/ch_misc.c
+++ b/bin/ch_misc.c
@@ -172,15 +172,11 @@ void path_split(const char *path, char **dir, char **base)
    point into a new buffer allocated with malloc(3). This has two
    implications: (1) the caller must free(3) *a but not *b, and (2) the parts
    can be rejoined by setting *(*b-1) to del. The point here is to provide an
-   easier wrapper for strsep(3).
-
-   FIXME (reidpr 2020-04-23): I feel like I should be able to add another
-   const to a and b, but it won't build. I don't understand what the
-   difference from path_split() is.*/
+   easier wrapper for strsep(3). */
 void split(char **a, char **b, const char *str, char del)
 {
    char *tmp;
-   char const delstr[2] = { del, 0 };
+   char delstr[2] = { del, 0 };
    T_ (str != NULL);
    tmp = strdup(str);
    *b = tmp;

--- a/bin/ch_misc.h
+++ b/bin/ch_misc.h
@@ -68,11 +68,13 @@ extern int verbose;
 
 /** Function prototypes **/
 
-char *cat(char *a, char *b);
-void log_ids(const char *func, int line);
-void msg(int level, char *file, int line, int errno_, char *fmt, ...);
-bool path_exists(char *path);
-unsigned long path_mount_flags(char *path);
-void path_split(char *path, char **dir, char **base);
-void split(char **a, char **b, char *str, char del);
+char *cat(char const * const a, char const * const b);
+void log_ids(char const * const func, int const line);
+void msg(int const level, char const * const file, int const line,
+         int const errno_, char const * const fmt, ...);
+bool path_exists(char const * const path);
+unsigned long path_mount_flags(char const * const path);
+void path_split(char const * const path,
+                char ** const dir, char ** const base);
+void split(char ** const a, char ** const b, char const * const str, char del);
 void version(void);

--- a/bin/ch_misc.h
+++ b/bin/ch_misc.h
@@ -68,11 +68,12 @@ extern int verbose;
 
 /** Function prototypes **/
 
-char *cat(char *a, char *b);
-void log_ids(char const *func, int line);
-void msg(int level, char *file, int line, int errno_, char *fmt, ...);
-bool path_exists(char *path);
-unsigned long path_mount_flags(char *path);
-void path_split(char *path, char **dir, char **base);
-void split(char **a, char **b, char *str, char del);
+char *cat(const char *a, const char *b);
+void log_ids(const char *func, int line);
+void msg(int level, const char *file, int line, int errno_,
+         const char *fmt, ...);
+bool path_exists(const char *path);
+unsigned long path_mount_flags(const char *path);
+void path_split(const char *path, char **dir, char **base);
+void split(char **a, char **b, const char *str, char del);
 void version(void);

--- a/doc/dev.rst
+++ b/doc/dev.rst
@@ -810,6 +810,36 @@ Variable conventions in shell scripts and :code:`.bats` files
     foo=${bar}/baz    # yes
     foo="${bar}/baz"  # no
 
+C code
+------
+
+:code:`const`
+~~~~~~~~~~~~~
+
+The :code:`const` keyword is used to indicate that variables are read-only. It
+has a variety of uses; in Charliecloud, we use it for `function pointer
+arguments <https://softwareengineering.stackexchange.com/a/204720>`_ to state
+whether or not the object pointed to will be altered by the function. For
+example:
+
+.. code-block:: c
+
+  void foo(const char *in, char *out)
+
+is a function that will not alter the string pointed to by :code:`in` but may
+alter the string pointed to by :code:`out`. (Note that :code:`char const` is
+equivalent to :code:`const char`, but we use the latter order because that's
+what appears in GCC error messages.)
+
+We do not use :code:`const` on local variables or function arguments passed by
+value. One could do this to be more clear about what is and isn't mutable, but
+it adds quite a lot of noise to the source code, and in our evaluations didn't
+catch any bugs. We also do not use it on double pointers (e.g., :code:`char
+**out` used when a function allocates a string and sets the caller's pointer
+to point to it), because so far those are all out-arguments and C has
+`confusing rules <http://c-faq.com/ansi/constmismatch.html>`_ about double
+pointers and :code:`const`.
+
 
 OCI technical notes
 ===================


### PR DESCRIPTION
Addresses #500, in part.

This PR is a partially complete implementation of adding `const` everywhere it fits. This keyword designates a variable as unmodifiable, though there is a lot of nuance ([1](https://en.wikipedia.org/wiki/Const_(computer_programming)), [2](https://softwareengineering.stackexchange.com/questions/204500/when-and-for-what-purposes-should-the-const-keyword-be-used-in-c-for-variables)) and compiler enforcement is [incomplete for double pointers](https://stackoverflow.com/questions/5055655)

Currently, `ch_misc.{c,h}` and `ch_core.{c.h}` are modified to add `const` to all pointer function arguments. `ch_misc.c` also adds `const` to non-pointer function arguments and local variables. If we like it, I will complete the implementation.

The advantage is that we convert some runtime errors into compile failures, though I did not find any such cases yet. The disadvantage is that it adds a fair amount of noise to the code.