### PR TITLE
`ch-test --file`: match via substrings rather than exact

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -41,10 +41,10 @@ Valid scopes: quick, standard, full
 
 Additional options:
 
-  -b, --builder BUILDER  image builder to use
+  -b,--builder BUILDER   image builder to use
   --dry-run              print summary of what would be tested and exit
-  --file FILE[:TEST]     run tests in FILE only, or even just TEST
-  -h, --help             print this help and exit
+  -f,--file FILE[:TEST]  run tests in FILE only, or even just TEST
+  -h,--help              print this help and exit
   --img-dir DIR          unpacked images directory; same as \$CH_TEST_IMGDIR
   --pack-dir DIR         packed imaged directory; same as \$CH_TEST_TARDIR
   --pack-fmt FMT         packed image format ("squash" or "tar")

--- a/doc/ch-test_desc.rst
+++ b/doc/ch-test_desc.rst
@@ -94,10 +94,10 @@ allows trading off thoroughness versus time.
     whatever is in the file are satisfied. Often running :code:`build` and
     :code:`run` first is sufficient, but this varies.
 
-    If :code:`TEST` is also given, then run only the test with that name,
-    skipping the others. The separator is a literal colon. Most test names
-    contain spaces, so you'll usually need to quote the argument to protect it
-    from the shell.
+    If :code:`TEST` is also given, then run only tests with name containing
+    that string, skipping the others. The separator is a literal colon. If the
+    string contains shell metacharacters such as space, you'll need to quote
+    the argument to protect it from the shell.
 
 Scope is specified with:
 

--- a/test/common.bash
+++ b/test/common.bash
@@ -136,7 +136,7 @@ run () {
 scope () {
     if [[ -n $ch_one_test ]]; then
         # Ignore scope if a single test is given.
-        if [[ $ch_one_test != "$BATS_TEST_DESCRIPTION" ]]; then
+        if [[ $BATS_TEST_DESCRIPTION != *"$ch_one_test"* ]]; then
             skip 'per --file'
         else
             return 0


### PR DESCRIPTION
Currently `ch-test -f foo.bats:bar` matches tests in `foo.bats` named exactly `bar`. With this PR, any test whose name contains the substring `bar` will match. This makes it easier to run single tests because the exact name need not be copied and pasted.

Before:

```
$ ch-test -f test/build/10_sanity.bats:lint
[...]
file:  /host/p/Charliecloud/charliecloud/test/build/10_sanity.bats
 - documentation seems sane (skipped: per --file)
 - version number seems sane (skipped: per --file)
 - executables seem sane (skipped: per --file)
 - lint shell scripts (skipped: per --file)
 - proxy variables (skipped: per --file)

5 tests, 0 failures, 5 skipped

All tests passed.
```

After:

```
$ ch-test -f test/build/10_sanity.bats:lint
[...]
file:  /host/p/Charliecloud/charliecloud/test/build/10_sanity.bats
 - documentation seems sane (skipped: per --file)
 - version number seems sane (skipped: per --file)
 - executables seem sane (skipped: per --file)
 ✓ lint shell scripts
 - proxy variables (skipped: per --file)

5 tests, 0 failures, 4 skipped

All tests passed.
```