### PR TITLE
progress meter for downloads/uploads

### DIFF
--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -920,10 +920,10 @@ class Progress:
       more numerous than what we want to display; for example, to count bytes
       but report MiB, use a divisor of 1048576.
 
-      Unless global log_festoon is set, moves to a new line at first update,
-      then assumes exclusive control of this line in the terminal, rewriting
-      the line as needed. If log_festoon is set, each update is one log entry
-      with no overwriting."""
+      By default, moves to a new line at first update, then assumes exclusive
+      control of this line in the terminal, rewriting the line as needed. If
+      output is not a TTY or global log_festoon is set, each update is one log
+      entry with no overwriting."""
 
    __slots__ = ("display_last",
                 "divisor",

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -979,7 +979,6 @@ class Progress:
 
 
 class Progress_Reader:
-
    """Wrapper around a binary file object to maintain a progress meter while
       reading."""
 
@@ -1277,7 +1276,7 @@ class Registry_HTTP:
          is given, it is set of acceptable response status codes, defaulting
          to {200}; any other response is a fatal error. If out is given,
          response content will be streamed to this Progress_Writer object and
-         must be non-zero length with valid Content-Length header.
+         must be non-zero length.
 
          Use current session if there is one, or start a new one if not. If
          authentication fails (or isn't initialized), then authenticate and

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -1301,20 +1301,18 @@ class Registry_HTTP:
             2. HTTP 200, but body is a skinny manifest: image exists but is
                not architecture-aware.
 
-            3. HTTP 400/401/404: image does not exist. (400 seems wrong but
-               that's how Docker Hub responds.)
+            3. HTTP 401/404: image does not exist.
 
          This method raises Not_In_Registry_Error in case 3. The caller is
          responsible for distinguishing cases 1 and 2."""
       url = self._url_of("manifests", self.ref.version)
       pw = Progress_Writer(path, msg)
-      statuses = {200, 400, 401, 404}
       # Including TYPE_MANIFEST avoids the server trying to convert its v2
       # manifest to a v1 manifest, which currently fails for images
       # Charliecloud pushes. The error in the test registry is “empty history
       # when trying to create schema1 manifest”.
       accept = "%s, %s;q=0.5" % (TYPE_MANIFEST_LIST, TYPE_MANIFEST)
-      res = self.request("GET", url, out=pw, statuses=statuses,
+      res = self.request("GET", url, out=pw, statuses={200, 401, 404},
                          headers={ "Accept" : accept })
       pw.close()
       if (res.status_code != 200):

--- a/lib/misc.py
+++ b/lib/misc.py
@@ -68,21 +68,19 @@ def list_(cli):
       # present remotely?
       print("full remote ref:     %s" % img.ref.canonical)
       pullet = pull.Image_Puller(img, not cli.no_cache)
-      pullet.fatman_load()
-      if (pullet.architectures is not None):
+      try:
+         pullet.fatman_load()
          remote = "yes"
          arch_aware = "yes"
          arch_avail = " ".join(sorted(pullet.architectures.keys()))
-      else:
-         pullet.manifest_load(True)
-         if (pullet.layer_hashes is not None):
-            remote = "yes"
-            arch_aware = "no"
-            arch_avail = "unknown"
-         else:
-            remote = "no"
-            arch_aware = "n/a"
-            arch_avail = "n/a"
+      except ch.Not_In_Registry_Error:
+         remote = "no"
+         arch_aware = "n/a"
+         arch_avail = "n/a"
+      except ch.No_Fatman_Error:
+         remote = "yes"
+         arch_aware = "no"
+         arch_avail = "unknown"
       pullet.done()
       print("available remotely:  %s" % remote)
       print("remote arch-aware:   %s" % arch_aware)

--- a/lib/pull.py
+++ b/lib/pull.py
@@ -85,19 +85,17 @@ class Image_Puller:
          if (os.path.exists(self.config_path) and use_cache):
             ch.INFO("config: using existing file")
          else:
-            ch.INFO("config: downloading")
-            dl.blob_to_file(self.config_hash, self.config_path)
+            dl.blob_to_file(self.config_hash, self.config_path,
+                            "config: downloading")
       # layers
       for (i, lh) in enumerate(self.layer_hashes, start=1):
          path = self.layer_path(lh)
          ch.VERBOSE("layer path: %s" % path)
-         ch.INFO("layer %d/%d: %s: "% (i, len(self.layer_hashes), lh[:7]),
-                 end="")
+         msg = "layer %d/%d: %s" % (i, len(self.layer_hashes), lh[:7])
          if (os.path.exists(path) and use_cache):
-            ch.INFO("using existing file")
+            ch.INFO("%s: using existing file" % msg)
          else:
-            ch.INFO("downloading")
-            dl.blob_to_file(lh, path)
+            dl.blob_to_file(lh, path, "%s: downloading" % msg)
       dl.close()
 
    def layer_path(self, layer_hash):
@@ -159,8 +157,8 @@ class Image_Puller:
          if (os.path.exists(self.manifest_path) and use_cache):
             ch.INFO("manifest: using existing file")
          else:
-            ch.INFO("manifest: downloading")
-            downloader.manifest_to_file(self.manifest_path)
+            downloader.manifest_to_file(self.manifest_path,
+                                        "manifest: downloading")
          # read and parse the JSON
          fp = ch.open_(self.manifest_path, "rt", encoding="UTF-8")
          text = ch.ossafe(fp.read, "can't read: %s" % self.manifest_path)

--- a/lib/pull.py
+++ b/lib/pull.py
@@ -162,9 +162,9 @@ class Image_Puller:
                                       "manifest list: downloading")
       fm = ch.json_from_file(self.fatman_path, "fat manifest")
       if ("layers" in fm or "fsLayers" in fm):
-         # If there is no fat manifest but the image exists, we get a skinny
-         # manifest instead. We can't use it, however, because it might be a
-         # v1 manifest when a v2 is available. ¯\_(ツ)_/¯
+         # FIXME (issue #1101): If it's a v2 manifest we could use it instead
+         # of re-requesting later. Maybe we could here move/copy it over to
+         # the skinny manifest path.
          raise ch.No_Fatman_Error()
       if ("errors" in fm):
          # fm is an error blob.

--- a/lib/pull.py
+++ b/lib/pull.py
@@ -87,24 +87,28 @@ class Image_Puller:
       # Spec: https://docs.docker.com/registry/spec/manifest-v2-2/
       ch.VERBOSE("downloading image: %s" % self.image)
       ch.mkdirs(ch.storage.download_cache)
-      # fat manifest
-      if (ch.arch != "yolo"):
-         self.fatman_load()
-         if (self.architectures is not None):
-            if (ch.arch not in self.architectures):
-               ch.FATAL("requested arch unavailable: %s not one of: %s"
-                        % (ch.arch,
-                           " ".join(sorted(self.architectures.keys()))))
-         elif (ch.arch == "amd64"):
-            # We're guessing that enough arch-unaware images are amd64 to
-            # barge ahead if requested architecture is amd64.
-            ch.arch = "yolo"
-            ch.WARNING("image is architecture-unaware")
-            ch.WARNING("requested arch is amd64; switching to --arch=yolo")
-         else:
-            ch.FATAL("image is architecture-unaware; try --arch=yolo (?)")
-      # manifest
-      self.manifest_load()
+      try:
+         # fat manifest
+         if (ch.arch != "yolo"):
+            try:
+               self.fatman_load()
+               if (ch.arch not in self.architectures):
+                  ch.FATAL("requested arch unavailable: %s not one of: %s"
+                           % (ch.arch,
+                              " ".join(sorted(self.architectures.keys()))))
+            except ch.No_Fatman_Error:
+               if (ch.arch == "amd64"):
+                  # We're guessing that enough arch-unaware images are amd64 to
+                  # barge ahead if requested architecture is amd64.
+                  ch.arch = "yolo"
+                  ch.WARNING("image is architecture-unaware")
+                  ch.WARNING("requested arch is amd64; using --arch=yolo")
+               else:
+                  ch.FATAL("image is architecture-unaware; try --arch=yolo?")
+         # manifest
+         self.manifest_load()
+      except ch.Not_In_Registry_Error:
+         ch.FATAL("not in registry: %s" % self.registry.ref)
       # config
       ch.VERBOSE("config path: %s" % self.config_path)
       if (self.config_path is not None):
@@ -140,29 +144,28 @@ class Image_Puller:
          the image has a fat manifest, populate self.architectures; this may
          be an empty dictionary if no valid architectures were found.
 
-         It is not an error if the image has no fat manifest or the registry
-         reports no such image. In this architecture-unaware condition, set
-         self.architectures to None."""
+         Raises:
+
+           * Not_In_Registry_Error if the image does not exist.
+
+           * No_Fatman_Error if the image exists but has no fat manifest,
+             i.e., is architecture-unaware. In this case self.architectures is
+             set to None."""
       self.architectures = None
       if (str(self.image.ref) in manifests_internal):
-         return  # no fat manifests for internal library
+         raise ch.No_Fatman_Error()  # no fat manifests for internal library
       if (os.path.exists(self.fatman_path) and self.use_cache):
          ch.INFO("manifest list: using existing file")
       else:
+         # raises Not_In_Registry_Error if needed
          self.registry.fatman_to_file(self.fatman_path,
-                                      "manifest list: downloading",
-                                      continue_404=True)
-      if (not os.path.exists(self.fatman_path)):
-         # Response was 404 (or equivalent).
-         ch.INFO("manifest list: no list found")
-         return
+                                      "manifest list: downloading")
       fm = ch.json_from_file(self.fatman_path, "fat manifest")
       if ("layers" in fm or "fsLayers" in fm):
          # If there is no fat manifest but the image exists, we get a skinny
          # manifest instead. We can't use it, however, because it might be a
          # v1 manifest when a v2 is available. ¯\_(ツ)_/¯
-         ch.INFO("manifest list: no valid list found")
-         return
+         raise ch.No_Fatman_Error()
       if ("errors" in fm):
          # fm is an error blob.
          (code, msg) = self.error_decode(fm)
@@ -194,12 +197,10 @@ class Image_Puller:
       "Return the path to tarball for layer layer_hash."
       return ch.storage.download_cache // (layer_hash + ".tar.gz")
 
-   def manifest_load(self, continue_404=False):
+   def manifest_load(self):
       """Download the manifest file if needed, parse it, and set
-         self.config_hash and self.layer_hashes. By default, if the image does
-         not exist, exit with error; if continue_404, then log the condition
-         but do not exit. In this case, self.config_hash and self.layer_hashes
-         will both be None."""
+         self.config_hash and self.layer_hashes. If the image does not exist,
+         exit with error."""
       def bad_key(key):
          ch.FATAL("manifest: %s: no key: %s" % (self.manifest_path, key))
       self.config_hash = None
@@ -221,12 +222,7 @@ class Image_Puller:
          else:
             self.registry.manifest_to_file(self.manifest_path,
                                            "manifest: downloading",
-                                           digest=digest,
-                                           continue_404=continue_404)
-         if (not os.path.exists(self.manifest_path)):
-            # response was 404 (or equivalent)
-            ch.INFO("manifest: none found")
-            return
+                                           digest=digest)
          manifest = ch.json_from_file(self.manifest_path, "manifest")
       # validate schema version
       try:

--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -405,7 +405,6 @@ EOF
 }
 
 @test 'pull images that do not exist' {
-
     # name does not exist remotely, in library
     run ch-image pull doesnotexist:latest
     echo "$output"

--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -281,7 +281,8 @@ EOF
     # Google Container Registry:
     # https://console.cloud.google.com/gcr/images/google-containers/GLOBAL
     # FIXME: "latest" tags do not work, but they do in Docker (issue #896)
-    ch-image pull gcr.io/google-containers/busybox:1.27
+    # FIXME: arch-aware pull does not work either (issue #1100)
+    ch-image pull --arch=yolo gcr.io/google-containers/busybox:1.27
 
     # nVidia NGC: https://ngc.nvidia.com
     # FIXME: 96 MiB unpacked; also kind of slow
@@ -374,7 +375,7 @@ EOF
 }
 
 
-@test 'ch-image pull by arch' {
+@test 'pull by arch' {
     # Has fat manifest; requested arch exists. There's not much simple to look
     # for in the output, so just see if it works.
     ch-image --arch=yolo pull alpine:latest
@@ -399,6 +400,33 @@ EOF
         run ch-image --arch=arm64/v8 pull charliecloud/metadata:2021-01-15
         echo "$output"
         [[ $status -eq 1 ]]
-        [[ $output = *'image is architecture-unaware; try --arch=yolo (?)' ]]
+        [[ $output = *'image is architecture-unaware; try --arch=yolo?' ]]
     fi
+}
+
+@test 'pull images that do not exist' {
+
+    # name does not exist remotely, in library
+    run ch-image pull doesnotexist:latest
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'registry-1.docker.io:443/library/doesnotexist:latest'* ]]
+
+    # tag does not exist remotely, in library
+    run ch-image pull alpine:doesnotexist
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'registry-1.docker.io:443/library/alpine:doesnotexist'* ]]
+
+    # name does not exist remotely, not in library
+    run ch-image pull charliecloud/doesnotexist:latest
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'registry-1.docker.io:443/charliecloud/doesnotexist:latest'* ]]
+
+    # tag does not exist remotely, not in library
+    run ch-image pull charliecloud/metadata:doesnotexist
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *'registry-1.docker.io:443/charliecloud/metadata:doesnotexist'* ]]
 }

