### PR TITLE
configure.ac: relax configure's nvidia library check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -313,7 +313,7 @@ CH_CHECK_VERSION([NVIDIA_CLI], [$vmin_nvidia_CLI],
                  [-V | head -1 | cut -d' ' -f2])
 AC_MSG_CHECKING([for nVidia libraries & executables])
 AS_IF([test -n "$NVIDIA_CLI"],
-  [AS_IF([nvidia-container-cli list | grep -Fq libnvidia-glcore.so],
+  [AS_IF([nvidia-container-cli list | grep -q libnvidia],
         [have_nvidia_libs=yes],
         [have_nvidia_libs=no])],
   [have_nvidia_libs=no])

--- a/configure.ac
+++ b/configure.ac
@@ -313,7 +313,7 @@ CH_CHECK_VERSION([NVIDIA_CLI], [$vmin_nvidia_CLI],
                  [-V | head -1 | cut -d' ' -f2])
 AC_MSG_CHECKING([for nVidia libraries & executables])
 AS_IF([test -n "$NVIDIA_CLI"],
-  [AS_IF([nvidia-container-cli list | grep -q libnvidia],
+  [AS_IF([nvidia-container-cli list | grep -Fq libnvidia],
         [have_nvidia_libs=yes],
         [have_nvidia_libs=no])],
   [have_nvidia_libs=no])


### PR DESCRIPTION
Addresses: #1123 

It seems like the intent of this check was just that `nvidia-container-cli` was finding nvidia libraries rather than checking for a particular one (potentially tricky given we don't know the user's application). This PR changes the configure logic to check `nvidia-container-cli list`'s output for any library of the form `*libnvidia*`.