### PR TITLE
examples/spark: resolve failures on Cray XC40

### DIFF
--- a/examples/spark/slurm.sh
+++ b/examples/spark/slurm.sh
@@ -59,6 +59,7 @@ SPARK_LOG_DIR=/tmp/spark/log
 SPARK_WORKER_DIR=/tmp/spark
 SPARK_LOCAL_IP=127.0.0.1
 SPARK_MASTER_HOST=${master_ip}
+JAVA_HOME=/usr/lib/jvm/default-java/
 EOF
 mysecret=$(cat /dev/urandom | tr -dc '0-9a-f' | head -c 48)
 cat <<EOF > "${conf}/spark-defaults.sh"

--- a/examples/spark/test.bats
+++ b/examples/spark/test.bats
@@ -31,13 +31,7 @@ setup () {
     spark_config=$spark_dir
     spark_log=/tmp/sparklog
     if [[ $ch_multinode ]]; then
-        # Use the last non-loopback IP address. This is a barely educated
-        # guess and shouldn't be relied on for real code, but hopefully it
-        # works for testing.
-        master_ip=$(  ip -o -f inet addr show \
-                    | grep -F 'scope global' \
-                    | tail -1 \
-                    | sed -r 's/^.+inet ([0-9.]+).+/\1/')
+        master_host="$(hostname)"
         # Start Spark workers using pdsh. We would really prefer to do this
         # using srun, but that doesn't work; see issue #230.
         command -v pdsh >/dev/null 2>&1 || pedantic_fail "pdsh not in path"
@@ -46,7 +40,7 @@ setup () {
         master_ip=127.0.0.1
         pernode=
     fi
-    master_url="spark://${master_ip}:7077"
+    master_url="spark://${master_host}:7077"
     master_log="${spark_log}/*master.Master*.out"
 }
 
@@ -63,7 +57,8 @@ SPARK_LOCAL_DIRS=/tmp/spark
 SPARK_LOG_DIR=$spark_log
 SPARK_WORKER_DIR=/tmp/spark
 SPARK_LOCAL_IP=127.0.0.1
-SPARK_MASTER_HOST=${master_ip}
+SPARK_MASTER_HOST=${master_host}
+JAVA_HOME=/usr/lib/jvm/default-java/
 EOF
     my_secret=$(cat /dev/urandom | tr -dc '0-9a-f' | head -c 48)
     tee <<EOF > "${spark_config}/spark-defaults.conf"

--- a/examples/spark/test.bats
+++ b/examples/spark/test.bats
@@ -37,7 +37,7 @@ setup () {
         command -v pdsh >/dev/null 2>&1 || pedantic_fail "pdsh not in path"
         pernode="pdsh -R ssh -w ${SLURM_NODELIST} -- PATH='${PATH}'"
     else
-        master_ip=127.0.0.1
+        master_host=localhost
         pernode=
     fi
     master_url="spark://${master_host}:7077"

--- a/examples/spark/test.bats
+++ b/examples/spark/test.bats
@@ -31,6 +31,11 @@ setup () {
     spark_config=$spark_dir
     spark_log=/tmp/sparklog
     if [[ $ch_multinode ]]; then
+        # We use hostname to determine the interface to use for this test,
+        # avoiding complicated logic determining which interface is the HSN.
+        # In many environments this likely results in the tests running over
+        # the slower management interface, which is fine for testing, but
+        # should be avoided for large scale runs.
         master_host="$(hostname)"
         # Start Spark workers using pdsh. We would really prefer to do this
         # using srun, but that doesn't work; see issue #230.
@@ -52,6 +57,8 @@ setup () {
     [[ $output = 'u=rwx,g=,o=' ]]
     # create config
     $ch_mpirun_node mkdir -p "$spark_config"
+    # We set JAVA_HOME in the spark environment file as this appears to be the
+    # idiomatic method for ensuring spark finds the java install.
     tee <<EOF > "${spark_config}/spark-env.sh"
 SPARK_LOCAL_DIRS=/tmp/spark
 SPARK_LOG_DIR=$spark_log


### PR DESCRIPTION
Addresses #978

We can get fancier for setting JAVA_HOME but this location appears to be consistent on Debian.

Marking as draft pending more tests.