### PR TITLE
add test for registry.access.redhat.com

### DIFF
--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -289,6 +289,10 @@ EOF
     LC_ALL=en_US.utf-8 \
     ch-image pull nvcr.io/hpc/foldingathome/fah-gpu:7.6.21
 
+    # Redhat Registry: https://catalog.redhat.com/software/containers/
+    # FIXME: 77 MiB unpacked, should find a smaller public image
+    ch-image pull registry.access.redhat.com/ubi7-minimal:latest
+
     # Things not here (yet?):
     #
     # 1. Harbor (issue #899): Has a demo repo (https://demo.goharbor.io) that

--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -289,7 +289,7 @@ EOF
     LC_ALL=en_US.utf-8 \
     ch-image pull nvcr.io/hpc/foldingathome/fah-gpu:7.6.21
 
-    # Redhat Registry: https://catalog.redhat.com/software/containers/
+    # Red Hat registry: https://catalog.redhat.com/software/containers/explore
     # FIXME: 77 MiB unpacked, should find a smaller public image
     ch-image pull registry.access.redhat.com/ubi7-minimal:latest
 


### PR DESCRIPTION
Addresses #1040

The Redhat registry is a mixture of images that require auth and those that do not.  After looking around I haven't found a public image smaller than 31/78 MiB (compressed/uncompressed) although it's quite possible one exists.