### PR TITLE
lib/charliecloud.py bump max support lark version

### DIFF
--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -38,7 +38,7 @@ depfails = []
 # [1]: https://github.com/lark-parser/lark/issues/505
 import lark
 LARK_MIN = (0,  7, 1)
-LARK_MAX = (0, 11, 3)
+LARK_MAX = (0, 12, 0)
 lark_version = tuple(int(i) for i in lark.__version__.split("."))
 if (not LARK_MIN <= lark_version <= LARK_MAX):
    depfails.append(("bad", 'found Python module "lark" version %d.%d.%d but need between %d.%d.%d and %d.%d.%d inclusive' % (lark_version + LARK_MIN + LARK_MAX)))


### PR DESCRIPTION
This should resolve CI failures. Another route would be to pin the lark version that we install in the CI environment but it sounds like we are hoping to only test with the bundled version of lark in the near future.