### PR TITLE
examples/spark unset Java env vars prior to running tests

### DIFF
--- a/examples/spark/test.bats
+++ b/examples/spark/test.bats
@@ -46,6 +46,13 @@ setup () {
     master_log="${spark_log}/*master.Master*.out"
 }
 
+unset_vars() {
+    # Unset these Java variables so the container doesn't use host paths.
+    unset JAVA_BINDIR
+    unset JAVA_HOME
+    unset JAVA_ROOT
+}
+
 @test "${ch_tag}/configure" {
     # check for restrictive umask
     run umask -S
@@ -73,6 +80,8 @@ EOF
 }
 
 @test "${ch_tag}/start" {
+    unset_vars
+
     # remove old master logs so new one has predictable name
     rm -Rf --one-file-system "$spark_log"
     # start the master
@@ -104,6 +113,8 @@ EOF
 }
 
 @test "${ch_tag}/pi" {
+    unset_vars
+
     run ch-run -b "$spark_config" "$ch_img" -- \
                /opt/spark/bin/spark-submit --master "$master_url" \
                /opt/spark/examples/src/main/python/pi.py 64
@@ -115,6 +126,8 @@ EOF
 }
 
 @test "${ch_tag}/stop" {
+    unset_vars
+
     $pernode ch-run -b "$spark_config" "$ch_img" -- /opt/spark/sbin/stop-slave.sh
     ch-run -b "$spark_config" "$ch_img" -- /opt/spark/sbin/stop-master.sh
     sleep 2


### PR DESCRIPTION
Addresses #879 

I saw three ways this could be resolved:
1. Put the `unset` calls in the setup function
2. Use `--unset-env=JAVA*` on each `ch-run`
3. Add a function to unset these vars

I went with option 3 as 1 would run the `unset` commands for every test even if they don't need it and 2 made the `ch-run` commands quite verbose. This is similar to what we do in the [ch-run_join.bats](https://github.com/hpc/charliecloud/blob/5b2b3cf2518ee39c45bee7f36e8ee22a853d0a31/test/run/ch-run_join.bats#L73) tests.

Tested locally and on the system where the issue was identified.
