### PR TITLE
ch-grow: execute instructions in order under Lark 0.8.6

### DIFF
--- a/bin/ch-grow.py.in
+++ b/bin/ch-grow.py.in
@@ -153,7 +153,16 @@ defined of --storage, $CH_GROW_STORAGE, and %s.
    if (cli.parse_only):
       sys.exit(0)
 
-   Main_Loop().visit(tree)
+   # We do not actually care whether the tree is traversed breadth-first or
+   # depth-first, but we *do* care that the nodes are visited in order.
+   # Neither visit() nor visit_topdown() are documented as of 2020-06-11 [1],
+   # but examining the source code [2] shows that visit_topdown() uses
+   # Tree.iter_trees_topdown(), which *is* documented to be in-order [3].
+   #
+   # [1]: https://lark-parser.readthedocs.io/en/latest/visitors/#visitors
+   # [2]: https://github.com/lark-parser/lark/blob/445c8d4/lark/visitors.py#L211
+   # [3]: https://lark-parser.readthedocs.io/en/latest/classes/#tree
+   Main_Loop().visit_topdown(tree)
 
    if (len(cli.build_arg) != 0):
       ch.FATAL("--build-arg: not consumed: " + " ".join(cli.build_arg.keys()))
@@ -483,4 +492,3 @@ def unescape(sl):
 
 if (__name__ == "__main__"):
    main()
-


### PR DESCRIPTION
This PR changes the the main loop to use `lark.Visitor.visit_topdown()` instead of `lark.Visitor.visit()`, because starting in Lark 0.8.6, `visit()` does not visit the nodes in order, while `visit_topdown()` does.

Using `visit()`:

```
$ pip3 install lark-parser==0.8.5
[...]
$ ch-grow -t argenv -f test/Dockerfile.argenv test
growing: argenv
  4 FROM 00_tiny
  6 ARG chse_arg1_df
  7 ARG chse_arg2_df='arg2'
  8 ARG chse_arg3_df='arg3 arg2'
  9 ENV chse_env1_df='env1'
 10 ENV chse_env2_df='env2 env1'
 11 RUN ['/bin/sh', '-c', "env | egrep '^chse_' | sort"]
chse_arg2_df=arg2
chse_arg3_df=arg3 arg2
chse_env1_df=env1
chse_env2_df=env2 env1
```

vs.

```
$ pip3 install lark-parser==0.8.6  # latest version
[...]
$ ch-grow -t argenv -f test/Dockerfile.argenv test
growing: argenv
 10 ENV chse_env2_df='env2 ${chse_env1_df}'
  6 ARG chse_arg1_df
  7 ARG chse_arg2_df='arg2'
  8 ARG chse_arg3_df='arg3 arg2'
  9 ENV chse_env1_df='env1'
 11 RUN ['/bin/sh', '-c', "env | egrep '^chse_' | sort"]
chse_arg2_df=arg2
chse_arg3_df=arg3 arg2
chse_env1_df=env1
chse_env2_df=env2 ${chse_env1_df}
  4 FROM 00_tiny
```

Using `visit_topdown()`, the order is correct in both 0.8.5 and 0.8.6.