### PR TITLE
ch-image: strip setuid/setgid bits on pull too

### DIFF
--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -1047,10 +1047,10 @@ class TarFile(tarfile.TarFile):
       ti.gid = 0
       ti.gname = "root"
       if (ti.mode & stat.S_ISUID):
-         WARNING("stripping unsafe setuid bit: %s" % ti.name)
+         DEBUG("stripping unsafe setuid bit: %s" % ti.name)
          ti.mode &= ~stat.S_ISUID
       if (ti.mode & stat.S_ISGID):
-         WARNING("stripping unsafe setgid bit: %s" % ti.name)
+         DEBUG("stripping unsafe setgid bit: %s" % ti.name)
          ti.mode &= ~stat.S_ISGID
       return ti
 

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -323,6 +323,7 @@ class Image:
                # Device or FIFO: Ignore.
                dev_ct += 1
                members.remove(m)
+               continue
             elif (m.issym()):
                # Symlink: Nothing to change, but accept it.
                pass

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -339,6 +339,7 @@ class Image:
                m.mode |= 0o600
             else:
                FATAL("unknown member type: %s" % m.name)
+            TarFile.fix_member_uidgid(m)
          if (dev_ct > 0):
             INFO("layer %d/%d: %s: ignored %d devices and/or FIFOs"
                  % (i, len(layers), lh[:7], dev_ct))
@@ -1007,7 +1008,7 @@ class TarFile(tarfile.TarFile):
    # Need new method name because add() is called recursively and we don't
    # want those internal calls to get our special sauce.
    def add_(self, name, **kwargs):
-      kwargs["filter"] = self.fix_new_member
+      kwargs["filter"] = self.fix_member_uidgid
       super().add(name, **kwargs)
 
    def clobber(self, targetpath, regulars=False, symlinks=False, dirs=False):
@@ -1036,7 +1037,7 @@ class TarFile(tarfile.TarFile):
                   % (stat.S_IFMT(st.st_mode), targetpath))
 
    @staticmethod
-   def fix_new_member(ti):
+   def fix_member_uidgid(ti):
       assert (ti.name[0] != "/")  # absolute paths unsafe but shouldn't happen
       if (not (ti.isfile() or ti.isdir() or ti.issym() or ti.islnk())):
          FATAL("invalid file type: %s" % ti.name)

--- a/test/build/50_localregistry.bats
+++ b/test/build/50_localregistry.bats
@@ -76,10 +76,10 @@ setup () {
     [[ $status -eq 0 ]]
     [[ $output = *'pushing image:   localhost:5000/foo/bar:weirdal'* ]]
     [[ $output = *"image path:      ${img}"* ]]
-    [[ $output = *'warning: stripping unsafe setgid bit: ./setgid_dir'* ]]
-    [[ $output = *'warning: stripping unsafe setgid bit: ./setgid_file'* ]]
-    [[ $output = *'warning: stripping unsafe setuid bit: ./setuid_dir'* ]]
-    [[ $output = *'warning: stripping unsafe setuid bit: ./setuid_file'* ]]
+    [[ $output = *'stripping unsafe setgid bit: ./setgid_dir'* ]]
+    [[ $output = *'stripping unsafe setgid bit: ./setgid_file'* ]]
+    [[ $output = *'stripping unsafe setuid bit: ./setuid_dir'* ]]
+    [[ $output = *'stripping unsafe setuid bit: ./setuid_file'* ]]
 
     # Pull it back
     run ch-image -v --tls-no-verify pull localhost:5000/foo/bar:weirdal "$img2"


### PR DESCRIPTION
Addresses #955.

Note, this now prints warnings when pulling common images, e.g.:

```
$ ch-image pull centos:7
pulling image:   centos:7
manifest: using existing file
layer 1/1: 2d473b0: using existing file
layer 1/1: 2d473b0: listing
validating tarball members
warning: stripping unsafe setuid bit: usr/bin/chage
warning: stripping unsafe setuid bit: usr/bin/chfn
warning: stripping unsafe setuid bit: usr/bin/chsh
warning: stripping unsafe setuid bit: usr/bin/gpasswd
warning: stripping unsafe setuid bit: usr/bin/mount
warning: stripping unsafe setuid bit: usr/bin/newgrp
warning: stripping unsafe setuid bit: usr/bin/passwd
warning: stripping unsafe setuid bit: usr/bin/su
warning: stripping unsafe setuid bit: usr/bin/umount
warning: stripping unsafe setgid bit: usr/bin/write
warning: stripping unsafe setuid bit: usr/libexec/dbus-1/dbus-daemon-launch-helper
warning: stripping unsafe setgid bit: usr/libexec/utempter/utempter
warning: stripping unsafe setuid bit: usr/sbin/pam_timestamp_check
warning: stripping unsafe setuid bit: usr/sbin/unix_chkpwd
resolving whiteouts
flattening image
layer 1/1: 2d473b0: extracting
done
```

Do we want that?