### PR TITLE
ch-test: test Microsoft Container Registry (MCR)

### DIFF
--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -293,6 +293,11 @@ EOF
     # FIXME: 77 MiB unpacked, should find a smaller public image
     ch-image pull registry.access.redhat.com/ubi7-minimal:latest
 
+    # Microsoft Container Registry:
+    # MCR doesn't have a catalog, Docker Hub is the way to browse images
+    # https://hub.docker.com/publishers/microsoftowner
+    ch-image pull mcr.microsoft.com/mcr/hello-world:latest
+
     # Things not here (yet?):
     #
     # 1. Harbor (issue #899): Has a demo repo (https://demo.goharbor.io) that

--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -294,9 +294,7 @@ EOF
     ch-image pull registry.access.redhat.com/ubi7-minimal:latest
 
     # Microsoft Container Registry:
-    # https://hub.docker.com/publishers/microsoftowner
-    # MCR doesn't have a catalog with a UI, Docker Hub is the official way to
-    # browse images.
+    # https://github.com/microsoft/containerregistry
     ch-image pull mcr.microsoft.com/mcr/hello-world:latest
 
     # Things not here (yet?):

--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -294,8 +294,9 @@ EOF
     ch-image pull registry.access.redhat.com/ubi7-minimal:latest
 
     # Microsoft Container Registry:
-    # MCR doesn't have a catalog, Docker Hub is the way to browse images
     # https://hub.docker.com/publishers/microsoftowner
+    # MCR doesn't have a catalog with a UI, Docker Hub is the official way to
+    # browse images.
     ch-image pull mcr.microsoft.com/mcr/hello-world:latest
 
     # Things not here (yet?):


### PR DESCRIPTION
Addresses #1071 

The Microsoft Container Registry is interesting in that they don't have a public UI to their catalog, instead they leverage Dockerhub as outlined in [this blog post](https://cloudblogs.microsoft.com/opensource/2019/01/17/improved-discovery-experience-microsoft-containers-docker-hub/).