### PR TITLE
Ignore existing fixtures dir during install.

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -70,7 +70,7 @@ all-local:
 clean-local:
 	rm -f fixtures/symlink-to-tmp
 install-data-hook:
-	mkdir $(DESTDIR)$(testdir)/fixtures
+	mkdir -p $(DESTDIR)$(testdir)/fixtures
 	ln -fs /tmp $(DESTDIR)$(testdir)/fixtures/symlink-to-tmp
 uninstall-hook:
 	rm -f $(DESTDIR)$(testdir)/fixtures/symlink-to-tmp


### PR DESCRIPTION
Currently `make install` will fail if there already exists a previously installed versions:

```
mkdir /usr/local/libexec/charliecloud/test/fixtures
mkdir: cannot create directory '/usr/local/libexec/charliecloud/test/fixtures': File exists
make[3]: *** [Makefile:668: install-data-hook] Error 1
```

This PR address this error.