--- a/test/build/50_ch-image.bats
+++ b/test/build/50_ch-image.bats
@@ -271,7 +271,7 @@ EOF
     run ch-image list scratch
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output = *'in local storage:    yes'* ]]
+    #[[ $output = *'in local storage:    yes'* ]]  # varies
     [[ $output = *'full remote ref:     registry-1.docker.io:443/library/scratch:latest'* ]]
     [[ $output = *'available remotely:  yes'* ]]
     [[ $output = *'remote arch-aware:   no'* ]]

--- a/test/build/50_ch-image.bats
+++ b/test/build/50_ch-image.bats
@@ -195,18 +195,50 @@ EOF
     [[ $status -eq 0 ]]
     [[ $output = *"00_tiny"* ]]
 
-    # does not exist remotely
+    # name does not exist remotely, in library
     run ch-image list doesnotexist:latest
     echo "$output"
-    [[ $status -eq 1 ]]
-    [[ $output = *'GET failed; expected status {200, 403} but got 400'* ]]
+    [[ $status -eq 0 ]]
+    [[ $output = *'in local storage:    no'* ]]
+    [[ $output = *'available remotely:  no'* ]]
+    [[ $output = *'remote arch-aware:   n/a'* ]]
+    [[ $output = *'archs available:     n/a'* ]]
+
+    # tag does not exist remotely, in library
+    run ch-image list alpine:doesnotexist
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *'in local storage:    no'* ]]
+    [[ $output = *'available remotely:  no'* ]]
+    [[ $output = *'remote arch-aware:   n/a'* ]]
+    [[ $output = *'archs available:     n/a'* ]]
+
+    # name does not exist remotely, not in library
+    run ch-image list charliecloud/doesnotexist:latest
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *'in local storage:    no'* ]]
+    [[ $output = *'available remotely:  no'* ]]
+    [[ $output = *'remote arch-aware:   n/a'* ]]
+    [[ $output = *'archs available:     n/a'* ]]
+
+    # tag does not exist remotely, not in library
+    run ch-image list charliecloud/metadata:doesnotexist
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *'in local storage:    no'* ]]
+    [[ $output = *'available remotely:  no'* ]]
+    [[ $output = *'remote arch-aware:   n/a'* ]]
+    [[ $output = *'archs available:     n/a'* ]]
 
     # in storage, does not exist remotely
     run ch-image list 00_tiny
     echo "$output"
