### PR TITLE
update tests for new Lark

### DIFF
--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -667,7 +667,10 @@ class Image_Ref:
       try:
          tree = class_.parser.parse(s)
       except lark.exceptions.UnexpectedInput as x:
-         FATAL("image ref syntax, char %d: %s" % (x.column, s))
+         if (x.column == -1):
+            FATAL("image ref syntax, at end: %s" % s)
+         else:
+            FATAL("image ref syntax, char %d: %s" % (x.column, s))
       except lark.exceptions.UnexpectedEOF as x:
          # We get UnexpectedEOF because of Lark issue #237. This exception
          # doesn't have a column location.

--- a/test/build/50_dockerfile.bats
+++ b/test/build/50_dockerfile.bats
@@ -61,7 +61,6 @@ EOF
     [[ $output = *"can't parse: -:2,1"* ]]
     # internal blabber
     [[ $output = *"No terminal defined for 'W' at line 2 col 1"* ]]
-    [[ $output = *'Expecting: {'* ]]
 
     # Bad long option.
     run ch-image build -t foo -f - . <<'EOF'


### PR DESCRIPTION
Lark 0.11.2 broke test suite. To fix it, I removed one of the output checks in the offending test. I could have made that check more fancy, but it seemed like the prior check probably covered it sufficiently.