### PR TITLE
tests: add ln -T for consistency with examples

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -68,12 +68,12 @@ nobase_nodist_test_SCRIPTS = $(sobuilts)
 CLEANFILES = $(sobuilts) docs-sane make-perms-test
 # See comment about symlinks in examples/Makefile.am.
 all-local:
-	ln -fs /tmp fixtures/symlink-to-tmp
+	ln -fTs /tmp fixtures/symlink-to-tmp
 clean-local:
 	rm -f fixtures/symlink-to-tmp
 install-data-hook:
 	mkdir -p $(DESTDIR)$(testdir)/fixtures
-	ln -fs /tmp $(DESTDIR)$(testdir)/fixtures/symlink-to-tmp
+	ln -fTs /tmp $(DESTDIR)$(testdir)/fixtures/symlink-to-tmp
 uninstall-hook:
 	rm -f $(DESTDIR)$(testdir)/fixtures/symlink-to-tmp
 	rmdir $(DESTDIR)$(testdir)/fixtures || true
@@ -92,9 +92,9 @@ sotest/libsotest.so.1.0: sotest/libsotest.c
 	$(CC) -o $@ $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) -shared -fPIC -Wl,-soname,libsotest.so.1 -lc $^
 
 sotest/libsotest.so: sotest/libsotest.so.1.0
-	ln -f -s ./libsotest.so.1.0 $@
+	ln -fTs ./libsotest.so.1.0 $@
 sotest/libsotest.so.1: sotest/libsotest.so.1.0
-	ln -f -s ./libsotest.so.1.0 $@
+	ln -fTs ./libsotest.so.1.0 $@
 
 sotest/bin/sotest: sotest/sotest
 	mkdir -p sotest/bin


### PR DESCRIPTION
As reported in spack/spack#17968, the `test` directory lacks argument `-T` for `ln(1)`.