### PR TITLE
Move charliecloud man page to section 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ a.out
 /doc/_deps.rst
 /doc/doctrees/
 /doc/html/
-/doc/man/*.1
+/doc/man/*.[17]
 /lib/charliecloud
 /lib/contributors.bash
 /lib/version.py

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -57,7 +57,7 @@ tutorial.rst
 
 if ENABLE_MAN
 man1_MANS = \
-man/charliecloud.1 \
+man/charliecloud.7 \
 man/ch-build.1 \
 man/ch-build2dir.1 \
 man/ch-builder2squash.1 \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -56,7 +56,7 @@ see_also.rst \
 tutorial.rst
 
 if ENABLE_MAN
-man1_MANS = \
+dist_man_MANS = \
 man/charliecloud.7 \
 man/ch-build.1 \
 man/ch-build2dir.1 \
@@ -93,7 +93,7 @@ endif
 
 # NOTE: ./html might be a Git checkout to support "make web", so make sure not
 # to delete it.
-CLEANFILES = $(man1_MANS) $(nobase_html_DATA) \
+CLEANFILES = $(dist_man_MANS) $(nobase_html_DATA) \
              _deps.rst html/.buildinfo html/.nojekyll
 if ENABLE_HTML
 # Automake can't remove directories.
@@ -165,6 +165,6 @@ if ENABLE_HTML
 HTML_FIRST = html
 endif
 
-$(man1_MANS): man
+$(dist_man_MANS): man
 man: mkdir_issue115 ../lib/version.txt _deps.rst $(HTML_FIRST)
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -56,7 +56,7 @@ see_also.rst \
 tutorial.rst
 
 if ENABLE_MAN
-dist_man_MANS = \
+man_MANS = \
 man/charliecloud.7 \
 man/ch-build.1 \
 man/ch-build2dir.1 \
@@ -93,7 +93,7 @@ endif
 
 # NOTE: ./html might be a Git checkout to support "make web", so make sure not
 # to delete it.
-CLEANFILES = $(dist_man_MANS) $(nobase_html_DATA) \
+CLEANFILES = $(man_MANS) $(nobase_html_DATA) \
              _deps.rst html/.buildinfo html/.nojekyll
 if ENABLE_HTML
 # Automake can't remove directories.
@@ -165,6 +165,6 @@ if ENABLE_HTML
 HTML_FIRST = html
 endif
 
-$(dist_man_MANS): man
+$(man_MANS): man
 man: mkdir_issue115 ../lib/version.txt _deps.rst $(HTML_FIRST)
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -243,7 +243,7 @@ latex_documents = [
 man_pages = [
    ("charliecloud", "charliecloud",
     "Lightweight user-defined software stacks for high-performance computing",
-    [], 1),
+    [], 7),
    ("ch-build", "ch-build",
     "Build an image and place it in the builder's back-end storage",
     [], 1),

--- a/doc/see_also.rst
+++ b/doc/see_also.rst
@@ -1,6 +1,6 @@
 See also
 ========
 
-charliecloud(1)
+charliecloud(7)
 
 Full documentation at: <https://hpc.github.io/charliecloud>

--- a/packaging/fedora/charliecloud.spec
+++ b/packaging/fedora/charliecloud.spec
@@ -115,6 +115,7 @@ ln -s "${sphinxdir}/js"    %{buildroot}%{_pkgdocdir}/html/_static/js
 %license LICENSE
 %doc README.rst %{?el7:README.EL7}
 %{_mandir}/man1/ch*
+%{_mandir}/man7/charliecloud*
 %{_pkgdocdir}/examples
 
 # Library files.

--- a/test/docs-sane.py.in
+++ b/test/docs-sane.py.in
@@ -6,7 +6,7 @@
 #
 #   1. Man page consistency.
 #
-#      a. man/charliecloud.1 exists.
+#      a. man/charliecloud.7 exists.
 #
 #      b. Every executable FOO in bin has:
 #
@@ -14,7 +14,7 @@
 #           - doc/FOO_desc.rst
 #           - doc/man/FOO.1
 #           - a section in doc/command-usage.rst
-#           - an entry under "See also" in charliecloud.1
+#           - an entry under "See also" in charliecloud.7
 #
 #      c. There aren't the things in (b) except for the executables (modulo a
 #         few execeptions for the other documentation source files).
@@ -89,17 +89,20 @@ def check_man():
          lose("conf.py: startdocname != name: %s != %s" % (docname, name))
       if (len(authors) != 0):
          lose("conf.py: bad authors: %s: %s" % (name, authors))
-      if (section != 1):
-         lose("conf.py: bad section: %s: %s != 1" % (name, section))
       if (name != "charliecloud"):
+         if (section != 1):
+            lose("conf.py: bad section: %s: %s != 1" % (name, section))
          if (name not in helps):
             lose("conf.py: unexpected man page: %s" % name)
          elif (desc + "." != helps[name]):
             lose("conf.py: bad summary: %s: %s" % (name, desc))
+      else:
+         if (section != 7):
+            lose("conf.py: bad section: %s: %s != 7" % (name, section))
 
    os.chdir(CH_BASE + "/doc/man")
 
-   mans = set(glob.glob("*.1")) - { "charliecloud.1" }
+   mans = set(glob.glob("*.1"))
    mans_expected = { i + ".1" for i in execs }
    lose_lots("unexpected man", mans - mans_expected)
    lose_lots("missing man",    mans_expected - mans)

--- a/test/run/build-rpms.bats
+++ b/test/run/build-rpms.bats
@@ -37,7 +37,7 @@ setup () {
     [[ $output = *'/usr/bin/ch-run'* ]]
     [[ $output = *'/usr/lib64/charliecloud/base.sh'* ]]
     [[ $output = *'/usr/share/doc/charliecloud-'*'/examples/lammps/Dockerfile'* ]]
-    [[ $output = *'/usr/share/man/man1/charliecloud.1.gz'* ]]
+    [[ $output = *'/usr/share/man/man7/charliecloud.7.gz'* ]]
     run ch-run "$img" -- rpm -ql "charliecloud-debuginfo"
     echo "$output"
     [[ $status -eq 0 ]]
@@ -103,7 +103,7 @@ setup () {
     [[ $output = *'/usr/bin/ch-run'* ]]
     [[ $output = *'/usr/lib64/charliecloud/base.sh'* ]]
     [[ $output = *'/usr/share/doc/charliecloud/examples/lammps/Dockerfile'* ]]
-    [[ $output = *'/usr/share/man/man1/charliecloud.1.gz'* ]]
+    [[ $output = *'/usr/share/man/man7/charliecloud.7.gz'* ]]
     run ch-run "$img" -- rpm -ql "charliecloud-debuginfo"
     echo "$output"
     [[ $status -eq 0 ]]


### PR DESCRIPTION
At present the charliecloud man page is installed in [section 1](https://manpages.debian.org/unstable/manpages/man-pages.7.en.html#Sections_of_the_manual_pages). This PR moves it to section 7 which is more suitable in my opinion.