### PR TITLE
ch-pull2dir: tidy use of sed

### DIFF
--- a/bin/ch-pull2dir
+++ b/bin/ch-pull2dir
@@ -28,5 +28,6 @@ image=$1
 dest=$2
 
 "${ch_bin}/ch-pull2tar" "$image" "$dest"
-"${ch_bin}/ch-tar2dir" "${dest}/$(echo "$image" | sed 's/\//\./').tar.gz" "$dest"
+image=$(echo "$image" | sed 's/\//\./g')
+"${ch_bin}/ch-tar2dir" "${dest}/${image}.tar.gz" "$dest"
 rm -v "${dest}/${image}.tar.gz"


### PR DESCRIPTION
Just a minor change I wanted to propose to the `ch-pull2dir` script after I ran into this issue this past weekend using it. With image names containing multiple `/` characters (e.g. from GitLab container registries) they hadn't been replaced with the `sed` command. Additionally, these will be observed by the `rm` used to remove the original tarball.

