### PR TITLE
docs: don’t claim we provide RPMs

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -142,12 +142,11 @@ package managers.
 
 Maintained by us:
 
-  * Generic RPMs downloadable from our `releases page <https://github.com/hpc/charliecloud/releases>`_.
   * `Spack
     <https://spack.readthedocs.io/en/latest/package_list.html#charliecloud>`_;
     install with :code:`+builder` to get :code:`ch-image`.
   * `Fedora/EPEL <https://bodhi.fedoraproject.org/updates/?search=charliecloud>`_;
-    check for availabile versions with :code:`{yum,dnf} list charliecloud`.
+    check for available versions with :code:`{yum,dnf} list charliecloud`.
 
 Maintained by others:
 


### PR DESCRIPTION
Currently the install instructions claim we provide “generic RPMs” on the GitHub releases page; we’ve never actually done this, AFAICT. Thus, let’s stop claiming that we do.