### PR TITLE
test form of version number but not value

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -147,13 +147,13 @@ Examples:
     Github provides. This should make you wary because you don't have any
     provenance. It might even be uncommitted work or an abandoned branch.
 
-  * :code:`0.2.1~pre.1a99f42` : Master branch commit 1a99f42, built from a
+  * :code:`0.2.1~pre+1a99f42` : Master branch commit 1a99f42, built from a
     clean working directory (i.e., no changes since that commit).
 
-  * :code:`0.2.1~pre.foo1.0729a78` : Commit 0729a78 on branch :code:`foo-1`,
+  * :code:`0.2.1~pre+foo1.0729a78` : Commit 0729a78 on branch :code:`foo-1`,
     :code:`foo_1`, etc. built from clean working directory.
 
-  * :code:`0.2.1~pre.foo1.0729a78.dirty` : Commit 0729a78 on one of those
+  * :code:`0.2.1~pre+foo1.0729a78.dirty` : Commit 0729a78 on one of those
     branches, plus un-committed changes.
 
 :code:`--uid 0` lets me read files I can’t otherwise!

--- a/packaging/fedora/lib64.patch
+++ b/packaging/fedora/lib64.patch
@@ -185,18 +185,3 @@ diff -ur charliecloud/lib/base.sh charliecloud-lib/lib/base.sh
 
 
 Only in charliecloud/packaging/fedora: ch-test.lib.patch
-diff -ur charliecloud/test/build/10_sanity.bats
-charliecloud-lib/test/build/10_sanity.bats
---- charliecloud/test/build/10_sanity.bats    2020-04-16 13:25:13.341230859
--0600
-+++ charliecloud-lib/test/build/10_sanity.bats    2020-04-20 11:55:56.472877646
--0600
-@@ -20,7 +20,7 @@
-     echo "version: ${ch_version}"
-     [[ $(echo "$ch_version" | wc -l) -eq 1 ]]   # one line
-     [[ $ch_version =~ ^0\.[0-9]+(\.[0-9]+)? ]]  # starts with right numbers
--    diff -u <(echo "$ch_version") "${ch_base}/lib/charliecloud/version.txt"
-+    diff -u <(echo "$ch_version") "${ch_base}/lib64/charliecloud/version.txt"
- }
-
- @test 'executables seem sane' {

--- a/test/build/10_sanity.bats
+++ b/test/build/10_sanity.bats
@@ -17,10 +17,13 @@ load ../common
 }
 
 @test 'version number seems sane' {
+    # This checks the form of the version number but not whether it's
+    # consistent with anything, because so far that level of strictness has
+    # yielded hundreds of false positives but zero actual bugs.
+    scope quick
     echo "version: ${ch_version}"
-    [[ $(echo "$ch_version" | wc -l) -eq 1 ]]   # one line
-    [[ $ch_version =~ ^0\.[0-9]+(\.[0-9]+)? ]]  # starts with right numbers
-    diff -u <(echo "$ch_version") "${ch_base}/lib/charliecloud/version.txt"
+    re='^0\.[0-9]+(\.[0-9]+)?(~pre\+[A-Za-z0-9]+(\.[0-9a-f]+(\.dirty)?)?)?$'
+    [[ $ch_version =~ $re ]]
 }
 
 @test 'executables seem sane' {
@@ -38,7 +41,6 @@ load ../common
         run "$path" --version
         echo "$output"
         [[ $status -eq 0 ]]
-        diff -u <(echo "${output}") <(echo "$ch_version")
         # --help: returns 0, says "Usage:" somewhere.
         run "$path" --help
         echo "$output"


### PR DESCRIPTION
I keep getting test failures on my dev box because the version number the test suite expects is different from what was most recently built. In no case has this ever identified a real bug, so this PR changes the test to check the *form* of the version number but not its *value*.

Since this PR involves a ludicrous regex, here is the test value I used in developing it on regex101.com:

```
0.2.0
0.2.1~pre
0.2.1~pre+1a99f42
0.2.1~pre+foo1.0729a78
0.2.1~pre+foo1.0729a78.dirty
0.2.1~pre+foo1.0729a78.dirtx
0.17~pre+8409d44
```

Screenshot of same:

![Screen Shot 2020-07-28 at 10 26 27 AM](https://user-images.githubusercontent.com/1682574/88693688-d1c50300-d0bc-11ea-8593-f548ed3b5341.png)

Note it doesn't match the second line, which is a valid version number, but a dubious situation (pre-release but no Git information).