### PR TITLE
test suite: demote Spark from standard to full scope

### DIFF
--- a/examples/spark/Dockerfile
+++ b/examples/spark/Dockerfile
@@ -1,4 +1,4 @@
-# ch-test-scope: standard
+# ch-test-scope: full
 # Use Buster because Stretch JRE install fails with:
 #
 #   tempnam() is so ludicrously insecure as to defy implementation.tempnam: Cannot allocate memory


### PR DESCRIPTION
Currently the Spark image takes 10 minutes to slowly download the 200MB Spark distribution, so for now we'll demote it to full scope.