### PR TITLE
lib/fakeroot.py: adjust regex match to account for CentOS Stream

### DIFF
--- a/lib/fakeroot.py
+++ b/lib/fakeroot.py
@@ -176,7 +176,7 @@ DEFAULT_CONFIGS = {
 
    "rhel8":
    { "name": "CentOS/RHEL 8",
-     "match":  ("/etc/redhat-release", r"release 8\."),
+     "match":  ("/etc/redhat-release", r"release 8"),
      "init": [ ("command -v fakeroot > /dev/null",
                 "set -ex; "
                 "if ! grep -Eq '\[epel\]' /etc/yum.conf /etc/yum.repos.d/*; then "


### PR DESCRIPTION
Addresses #1095 

NOTE: I went to add a test for this but since there aren't official images for CentOS Stream that I could find I saw three options:

1. Use a third party base image (I don't like this route)
2. Use a CentOS 8 base image and [convert to Stream](https://www.centos.org/centos-stream/) for testing locally (this requires `--force` support to accomplish so it doesn't seem like an effective test without a more complicated process).
3. Don't add a test 

I went with 3 for now but can chase 2 down if desired.