### PR TITLE
PR #1072: add runtime check for Python version (closes #1070)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -315,7 +315,7 @@ AS_IF([test -n "$NVIDIA_CLI"],
 AC_MSG_RESULT($have_nvidia_libs)
 
 # Python
-vmin_python=3.6
+vmin_python=3.6  # NOTE: Keep in sync with lib/charliecloud.py
 AC_MSG_CHECKING([if "$PYTHON_SHEBANG" starts with slash])
 AS_CASE([$PYTHON_SHEBANG],
   [/*], [AC_MSG_RESULT([ok])],

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -1398,8 +1398,8 @@ def dependencies_check():
       (e.g., lark module checked at import time), then complain and exit."""
    vsys_py = sys.version_info[:2]
    if vsys_py < vmin_py:
-      depfails.append(("bad", "found Python %s.%s; Needs 3.6 minimum\n"
-                       "       executable: %s" % (*vsys_py, sys.executable)))
+      depfails.append(("bad", """found Python %s.%s; Needs 3.6 minimum
+       executable: %s""" % (*vsys_py, sys.executable)))
 
    for (p, v) in depfails:
       ERROR("%s dependency: %s" % (p, v))

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -1397,7 +1397,7 @@ def dependencies_check():
    vmin_py = (3, 6)
    vsys_py = sys.version_info[:2]
    if vsys_py < vmin_py:
-      depfails.append(("bad", """found Python %s.%s; Needs 3.6 minimum
+      depfails.append(("outdated", """found Python %s.%s; Needs 3.6 minimum
        executable: %s""" % (*vsys_py, sys.executable)))
 
    for (p, v) in depfails:

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -59,9 +59,6 @@ except ImportError:
 
 ## Globals ##
 
-# Minimum version of Python to enforce
-vmin_py = (3, 6)
-
 # FIXME: currently set in ch-image :P
 CH_BIN = None
 CH_RUN = None
@@ -1396,6 +1393,8 @@ def copytree(*args, **kwargs):
 def dependencies_check():
    """Check more dependencies. If any dependency problems found, here or above
       (e.g., lark module checked at import time), then complain and exit."""
+   # Minimum version of Python to enforce
+   vmin_py = (3, 6)
    vsys_py = sys.version_info[:2]
    if vsys_py < vmin_py:
       depfails.append(("bad", """found Python %s.%s; Needs 3.6 minimum

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -68,6 +68,9 @@ verbose = 0          # Verbosity level. Can be 0, 1, or 2.
 log_festoon = False  # If true, prepend pid and timestamp to chatter.
 log_fp = sys.stderr  # File object to print logs to.
 
+# Minimum Python version. NOTE: Keep in sync with configure.ac.
+PYTHON_MIN = (3,6)
+
 # Verify TLS certificates? Passed to requests.
 tls_verify = True
 
@@ -1393,13 +1396,14 @@ def copytree(*args, **kwargs):
 def dependencies_check():
    """Check more dependencies. If any dependency problems found, here or above
       (e.g., lark module checked at import time), then complain and exit."""
-   # Minimum version of Python to enforce
-   vmin_py = (3, 6)
-   vsys_py = sys.version_info[:2]
-   if (vsys_py < vmin_py):
-      depfails.append(("outdated", """found Python %s.%s; Needs 3.6 minimum
-       executable: %s""" % (*vsys_py, sys.executable)))
-
+   # enforce Python minimum version
+   vsys_py = sys.version_info[:3]  # 4th element is a string
+   if (vsys_py < PYTHON_MIN):
+      vmin_py_str = ".".join(("%d" % i) for i in PYTHON_MIN)
+      vsys_py_str = ".".join(("%d" % i) for i in vsys_py)
+      depfails.append(("bad", ("need Python %s but running under %s: %s"
+                               % (vmin_py_str, vsys_py_str, sys.executable))))
+   # report problems & exit
    for (p, v) in depfails:
       ERROR("%s dependency: %s" % (p, v))
    if (len(depfails) > 0):

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -1396,7 +1396,7 @@ def dependencies_check():
    # Minimum version of Python to enforce
    vmin_py = (3, 6)
    vsys_py = sys.version_info[:2]
-   if vsys_py < vmin_py:
+   if (vsys_py < vmin_py):
       depfails.append(("outdated", """found Python %s.%s; Needs 3.6 minimum
        executable: %s""" % (*vsys_py, sys.executable)))
 

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -59,6 +59,9 @@ except ImportError:
 
 ## Globals ##
 
+# Minimum version of Python to enforce
+vmin_py = (3, 6)
+
 # FIXME: currently set in ch-image :P
 CH_BIN = None
 CH_RUN = None
@@ -1393,6 +1396,11 @@ def copytree(*args, **kwargs):
 def dependencies_check():
    """Check more dependencies. If any dependency problems found, here or above
       (e.g., lark module checked at import time), then complain and exit."""
+   vsys_py = sys.version_info[:2]
+   if vsys_py < vmin_py:
+      depfails.append(("bad", "found Python %s.%s; Needs 3.6 minimum\n"
+                       "       executable: %s" % (*vsys_py, sys.executable)))
+
    for (p, v) in depfails:
       ERROR("%s dependency: %s" % (p, v))
    if (len(depfails) > 0):


### PR DESCRIPTION
Addresses issue #1070

Example output:
```
error: outdated dependency: found Python 3.5; Needs 3.6 minimum
       executable: /home/heasterday/anaconda3/envs/python-3.1/bin/python3
```

NOTE: This doesn't add a dependency check to ch-run-oci as it is a bit of an oddball. @reidpr let me know if you would like that added.