-    [[ $status -eq 1 ]]
+    [[ $status -eq 0 ]]
     [[ $output = *'in local storage:    yes'* ]]
-    [[ $output = *'GET failed; expected status {200, 403} but got 400'* ]]
+    [[ $output = *'available remotely:  no'* ]]
+    [[ $output = *'remote arch-aware:   n/a'* ]]
+    [[ $output = *'archs available:     n/a'* ]]
 
     # not in storage, exists remotely, fat manifest exists
     run ch-image list debian:buster-slim
@@ -234,6 +266,16 @@ EOF
     [[ $output = *'available remotely:  yes'* ]]
     [[ $output = *'remote arch-aware:   yes'* ]]
     [[ $output = *'warning: no valid architectures found'* ]]
+
+    # scratch is weird and tells lies
+    run ch-image list scratch
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *'in local storage:    yes'* ]]
+    [[ $output = *'full remote ref:     registry-1.docker.io:443/library/scratch:latest'* ]]
+    [[ $output = *'available remotely:  yes'* ]]
+    [[ $output = *'remote arch-aware:   no'* ]]
+    [[ $output = *'archs available:     unknown'* ]]
 }
 
 @test 'ch-image reset' {


### PR DESCRIPTION
This implements a simple progress meter for image upload and download. It prints bytes processed, total bytes, and percent done, but not any sort of progress bar. If the server gives no `Content-Length` header, downloads give just an increasing byte count. Addresses #1003.

Passes semi-automated registry tests for me.

Quirks:

1. For small files like the config and manifest, a progress meter is still printed, but it updates once and says "`0.0/0.0 MiB (100%)`". I wasn't able to figure out anything simple to solve this. Options that I considered that seemed awkward: (a) omit the byte counts and just print the percentage, (b) extend the precision until it doesn't round to zero (this ended up at "`0.0004/0.0004 (100%)`" which seemed awkward).

2. Config an manifest do not get a progress meter on upload. Again they are small and finish almost instantly even on something like a modem, but it's not consistent with the above.

Sample output for download:

```
$ ch-image pull --no-cache centos:7
pulling image:   centos:7
manifest: downloading: 0.0/0.0 MiB (100%)
config: downloading: 0.0/0.0 MiB (100%)
layer 1/1: 89d400c: downloading: 27.5/70.7 MiB (38%)
```

Sample output for upload (note meter is split by auth prompt):

```
$ ch-image push alpine:latest [...]
pushing image:   alpine:latest
destination:     [...]
layer 1/1: gathering
layer 1/1: preparing
preparing metadata
starting upload
layer 1/1: c64f51a: checking if already in repository
layer 1/1: c64f51a: not present, uploading: 0.0/2.6 MiB (0%)
Username: reidpr@lanl.gov
Password:
layer 1/1: c64f51a: not present, uploading: 2.6/2.6 MiB (100%)
```

Sample output for Red Hat registry that's unreliable on `Content-Length`:

```
$ ch-image pull registry.access.redhat.com/ubi8/ubi
pulling image:   registry.access.redhat.com/ubi8/ubi
manifest: downloading: 0.0/0.0 MiB (100%)
config: downloading: 0.0/0.0 MiB (363%)
layer 1/2: 053724d: downloading: 79.6/unknown MiB
layer 2/2: f0ae454: downloading: 0.0/0.0 MiB (98%)
flattening image
layer 1/2: 053724d: listing
layer 2/2: f0ae454: listing
validating tarball members
resolving whiteouts
layer 1/2: 053724d: extracting
layer 2/2: f0ae454: extracting
done
```