### PR TITLE
ch-grow build: new option --bind to bind-mount directories during build

### DIFF
--- a/bin/ch-grow.py.in
+++ b/bin/ch-grow.py.in
@@ -105,8 +105,11 @@ def main():
                        formatter_class=ch.HelpFormatter)
    sp.set_defaults(func=build.main)
    add_opts(sp, common_opts, True)
-   sp.add_argument("--build-arg", action="append", default=None,
-                   metavar="ARG[=VAL]",
+   sp.add_argument("-b", "--bind", metavar="SRC[:DST]",
+                   action="append", default=[],
+                   help="mount SRC at guest DST (default /mnt/0, /mnt/1, etc.)")
+   sp.add_argument("--build-arg", metavar="ARG[=VAL]",
+                   action="append", default=[],
                    help="set build-time variable ARG to VAL, or $ARG if no VAL")
    sp.add_argument("-f", "--file", metavar="DOCKERFILE",
                    help="Dockerfile to use (default: CONTEXT/Dockerfile)")

--- a/doc/ch-grow_desc.rst
+++ b/doc/ch-grow_desc.rst
@@ -101,6 +101,10 @@ Options:
     during :code:`RUN` instructions. Can be repeated; the default destination
     if :code:`DST` is omitted is :code:`/mnt/0`, :code:`/mnt/1`, etc.
 
+    **Note:** This applies only to :code:`RUN` instructions. Other
+    instructions that modify the image filesystem, e.g. :code:`COPY`, can only
+    access host files from the context directory.
+
   :code:`--build-arg KEY[=VALUE]`
     Set build-time variable :code:`KEY` defined by :code:`ARG` instruction
     to :code:`VALUE`. If :code:`VALUE` not specified, use the value of
@@ -404,6 +408,18 @@ path::
    [...]
    grown in 4 instructions: bar
 
+Build using humongous vendor compilers you want to bind-mount instead of
+installing into a layer::
+
+   $ ch-grow build --bind /opt/bigvendor:/opt .
+   $ cat Dockerfile
+   FROM centos:7
+
+   RUN /opt/bin/cc hello.c
+   #COPY /opt/lib/*.so /usr/local/lib   # fail: COPY doesn't bind mount
+   RUN cp /opt/lib/*.so /usr/local/lib  # possible workaround
+   RUN ldconfig
+
 :code:`pull`
 ------------
 
@@ -429,4 +445,4 @@ Same, except place the image in :code:`/tmp/buster`::
    bin   dev  home  lib64  mnt  proc  run   srv  tmp  var
    boot  etc  lib   media  opt  root  sbin  sys  usr
 
-..  LocalWords:  tmpfs'es
+..  LocalWords:  tmpfs'es bigvendor

--- a/doc/ch-grow_desc.rst
+++ b/doc/ch-grow_desc.rst
@@ -96,6 +96,11 @@ Required argument:
 
 Options:
 
+  :code:`-b`, :code:`--bind SRC[:DST]`
+    Bind-mount host directory :code:`SRC` at container directory :code:`DST`
+    during :code:`RUN` instructions. Can be repeated; the default destination
+    if :code:`DST` is omitted is :code:`/mnt/0`, :code:`/mnt/1`, etc.
+
   :code:`--build-arg KEY[=VALUE]`
     Set build-time variable :code:`KEY` defined by :code:`ARG` instruction
     to :code:`VALUE`. If :code:`VALUE` not specified, use the value of

--- a/lib/build.py
+++ b/lib/build.py
@@ -90,8 +90,6 @@ def main(cli_):
          if (v is None):
             ch.FATAL("--build-arg: %s: no value and not in environment" % kv[0])
          return (kv[0], v)
-   if (cli.build_arg is None):
-      cli.build_arg = list()
    cli.build_arg = dict( build_arg_get(i) for i in cli.build_arg )
 
    # Finish CLI initialization.
@@ -550,7 +548,7 @@ class Run(Instruction):
 
    def execute_(self):
       rootfs = images[image_i].unpack_path
-      ch.ch_run_modify(rootfs, self.cmd, env.env_build, env.workdir)
+      ch.ch_run_modify(rootfs, self.cmd, env.env_build, env.workdir, cli.bind)
 
    def str_(self):
       return str(self.cmd)

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -267,6 +267,8 @@ class Image:
       # Mount points.
       file_ensure_exists("%s/etc/hosts" % self.unpack_path)
       file_ensure_exists("%s/etc/resolv.conf" % self.unpack_path)
+      for i in range(10):
+         mkdirs("%s/mnt/%d" % (self.unpack_path, i))
 
    def flatten(self, last_layer=None):
       "Flatten the layers in the download cache into the unpack directory."
@@ -884,9 +886,11 @@ def INFO(*args, **kwargs):
 def WARNING(*args, **kwargs):
    log(color="31m", prefix="warning: ", *args, **kwargs)
 
-def ch_run_modify(img, args, env, workdir="/"):
-   args = [CH_BIN + "/ch-run", "-w", "--cd", workdir, "--uid=0", "--gid=0",
-           "--no-home", "--no-passwd", img, "--"] + args
+def ch_run_modify(img, args, env, workdir="/", binds=[]):
+   args = (  [CH_BIN + "/ch-run"]
+           + ["-w", "-u0", "-g0", "--no-home", "--no-passwd", "--cd", workdir]
+           + sum([["-b", i] for i in binds], [])
+           + [img, "--"] + args)
    cmd(args, env)
 
 def cmd(args, env=None):

--- a/test/build/10_sanity.bats
+++ b/test/build/10_sanity.bats
@@ -22,7 +22,7 @@ load ../common
     # yielded hundreds of false positives but zero actual bugs.
     scope quick
     echo "version: ${ch_version}"
-    re='^0\.[0-9]+(\.[0-9]+)?(~pre\+[A-Za-z0-9]+(\.[0-9a-f]+(\.dirty)?)?)?$'
+    re='^0\.[0-9]+(\.[0-9]+)?(~pre\+([A-Za-z0-9]+\.)?([0-9a-f]+(\.dirty)?)?)?$'
     [[ $ch_version =~ $re ]]
 }
 
@@ -107,6 +107,7 @@ load ../common
         shellcheck -e SC1090,SC2002,SC2154 "$i"
     done < <( find "$ch_base" \
                    \(    -name .git \
+                      -o -name .vagrant \
                       -o -name build-aux \) -prune \
                 -o \( -name '*.sh' -print \) \
                 -o \( -name '*.bash' -print \) \

--- a/test/build/50_ch-grow.bats
+++ b/test/build/50_ch-grow.bats
@@ -45,3 +45,14 @@ setup () {
     [[ $output = /* ]]                                      # absolute path
     [[ $CH_GROW_STORAGE && $output = "$CH_GROW_STORAGE" ]]  # match what we set
 }
+
+@test 'ch-grow build --bind' {
+    run ch-grow --no-cache build -t build-bind -f - \
+                -b ./fixtures -b ./fixtures:/mnt/9 . <<'EOF'
+FROM 00_tiny
+RUN test -f /mnt/0/README
+RUN test -f /mnt/9/README
+EOF
+    echo "$output"
+    [[ $status -eq 0 ]]
+}

--- a/test/build/50_ch-grow.bats
+++ b/test/build/50_ch-grow.bats
@@ -57,5 +57,4 @@ RUN test -f /mnt/9/empty-file
 EOF
     echo "$output"
     [[ $status -eq 0 ]]
-    false
 }

--- a/test/build/50_ch-grow.bats
+++ b/test/build/50_ch-grow.bats
@@ -50,9 +50,12 @@ setup () {
     run ch-grow --no-cache build -t build-bind -f - \
                 -b ./fixtures -b ./fixtures:/mnt/9 . <<'EOF'
 FROM 00_tiny
-RUN test -f /mnt/0/README
-RUN test -f /mnt/9/README
+RUN mount
+RUN ls -lR /mnt
+RUN test -f /mnt/0/empty-file
+RUN test -f /mnt/9/empty-file
 EOF
     echo "$output"
     [[ $status -eq 0 ]]
+    false
 }

--- a/test/run/ch-run_uidgid.bats
+++ b/test/run/ch-run_uidgid.bats
@@ -29,23 +29,29 @@ setup () {
 }
 
 @test 'user and group as specified' {
+    # shellcheck disable=SC2086
     g=$(ch-run $uid_args $gid_args "$ch_timg" -- id -un)
     [[ $GUEST_USER = "$g" ]]
+    # shellcheck disable=SC2086
     g=$(ch-run $uid_args $gid_args "$ch_timg" -- id -u)
     [[ $guest_uid = "$g" ]]
+    # shellcheck disable=SC2086
     g=$(ch-run $uid_args $gid_args "$ch_timg" -- id -gn)
     [[ $GUEST_GROUP = "$g" ]]
+    # shellcheck disable=SC2086
     g=$(ch-run $uid_args $gid_args "$ch_timg" -- id -g)
     [[ $guest_gid = "$g" ]]
 }
 
 @test 'chroot escape' {
     # Try to escape a chroot(2) using the standard approach.
+    # shellcheck disable=SC2086
     ch-run $uid_args $gid_args "$ch_timg" -- /test/chroot-escape
 }
 
 @test '/dev /proc /sys' {
     # Read some files in /dev, /proc, and /sys that I shouldn't have access to.
+    # shellcheck disable=SC2086
     ch-run $uid_args $gid_args "$ch_timg" -- /test/dev_proc_sys.py
 }
 
@@ -54,16 +60,17 @@ setup () {
     for d in $CH_TEST_PERMDIRS; do
         d="${d}/pass"
         echo "verifying: ${d}"
-          ch-run --no-home --private-tmp \
-                 $uid_args $gid_args -b "$d" "$ch_timg" -- \
-                 /test/fs_perms.py /mnt/0
+        # shellcheck disable=SC2086
+        ch-run --no-home --private-tmp \
+               $uid_args $gid_args -b "$d" "$ch_timg" -- \
+               /test/fs_perms.py /mnt/0
     done
 }
 
 @test 'mknod(2)' {
     # Make some device files. If this works, we might be able to later read or
     # write them to do things we shouldn't. Try on all mount points.
-    # shellcheck disable=SC2016
+    # shellcheck disable=SC2016,SC2086
     ch-run $uid_args $gid_args "$ch_timg" -- \
            sh -c '/test/mknods $(cat /proc/mounts | cut -d" " -f2)'
 }
@@ -88,11 +95,14 @@ setup () {
     #   - We leave the filesystem mounted even if successful, again to make
     #     the test simpler. The rest of the tests will ignore it or maybe
     #     over-mount something else.
+    #
+    # shellcheck disable=SC2086
     ch-run $uid_args $gid_args "$ch_timg" -- \
            sh -c '[ -f /bin/mount -a -x /bin/mount ]'
     dev=$(findmnt -n -o SOURCE -T /)
     type=$(findmnt -n -o FSTYPE -T /)
     opts=$(findmnt -n -o OPTIONS -T /)
+    # shellcheck disable=SC2086
     run ch-run $uid_args $gid_args "$ch_timg" -- \
                /bin/mount -n -o "$opts" -t "$type" "$dev" /mnt/0
     echo "$output"
@@ -128,11 +138,13 @@ setup () {
 
 @test 'setgroups(2)' {
     # Can we change our supplemental groups?
+    # shellcheck disable=SC2086
     ch-run $uid_args $gid_args "$ch_timg" -- /test/setgroups
 }
 
 @test 'seteuid(2)' {
     # Try to seteuid(2) to another UID we shouldn't have access to
+    # shellcheck disable=SC2086
     ch-run $uid_args $gid_args "$ch_timg" -- /test/setuid
 }
 
@@ -144,5 +156,6 @@ setup () {
     # dynamically, so there may be none running. See your distro's
     # documentation on how to configure this. See also e.g. issue #840.
     [[ $(pgrep -c getty) -eq 0 ]] && pedantic_fail 'no getty process found'
+    # shellcheck disable=SC2086
     ch-run $uid_args $gid_args "$ch_timg" -- /test/signal_out.py
 }

--- a/test/travis.bash
+++ b/test/travis.bash
@@ -81,6 +81,7 @@ else
     sudo_=
 fi
 
+# shellcheck disable=SC2086
 "$ch_test" build $sudo_
 ls -lha "$CH_TEST_TARDIR"
 
@@ -93,6 +94,8 @@ else
     sudo_=
 fi
 
+# shellcheck disable=SC2086
 "$ch_test" run $sudo_
 ls -lha "$CH_TEST_IMGDIR"
+# shellcheck disable=SC2086
 "$ch_test" examples $sudo_


### PR DESCRIPTION
This PR adds `ch-grow build --bind` to bind-mount directories at build time.

There's some extra mess so I could get the tests passing on my new platform.