### PR TITLE
`ch_misc.h`: mark `host_tmp` as extern to fix linking errors

### DIFF
--- a/bin/ch_misc.h
+++ b/bin/ch_misc.h
@@ -67,7 +67,7 @@
 /** External variables **/
 
 extern int verbose;
-char * host_tmp;
+extern char * host_tmp;
 
 
 /** Function prototypes **/


### PR DESCRIPTION
Without marking this as `extern`, `ld` fails with:
```
ld: ch_run-ch_core.o:DIR/bin/ch_misc.h:70: multiple definition of `host_tmp'; ch_run-ch-run.o:DIR/bin/ch_misc.h:70: first defined here
ld: ch_run-ch_misc.o:DIR/bin/ch_misc.h:70: multiple definition of `host_tmp'; ch_run-ch-run.o:DIR/bin/ch_misc.h:70: first defined here
collect2: error: ld returned 1 exit status
```