### PR TITLE
ENV: accept line continuations

### DIFF
--- a/bin/ch-build
+++ b/bin/ch-build
@@ -82,6 +82,14 @@ case $CH_BUILDER in
                 ignore_chown=false
                 ;;
         esac
+        # If Buildah sees a terminal on stdin, it does TTY stuff that confuses
+        # ch-run-oci, so we always have to redirect stdin. If it's already
+        # redirected, just pass that through; otherwise, use /dev/null.
+        if [ -t 0 ]; then
+            stdin=/dev/null   # is TTY
+        else
+            stdin=/dev/stdin  # not TTY
+        fi
         BUILDAH_LAYERS=true \
         buildah --storage-opt .ignore_chown_errors="$ignore_chown" \
                 build-using-dockerfile \
@@ -93,7 +101,7 @@ case $CH_BUILDER in
                 --build-arg no_proxy="$no_proxy" \
                 --isolation=rootless \
                 --runtime="$runtime" \
-                "$@" < /dev/null
+                "$@" < $stdin
         ;;
     ch-grow)
         "${ch_bin}/ch-grow" "$@"

--- a/examples/exhaustive/Dockerfile
+++ b/examples/exhaustive/Dockerfile
@@ -14,15 +14,6 @@
 # Use a moderately complex image reference.
 FROM registry-1.docker.io:443/library/alpine:3.9 AS stage1
 
-# FIXME: These should maybe be moved into Dockerfile.argenv?
-ENV chse_1 value1 with spaces and trailing space 
-ENV chse_2 "value2"
-ENV chse_2a chse2: ${chse_2}
-ENV chse_2b="chse2: ${chse_2}"
-ENV chse_3 \"value3\"
-ENV chse_4=value4 chse_5="value5 foo" chse_7=\"value7\"
-#ENV chse_4=value4 chse_5="value5 foo" chse_6=value6\ foo chse_7=\"value7\"
-
 RUN pwd
 WORKDIR /usr/local/src
 RUN pwd

--- a/examples/spark/Dockerfile
+++ b/examples/spark/Dockerfile
@@ -25,8 +25,8 @@ RUN touch /usr/bin/ch-ssh
 # 3. We disapprove of Spark's master/slave terminology, but it's what the
 #    scripts are called, so we don't see a way to avoid it currently.
 
-ARG URLPATH=https://www.apache.org/dist/spark/spark-2.4.6/
-ARG DIR=spark-2.4.6-bin-hadoop2.7
+ARG URLPATH=https://www.apache.org/dist/spark/spark-2.4.7/
+ARG DIR=spark-2.4.7-bin-hadoop2.7
 ARG TAR=$DIR.tgz
 RUN wget -nv $URLPATH/$TAR \
  && tar xf $TAR \

--- a/examples/spark/Dockerfile
+++ b/examples/spark/Dockerfile
@@ -24,8 +24,7 @@ RUN touch /usr/bin/ch-ssh
 #
 # 3. We disapprove of Spark's master/slave terminology, but it's what the
 #    scripts are called, so we don't see a way to avoid it currently.
-
-ARG URLPATH=https://www.apache.org/dist/spark/spark-2.4.7/
+ARG URLPATH=https://archive.apache.org/dist/spark/spark-2.4.7/
 ARG DIR=spark-2.4.7-bin-hadoop2.7
 ARG TAR=$DIR.tgz
 RUN wget -nv $URLPATH/$TAR \

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -130,16 +130,14 @@ OPTION_KEY: /[a-z]+/
 OPTION_VALUE: /[^ \t\n]+/
 
 HEX_STRING: /[0-9A-Fa-f]+/
-LINE: ( LINE_CONTINUE | /[^\n]/ )+
+LINE: ( _LINE_CONTINUE | /[^\n]/ )+
 WORD: /[^ \t\n=]/+
 
 _string_list: "[" _WS? STRING_QUOTED ( "," _WS? STRING_QUOTED )* _WS? "]"
 
-LINE_CONTINUE: "\\\n"
-%ignore LINE_CONTINUE
-
 _NEWLINES: _WS? "\n"+
-_WS: /[ \t]/+
+_WS: /[ \t]|\\\n/+
+_LINE_CONTINUE: "\\\n"
 
 %import common.ESCAPED_STRING -> STRING_QUOTED
 """

--- a/test/Dockerfile.argenv
+++ b/test/Dockerfile.argenv
@@ -1,4 +1,9 @@
-# Test ARG and ENV handling.
+# Test how ARG and ENV variables flow around. This does not address syntax
+# quirks; for that see test 'Dockerfile: syntax quirks' in
+# build/50_dockerfile.bats. Results are checked in both test 'Dockerfile: ARG
+# and ENV values' in build/50_dockerfile.bats and multiple tests in
+# run/ch-run_misc.bats. The latter is why this is a separate Dockerfile
+# instead of embedded in a .bats file.
 
 # ch-test-scope: standard
 FROM 00_tiny
@@ -8,4 +13,4 @@ ARG chse_arg2_df=arg2
 ARG chse_arg3_df="arg3 ${chse_arg2_df}"
 ENV chse_env1_df env1
 ENV chse_env2_df="env2 ${chse_env1_df}"
-RUN env | egrep '^chse_' | sort
+RUN env | sort


### PR DESCRIPTION
`ENV` should accept backslash line continuations, but currently it does not. This PR fixes that.

Also, it fixes #847 and #850 to make the tests pass.

`build/50_dockerfile.bats` is inflated because I moved a test. New test is at the end of the addition.