### PR TITLE
examples/spark update spark to 3.0.1 to fix compatibility with Java 11 runtime

### DIFF
--- a/bin/ch-run-oci.py.in
+++ b/bin/ch-run-oci.py.in
@@ -136,7 +136,6 @@ nogroup:x:65534:
    # unprivileged user namespace. See also the default environment.
    #
    # Debian apt/dpkg/etc. want to chown(1), chgrp(1), etc. in various ways.
-   ch.symlink("/bin/true", "%s/ch/bin/chown" % path)
    ch.symlink("/bin/true", "%s/ch/bin/chgrp" % path)
    ch.symlink("/bin/true", "%s/ch/bin/dpkg-statoverride" % path)
    # Debian package management also wants to mess around with users. This is
@@ -144,6 +143,7 @@ nogroup:x:65534:
    # work if they are in /ch/bin, I think because dpkg is resetting the path?
    # For now we'll do this, but I don't like it. fakeroot(1) also solves the
    # problem (see issue #472).
+   ch.symlink("/bin/true", "%s/bin/chown" % path, clobber=True)
    ch.symlink("/bin/true", "%s/usr/sbin/groupadd" % path, clobber=True)
    ch.symlink("/bin/true", "%s/usr/sbin/useradd" % path, clobber=True)
    ch.symlink("/bin/true", "%s/usr/sbin/usermod" % path, clobber=True)

--- a/examples/spark/Dockerfile
+++ b/examples/spark/Dockerfile
@@ -1,10 +1,4 @@
-# ch-test-scope: skip
-#
-# FIXME: currently fails spark/pi; change to standard when fixed. E.g.:
-#
-#   WARNING: An illegal reflective access operation has occurred
-#   pyspark.sql.utils.IllegalArgumentException: u'Unsupported class file major version 55'
-#
+# ch-test-scope: standard
 # Use Buster because Stretch JRE install fails with:
 #
 #   tempnam() is so ludicrously insecure as to defy implementation.tempnam: Cannot allocate memory
@@ -36,8 +30,8 @@ RUN touch /usr/bin/ch-ssh
 #
 # 3. We disapprove of Spark's master/slave terminology, but it's what the
 #    scripts are called, so we don't see a way to avoid it currently.
-ARG URLPATH=https://archive.apache.org/dist/spark/spark-2.4.7/
-ARG DIR=spark-2.4.7-bin-hadoop2.7
+ARG URLPATH=https://archive.apache.org/dist/spark/spark-3.0.1/
+ARG DIR=spark-3.0.1-bin-hadoop2.7
 ARG TAR=$DIR.tgz
 RUN wget -nv $URLPATH/$TAR \
  && tar xf $TAR \


### PR DESCRIPTION
Addresses #859 

Passes the tests locally.