### PR TITLE
ch-image: implement scratch special image

### DIFF
--- a/lib/build.py
+++ b/lib/build.py
@@ -636,9 +636,10 @@ class I_from_(Instruction):
          ch.FATAL("output image ref same as FROM: %s" % self.base_ref)
       # Initialize image.
       self.base_image = ch.Image(self.base_ref)
-      if (not os.path.isdir(self.base_image.unpack_path)):
-         ch.VERBOSE("image not found, pulling: %s"
-                    % self.base_image.unpack_path)
+      if (os.path.isdir(self.base_image.unpack_path)):
+         ch.VERBOSE("base image found: %s" % self.base_image.unpack_path)
+      else:
+         ch.VERBOSE("base image not found, pulling")
          # a young hen, especially one less than one year old.
          pullet = pull.Image_Puller(self.base_image)
          pullet.pull_to_unpacked()

--- a/test/build/50_dockerfile.bats
+++ b/test/build/50_dockerfile.bats
@@ -843,6 +843,7 @@ EOF
     fi
 }
 
+
 @test 'Dockerfile: COPY --from errors' {
     scope standard
     [[ $CH_BUILDER = none ]] && skip 'no builder'
@@ -978,4 +979,42 @@ EOF
             false
             ;;
     esac
+}
+
+
+@test 'Dockerfile: FROM scratch' {
+    scope standard
+    [[ $CH_BUILDER = ch-image ]] || skip 'ch-image only'
+
+    # pull it; validate special handling
+    run ch-image pull -v scratch
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *'manifest: using internal library'* ]]
+    [[ $output = *'no config found; initializing empty metadata'* ]]
+    [[ $output != *'layer 1'* ]]  # no layers
+
+    # remove
+    ch-image delete scratch
+
+    # build 1; validate pulled with special handling
+    run ch-image build -v -t foo -f - . <<'EOF'
+FROM scratch
+EOF
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *'base image not found, pulling'* ]]
+    [[ $output = *'manifest: using internal library'* ]]
+    [[ $output = *'no config found; initializing empty metadata'* ]]
+    [[ $output != *'layer 1'* ]]  # no layers
+    ls -lha "${CH_IMAGE_STORAGE}/img/foo/usr"
+    [[ $(find /tmp/foo -mindepth 1 "${CH_IMAGE_STORAGE}/img/foo/usr") = '' ]]
+
+    # build 2; validate not pulled
+    run ch-image build -v -t foo -f - . <<'EOF'
+FROM scratch
+EOF
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *"base image found: ${CH_IMAGE_STORAGE}/img/scratch"* ]]
 }


### PR DESCRIPTION
Addresses #1013.

This PR introduces the notion of “internal” manifests that are never pulled. Currently there is one, called `scratch`, that has no config and no layers. This makes image `scratch` pullable and `FROM scratch` work.