### PR TITLE
Configure yum to fail on missing packages

### DIFF
--- a/examples/Dockerfile.centos7
+++ b/examples/Dockerfile.centos7
@@ -4,11 +4,9 @@ FROM centos:7
 # This image has two purposes: (1) demonstrate we can build a CentOS 7 image
 # and (2) provide a build environment for Charliecloud EPEL 7 RPMs.
 
-# Configure yum to fail if a package can't be installed (see issue #858).
-RUN echo 'skip_missing_names_on_install=0' >> /etc/yum.conf
-
+# Install our dependencies, ensuring we fail out if any are missing.
 RUN yum install -y epel-release \
- && yum install -y \
+ && yum install -y --setopt=skip_missing_names_on_install=0 \
                 autoconf \
                 automake \
                 bats \

--- a/examples/spack/Dockerfile
+++ b/examples/spack/Dockerfile
@@ -1,5 +1,5 @@
 # ch-test-scope: full
-FROM centos:7
+FROM centos:8
 
 # Note: Spack is a bit of an odd duck testing wise. Because it's a package
 # manager, the key tests we want are to install stuff (this includes the Spack
@@ -15,25 +15,22 @@ FROM centos:7
 
 # Packages needed to install Spack [1].
 #
-# Note: Spack claims that Python 3 works, but using python3 here fails later
-# with "/usr/bin/env: 'python': No such file or directory".
-# bzip, file, patch, unzip, and which are packages needed to install 
+# bzip, file, patch, unzip, and which are packages needed to install
 # Charliecloud with Spack. These are in Spack's Docker example [2] but are not
 # documented as prerequisites [1].
-RUN yum install -y \
-                curl \
+RUN dnf install -y --setopt=install_weak_deps=false \
                 gcc \
                 gcc-c++ \
                 git \
                 gnupg2-smime \
-                python \
+                python3 \
                 make \
                 bzip2 \
                 file \
                 patch \
                 unzip \
                 which \
- && yum clean all
+ && dnf clean all
 
 # Certain Spack packages (e.g., tar) puke if they detect themselves being
 # configured as UID 0. This is the override. See issue #540 and [2].

--- a/examples/spack/Dockerfile
+++ b/examples/spack/Dockerfile
@@ -41,14 +41,9 @@ ARG FORCE_UNSAFE_CONFIGURE=1
 # place it at a standard path ("spack clone" simply clones another working
 # directory to a new path).
 #
-# Spack does have releases, but they seem pretty stale. As of 2019-09-12, the
-# most recent version is 0.12.1 dated 8 months ago, 2019-01-13; there have
-# been hundreds if not thousands of commits on the default branch "develop"
-# since then. We follow develop for this reason and also to catch problems
-# installing Charliecloud with latest Spack.
+# We follow the develop branch to catch problems installing Charliecloud with
+# the latest Spack.
 ARG SPACK_REPO=https://github.com/spack/spack
-#ENV SPACK_VERSION 0.12.1
-#RUN git clone --branch v$SPACK_VERSION --depth 1 $SPACK_REPO
 RUN git clone --depth 1 $SPACK_REPO
 RUN cd spack && git status && git rev-parse --short HEAD
 

--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -69,16 +69,16 @@ Vagrant.configure("2") do |c|
     set -e
     cd /tmp
 
-    # Basic stuff from standard repos.
+    # Basic stuff from standard repos and confgure yum to fail on missing pkgs.
     yum makecache fast
-    yum-config-manager --setopt=deltarpm=0 --save
+    yum-config-manager --setopt=deltarpm=0 --setopt=skip_missing_names_on_install=0 --save
     yum -y upgrade
     yum -y install emacs \
                    vim \
                    wget
 
     # Git from IUS. This also activates EPEL.
-    # From here: https://ius.io/setup 
+    # From here: https://ius.io/setup
     # Likely to be deprecated again sometime in the future
     wget https://repo.ius.io/ius-release-el7.rpm
     yum -y install epel-release


### PR DESCRIPTION
Addresses #858 

Due to failures installing the docs with Spack I tested by removing `+docs` from the Dockerfile and it appeared to be successful with the new CentOS 8 base and python3.

I also tidied up a comment in the spack Dockerfile that appears outdated, Spack now appears to semi-consistently do [releases](https://github.com/spack/spack/releases).

This passes in the standard scope (minus some failures building el7 rpms that appear unrelated) on my dev machine.