### PR TITLE
Add support for debian 11

### DIFF
--- a/lib/fakeroot.py
+++ b/lib/fakeroot.py
@@ -213,8 +213,8 @@ DEFAULT_CONFIGS = {
    #      | egrep '^(fakeroot|fakeroot-ng|pseudo)$'
 
    "debderiv":
-   { "name": "Debian (9, 10) or Ubuntu (16, 18, 20)",
-     "match": ("/etc/os-release", r"(stretch|buster|xenial|bionic|focal)"),
+   { "name": "Debian (9, 10, 11) or Ubuntu (16, 18, 20)",
+     "match": ("/etc/os-release", r"(stretch|buster|bullseye|xenial|bionic|focal)"),
      "init": [ ("apt-config dump | fgrep -q 'APT::Sandbox::User \"root\"'"
                 " || ! fgrep -q _apt /etc/passwd",
                 "echo 'APT::Sandbox::User \"root\";'"

--- a/test/force-auto.py.in
+++ b/test/force-auto.py.in
@@ -249,9 +249,9 @@ class _Debian(Test):
    runs = { **Test.runs, **{ Run.NEEDED:      "apt-get update && apt-get install -y openssh-client" } }
 class Debian_9(_Debian):
    base = "debian:stretch"
-class Debian_10(_Debian):
+class Debian_11(_Debian):
    scope = Scope.STANDARD
-   base = "debian:buster"
+   base = "debian:bullseye"
 class Ubuntu_16(_Debian):
    base = "ubuntu:xenial"
 class Ubuntu_18(_Debian):
@@ -279,7 +279,7 @@ for test in [CentOS_7,
              Fedora_26,
              Fedora_Latest,
              Debian_9,
-             Debian_10,
+             Debian_11,
              Ubuntu_16,
              Ubuntu_18,
              Ubuntu_20]:


### PR DESCRIPTION
Not a nice solution, but it works.

I haven't tested, but wouldn't it be easier to test for debian/ubuntu, and just let it fail if it doesn't work? The user can still remove `--force` and try without, so they are not worse of than now?

Addresses #1043 