### PR TITLE
ch-builder2tar: clean up builder checking

### DIFF
--- a/bin/ch-builder2tar
+++ b/bin/ch-builder2tar
@@ -156,8 +156,15 @@ docker)
 
     ;;
 
+none)
+
+    echo 'this script does not support the above builder' 1>&2
+    exit 1
+    ;;
+
 *)
-    Echo "unknown builder: $CH_BUILDER" 1>&2
+    # builder_choose() above should have ensured the builder is good.
+    echo "unreachable code reached: unknown builder: $CH_BUILDER" 1>&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
We had a case typo and also the error message was confusing and *almost* unreachable. Now it really is unreachable.