### PR TITLE
ch-test: add individual tests to --file

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -43,7 +43,7 @@ Additional options:
 
   -b, --builder BUILDER  image builder to use
   --dry-run              print summary of what would be tested and exit
-  --file FILE            run tests in FILE only
+  --file FILE[:TEST]     run tests in FILE only, or even just TEST
   -h, --help             print this help and exit
   --img-dir DIR          unpacked images directory; same as \$CH_TEST_IMGDIR
   --pack-dir DIR         packed imaged directory; same as \$CH_TEST_TARDIR
@@ -858,6 +858,11 @@ fi
 printf 'contributor:  %s\n\n' "$ch_contributor_note"
 
 if [[ $phase = one-file ]]; then
+    if [[ $one_file == *:* ]]; then
+        x=$one_file
+        one_file=${x%%:*}            # before first colon
+        export ch_one_test=${x#*:}   # after first colon
+    fi
     if [[ ! -f $one_file ]]; then
         fatal "not a file: $one_file"
     fi
@@ -869,7 +874,7 @@ fi
 
 printf "%-21s %s" 'phase:' "$phase"
 if [[ $phase = one-file ]]; then
-    printf ': %s' "$one_file"
+    printf ': %s (%s)' "$one_file" "$ch_one_test"
 fi
 if [[ -z $phase ]]; then
     fatal 'phase: no phase specified'

--- a/doc/ch-test_desc.rst
+++ b/doc/ch-test_desc.rst
@@ -85,7 +85,7 @@ allows trading off thoroughness versus time.
     Remove the filesystem permissions directories. Requires
     :code:`--perm-dirs`.
 
-  :code:`-f`, :code:`--file FILE`
+  :code:`-f`, :code:`--file FILE[:TEST]`
     Run the tests in the given file only, which can be an arbitrary
     :code:`.bats` file, except for :code:`test.bats` under :code:`examples`,
     where you must specify the corresponding Dockerfile or :code:`Build` file
@@ -93,6 +93,11 @@ allows trading off thoroughness versus time.
     debugging. For example, it does not check whether the pre-requisites of
     whatever is in the file are satisfied. Often running :code:`build` and
     :code:`run` first is sufficient, but this varies.
+
+    If :code:`TEST` is also given, then run only the test with that name,
+    skipping the others. The separator is a literal colon. Most test names
+    contain spaces, so you'll usually need to quote the argument to protect it
+    from the shell.
 
 Scope is specified with:
 

--- a/test/common.bash
+++ b/test/common.bash
@@ -134,6 +134,14 @@ run () {
 }
 
 scope () {
+    if [[ -n $ch_one_test ]]; then
+        # Ignore scope if a single test is given.
+        if [[ $ch_one_test != "$BATS_TEST_DESCRIPTION" ]]; then
+            skip 'per --file'
+        else
+            return 0
+        fi
+    fi
     case $1 in  # $1 is the test's scope
         quick)
             ;;  # always run quick-scope tests


### PR DESCRIPTION
Addresses #703.

Caveats/gotchas:

1. The exclusion happens in `common.bash:scope()`, so any test that does not call `scope` cannot be excluded. I don't recall if tests can do so and get a default scope.
2. It's implemented by skipping, so you still have to pay the skip overhead. But, this was a much simpler way to do it than editing the files on the fly somehow.