### PR TITLE
lib/fakeroot.py: --force, don't enforce max supported version

### DIFF
--- a/lib/fakeroot.py
+++ b/lib/fakeroot.py
@@ -175,8 +175,8 @@ DEFAULT_CONFIGS = {
      "each": ["fakeroot"] },
 
    "rhel8":
-   { "name": "CentOS/RHEL 8",
-     "match":  ("/etc/redhat-release", r"release 8"),
+   { "name": "CentOS/RHEL 8+",
+     "match":  ("/etc/redhat-release", r"release (?![0-7]\.)"),
      "init": [ ("command -v fakeroot > /dev/null",
                 "set -ex; "
                 "if ! grep -Eq '\[epel\]' /etc/yum.conf /etc/yum.repos.d/*; then "
@@ -213,8 +213,8 @@ DEFAULT_CONFIGS = {
    #      | egrep '^(fakeroot|fakeroot-ng|pseudo)$'
 
    "debderiv":
-   { "name": "Debian (9, 10, 11) or Ubuntu (16, 18, 20)",
-     "match": ("/etc/os-release", r"(stretch|buster|bullseye|xenial|bionic|focal)"),
+   { "name": "Debian 9+ or Ubuntu 14+",
+     "match": ("/etc/os-release", r"Debian GNU/Linux (?![0-8] )|Ubuntu (?![0-9]\.|1[0-3]\.)"),
      "init": [ ("apt-config dump | fgrep -q 'APT::Sandbox::User \"root\"'"
                 " || ! fgrep -q _apt /etc/passwd",
                 "echo 'APT::Sandbox::User \"root\";'"
@@ -235,7 +235,7 @@ DEFAULT_CONFIGS = {
 
    "fedora":
    { "name": "Fedora 24+,",
-     "match":  ("/etc/fedora-release", r"release (2[4-9]|[3-9][0-9])"),
+     "match":  ("/etc/fedora-release", r"release (?!1?[0-9] |2[0-3] )"),
      "init": [ ("command -v fakeroot > /dev/null",
                 "dnf install -y fakeroot") ],
      "cmds": ["dnf", "rpm", "yum"],

--- a/lib/fakeroot.py
+++ b/lib/fakeroot.py
@@ -161,7 +161,7 @@ DEFAULT_CONFIGS = {
 
    "rhel7":
    { "name": "CentOS/RHEL 7",
-     "match": ("/etc/redhat-release", r"release 7\."),
+     "match": ("/etc/redhat-release", r"(Red Hat|CentOS).*release 7\."),
      "init": [ ("command -v fakeroot > /dev/null",
                 "set -ex; "
                 "if ! grep -Eq '\[epel\]' /etc/yum.conf /etc/yum.repos.d/*; then "
@@ -176,7 +176,7 @@ DEFAULT_CONFIGS = {
 
    "rhel8":
    { "name": "CentOS/RHEL 8+",
-     "match":  ("/etc/redhat-release", r"release (?![0-7]\.)"),
+     "match":  ("/etc/redhat-release", r"(Red Hat|CentOS).*release (?![0-7]\.)"),
      "init": [ ("command -v fakeroot > /dev/null",
                 "set -ex; "
                 "if ! grep -Eq '\[epel\]' /etc/yum.conf /etc/yum.repos.d/*; then "

--- a/test/force-auto.py.in
+++ b/test/force-auto.py.in
@@ -221,8 +221,8 @@ class _RHEL8(Test):
    runs = { **Test.runs, **{ Run.FAKE_NEEDED: "dnf install -y --setopt=install_weak_deps=false ed",
                              Run.NEEDED:      "dnf install -y --setopt=install_weak_deps=false openssh" } }
 
-class CentOS_8(_RHEL8, _EPEL_Mixin):
-   base = "centos:8"
+class CentOS_Latest(_RHEL8, _EPEL_Mixin):
+   base = "centos:latest"
    prep_run = "dnf install -y epel-release"
 class CentOS_8_Stream(_RHEL8):
    # pulling from quay.io per the CentOS wiki
@@ -248,16 +248,16 @@ class _Debian(Test):
    config = "debderiv"
    runs = { **Test.runs, **{ Run.NEEDED:      "apt-get update && apt-get install -y openssh-client" } }
 class Debian_9(_Debian):
-   base = "debian:stretch"
-class Debian_11(_Debian):
+   base = "debian:9"
+class Debian_Latest(_Debian):
    scope = Scope.STANDARD
-   base = "debian:bullseye"
+   base = "debian:latest"
 class Ubuntu_16(_Debian):
-   base = "ubuntu:xenial"
+   base = "ubuntu:16.04"
 class Ubuntu_18(_Debian):
-   base = "ubuntu:bionic"
-class Ubuntu_20(_Debian):
-   base = "ubuntu:focal"
+   base = "ubuntu:18.04"
+class Ubuntu_Latest(_Debian):
+   base = "ubuntu:latest"
 
 
 # main loop
@@ -273,16 +273,16 @@ setup () {
 """)
 
 for test in [CentOS_7,
-             CentOS_8,
+             CentOS_Latest,
              CentOS_8_Stream,
              RHEL_UBI_8,
              Fedora_26,
              Fedora_Latest,
              Debian_9,
-             Debian_11,
+             Debian_Latest,
              Ubuntu_16,
              Ubuntu_18,
-             Ubuntu_20]:
+             Ubuntu_Latest]:
    for run in Run:
       for forced in (False, True):
          for preprep in (False, True):


### PR DESCRIPTION
Addresses #1057 

This PR removes the max supported version logic from `--force`. Instead, `fakeroot.py` checks that the target os version isn't a known unsupported version. In addition, I adjusted the relevant tests to test image releases tagged `latest`. I also changed the Ubuntu tests to use image tags based on release numbers instead of their release names (20.04 instead of focal).