### PR TITLE
demote Buildah to experimental

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true  # if any job fails, cancel the rest immediately
       matrix:
-        builder: [none, docker, ch-image, buildah, buildah-runc, buildah-setuid]
+        builder: [none, docker, ch-image]
         keep_sudo:  # if false, remove self from sudoers after install/setup
           - false
         include:

--- a/bin/ch-build
+++ b/bin/ch-build
@@ -11,7 +11,8 @@ Usage:
 
   $ $(basename "$0") [-b BUILDER] [--builder-info] -t TAG [ARGS ...] CONTEXT
 
-BUILDER is one of: buildah ch-image docker.
+BUILDER is "ch-image" or "docker"
+        (or experimentally: "buildah", "buildah-runc", "buildah-setuid")
 ARGS are passed unchanged to the underlying builder.
 EOF
 )

--- a/doc/ch-build_desc.rst
+++ b/doc/ch-build_desc.rst
@@ -20,13 +20,17 @@ build environment if the builder doesn't do this by default).
 
 Supported builders, unprivileged:
 
-  * :code:`buildah`: Buildah in "rootless" mode with no setuid helpers, using
-    :code:`ch-run` (via :code:`ch-run-oci`) for :code:`RUN` instructions. This
-    requires Buildah v1.10.1+; see the install instructions.
-
   * :code:`ch-image`: Our internal builder.
 
 Supported builders, privileged:
+
+  * :code:`docker`: Docker.
+
+Experimental builders (i.e., the code is there but not tested much):
+
+  * :code:`buildah`: Buildah in "rootless" mode with no setuid helpers, using
+    :code:`ch-run` (via :code:`ch-run-oci`) for :code:`RUN` instructions. This
+    mode is fully unprivileged.
 
   * :code:`buildah-runc`: Buildah in "rootless" mode with setuid
     helpers, using the default :code:`runc` for :code:`RUN` instructions.
@@ -34,8 +38,6 @@ Supported builders, privileged:
   * :code:`buildah-setuid`: Buildah in "rootless" mode with setuid helpers,
     using :code:`ch-run` (via :code:`ch-run-oci`) for :code:`RUN`
     instructions.
-
-  * :code:`docker`: Docker.
 
 Specifying the builder, in descending order of priority:
 

--- a/packaging/vagrant/Vagrantfile
+++ b/packaging/vagrant/Vagrantfile
@@ -196,7 +196,7 @@ EOF2
   EOF
 
   # Install Buildah.
-  c.vm.provision "buildah", type: "shell", privileged: false,
+  c.vm.provision "buildah", type: "shell", run: "never", privileged: false,
                  inline: <<-EOF
     set -e
     cd /usr/local/src
@@ -328,7 +328,7 @@ EOF2
         user=vagrant
     fi
     sudo -iu $user -- sh -c "ch-test --pedantic yes -b docker all"
-    sudo -iu $user -- sh -c "ch-test --pedantic yes -b buildah all"
+    #sudo -iu $user -- sh -c "ch-test --pedantic yes -b buildah all"
     sudo -iu $user -- sh -c "ch-test --pedantic yes -b ch-image all"
   EOF
 end


### PR DESCRIPTION
Buildah keeps breaking CI and we haven't heard of people using it. Demote it to "experimental" and stop testing it in CI.