### PR TITLE
automake: override distcheck; add installcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+ch_libdir = $(DESTDIR)$(libdir)/charliecloud
+
 SUBDIRS = lib bin doc examples misc packaging test
 
 # The Travis stuff isn't really relevant for the tarballs, but they should
@@ -5,3 +7,21 @@ SUBDIRS = lib bin doc examples misc packaging test
 EXTRA_DIST = .travis.yml
 
 EXTRA_DIST += LICENSE README.rst VERSION autogen.sh
+
+override distcheck:
+	tar -xf $(distdir).tar.gz
+	cd $(distdir) && ./configure \
+	              && $(MAKE) \
+	              && ./bin/ch-test all;
+	tar -xf $(distdir).tar.gz
+	cd $(distdir) && ./autogen.sh \
+	              && ./configure --prefix=$(abs_top_builddir)/$(distdir)/prefix \
+	              && $(MAKE) install \
+	              && $(MAKE) installcheck;
+	rm -rf $(distdir)
+
+installcheck-local:
+	diff $(top_builddir)/lib/version.txt $(ch_libdir)/version.txt
+	$(DESTDIR)$(bindir)/ch-test all \
+		--pack-dir=/tmp/ch-test.tmp.${USER}/tar \
+		--img-dir=/tmp/ch-test.tmp.${USER}/img;

--- a/autogen.sh
+++ b/autogen.sh
@@ -53,7 +53,7 @@ rm -rf Makefile \
 
 # Create configure and friends.
 if [[ $1 != --clean ]]; then
-    autoreconf --force --install -Wall -Werror
+    autoreconf --force --install -Wno-override -Wall -Werror
 
     set +x
     echo

--- a/test/travis.bash
+++ b/test/travis.bash
@@ -63,9 +63,8 @@ esac
 make "$MAKEJ"
 bin/ch-run --version
 
-if [[ $MAKE_INSTALL ]]; then
-    sudo make "$MAKEJ" install
-    ch_test="${PREFIX}/bin/ch-test"
+if [[ $DISTCHECK ]]; then
+    sudo make distcheck
 else
     ch_test=$(readlink -f bin/ch-test)  # need absolute path
 fi

--- a/test/travis.bash
+++ b/test/travis.bash
@@ -64,7 +64,7 @@ make "$MAKEJ"
 bin/ch-run --version
 
 if [[ $DISTCHECK ]]; then
-    sudo make distcheck
+    make distcheck
 else
     ch_test=$(readlink -f bin/ch-test)  # need absolute path
 fi

--- a/test/travis.yml
+++ b/test/travis.yml
@@ -21,8 +21,8 @@ compiler: gcc
 #   TARBALL=              # build in Git checkout
 #   TARBALL=archive       # build from "git archive" tarball
 #   TARBALL=export        # build from "make export" tarball
-#   MAKE_INSTALL=         # run from build directory
-#   MAKE_INSTALL=yes      # "make install"; run that one
+#   DISTCHECK=            # run from build directory
+#   DISTCHECK=yes         # "make distcheck" and "installcheck"
 #
 # Note: $INSTALL is used by Autotools, and setting it to "yes" causes very
 # weird errors, e.g.:
@@ -82,15 +82,15 @@ jobs:
       env: CH_BUILDER=docker          PACK_FMT=tar
 
     - <<: *stage_install
-      env: CH_BUILDER=none            TARBALL=export       MAKE_INSTALL=yes
+      env: CH_BUILDER=none            TARBALL=export       DISTCHECK=yes
     - <<: *stage_install
-      env: CH_BUILDER=buildah         TARBALL=export       MAKE_INSTALL=yes
+      env: CH_BUILDER=buildah         TARBALL=export       DISTCHECK=yes
     - <<: *stage_install
-      env: CH_BUILDER=buildah-runc    TARBALL=export       MAKE_INSTALL=yes
+      env: CH_BUILDER=buildah-runc    TARBALL=export       DISTCHECK=yes
     - <<: *stage_install
-      env: CH_BUILDER=ch-grow         TARBALL=export       MAKE_INSTALL=yes
+      env: CH_BUILDER=ch-grow         TARBALL=export       DISTCHECK=yes
     - <<: *stage_install
-      env: CH_BUILDER=docker          TARBALL=export       MAKE_INSTALL=yes
+      env: CH_BUILDER=docker          TARBALL=export       DISTCHECK=yes
 
     - <<: *stage_misc
       env: CH_BUILDER=buildah         MINIMAL_DEPS=yes


### PR DESCRIPTION
Addresses #604 and partially addresses #603. 

A couple notes: 1) unlike #753, this PR avoids `make check` due to Travis timeout issues; and 2) we override `distcheck` to avoid issue #820. 

