### PR TITLE
configure: correct nvidia configure check to use NVIDIA_CLI consistently

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -287,7 +287,7 @@ AC_CHECK_PROG([NVIDIA_CLI], [nvidia-container-cli], [nvidia-container-cli])
 CH_CHECK_VERSION([NVIDIA_CLI], [$vmin_nvidia_CLI],
                  [-V | head -1 | cut -d' ' -f2])
 AC_MSG_CHECKING([for nVidia libraries & executables])
-AS_IF([test -n "$NVIDIA_CLI_VERSION"],
+AS_IF([test -n "$NVIDIA_CLI"],
   [AS_IF([nvidia-container-cli list | grep -Fq libnvidia-glcore.so],
         [have_nvidia_libs=yes],
         [have_nvidia_libs=no])],


### PR DESCRIPTION
Addresses #853 

Thank you to @jyaghob for the report and the suggested fix.

Tested on an platform with nvidia libraries, diff of before and after the fix below:
```diff
diff before.txt after.txt 
46c46
< checking for nVidia libraries & executables... no
---
> checking for nVidia libraries & executables... yes
72d71
< config.status: bin/config.h is unchanged
158c157
<   inject nVidia GPU libraries: no
---
>   inject nVidia GPU libraries: yes
160c159
<     nVidia libraries & executables present ... no
---
>     nVidia libraries & executables present ... yes
```