### PR TITLE
allow non-Docker Hub default registry, misc tidying

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -649,6 +649,36 @@ if /bin/bash -c 'set -e; [[ 1 = 0 ]]; exit 0'; then
     fatal 'Bash minimum version is 4.1'
 fi
 
+# Is the user a contributor?
+email=
+# First, ask Git for the configured e-mail address.
+if command -v git > /dev/null 2>&1; then
+    email="$(git config --get user.email || true)"
+fi
+# If that doesn't work, construct it from the environment.
+if [[ -z $email ]]; then
+    email="$USER@$(hostname --domain)"
+fi
+ch_contributor=
+for i in "${ch_contributors[@]}"; do
+    if [[ $i == "$email" ]]; then
+        ch_contributor=yes
+    fi
+done
+
+# Ensure Bats is installed.
+if command -v bats > /dev/null 2>&1; then
+    bats=$(command -v bats)
+    bats_version="$(bats --version | awk '{print $2}')"
+else
+    fatal 'Bats not found'
+fi
+
+# Reject non-default registry on GitHub Actions.
+if [[ -n $GITHUB_ACTIONS && -n $CH_REGY_DEFAULT_HOST ]]; then
+    fatal 'non-default registry on GitHub Actions invalid'
+fi
+
 # Create a directory to hold auto-generated test artifacts.
 TMP_=/tmp/ch-test.tmp.$USER
 if [[ ! -d $TMP_ ]]; then
@@ -691,36 +721,10 @@ if [[ ! -d $CHTEST_EXAMPLES_DIR ]]; then
     fatal "examples not found: $CHTEST_EXAMPLES_DIR"
 fi
 
-# Is the user a contributor?
-email=
-# First, ask Git for the configured e-mail address.
-if command -v git > /dev/null 2>&1; then
-    email="$(git config --get user.email || true)"
-fi
-# If that doesn't work, construct it from the environment.
-if [[ -z $email ]]; then
-    email="$USER@$(hostname --domain)"
-fi
-ch_contributor=
-for i in "${ch_contributors[@]}"; do
-    if [[ $i == "$email" ]]; then
-        ch_contributor=yes
-    fi
-done
-
-# Ensure Bats is installed.
-if command -v bats > /dev/null 2>&1; then
-    bats=$(command -v bats)
-    bats_version="$(bats --version | awk '{print $2}')"
-else
-    fatal 'Bats not found'
-fi
-
+# Parse arguments.
 if [[ $# == 0 ]]; then
     usage 1
 fi
-
-# Parse arguments.
 while [[ $# -gt 0 ]]; do
     opt=$1; shift
     case $opt in

--- a/examples/exhaustive/Dockerfile
+++ b/examples/exhaustive/Dockerfile
@@ -8,7 +8,7 @@
 #
 # See: https://docs.docker.com/engine/reference/builder
 #
-# ch-test-scope: standard
+# ch-test-scope: full
 # ch-test-builder-include: ch-image
 
 # Use a moderately complex image reference.

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -850,12 +850,15 @@ fields:
    def defaults_add(self):
       "Set defaults for all empty fields."
       if (self.host is None):
-         self.host = os.getenv("CH_REGY_DEFAULT_HOST", "registry-1.docker.io")
-         prefix = os.getenv("CH_REGY_PATH_PREFIX")
-         if (prefix is not None):
-            self.path = prefix.split("/") + self.path
-      if (self.port is None):
-         self.port = int(os.getenv("CH_REGY_DEFAULT_PORT", 443))
+         if ("CH_REGY_DEFAULT_HOST" not in os.environ):
+            self.host = "registry-1.docker.io"
+         else:
+            self.host = os.getenv("CH_REGY_DEFAULT_HOST")
+            self.port = int(os.getenv("CH_REGY_DEFAULT_PORT", 443))
+            prefix = os.getenv("CH_REGY_PATH_PREFIX")
+            if (prefix is not None):
+               self.path = prefix.split("/") + self.path
+      if (self.port is None): self.port = 443
       if (self.host == "registry-1.docker.io" and len(self.path) == 0):
          # FIXME: For Docker Hub only, images with no path need a path of
          # "library" substituted. Need to understand/document the rules here.

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -854,7 +854,9 @@ fields:
       if (self.port is None):
          self.port = int(os.getenv("CH_REGY_DEFAULT_PORT", 443))
       if (len(self.path) == 0):
-         self.path = os.getenv("CH_REGY_DEFAULT_PATH", "").split("/")
+         self.path = os.getenv("CH_REGY_DEFAULT_PATH", [])
+         if (isinstance(self.path, str)):
+            self.path = self.path.split("/")
          if (len(self.path) == 0 and self.host == "registry-1.docker.io"):
             # FIXME: For Docker Hub only, images with no path need a path of
             # "library" substituted. Need to understand/document rules here.

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -849,12 +849,16 @@ fields:
 
    def defaults_add(self):
       "Set defaults for all empty fields."
-      if (self.host is None): self.host = "registry-1.docker.io"
-      if (self.port is None): self.port = 443
-      if (self.host == "registry-1.docker.io" and len(self.path) == 0):
-         # FIXME: For Docker Hub only, images with no path need a path of
-         # "library" substituted. Need to understand/document the rules here.
-         self.path = ["library"]
+      if (self.host is None):
+         self.host = os.getenv("CH_REGY_DEFAULT_HOST", "registry-1.docker.io")
+      if (self.port is None):
+         self.port = int(os.getenv("CH_REGY_DEFAULT_PORT", 443))
+      if (len(self.path) == 0):
+         self.path = os.getenv("CH_REGY_DEFAULT_PATH", "").split("/")
+         if (len(self.path) == 0 and self.host == "registry-1.docker.io"):
+            # FIXME: For Docker Hub only, images with no path need a path of
+            # "library" substituted. Need to understand/document rules here.
+            self.path = ["library"]
       if (self.tag is None and self.digest is None): self.tag = "latest"
 
    def from_tree(self, t):

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -853,14 +853,13 @@ fields:
          self.host = os.getenv("CH_REGY_DEFAULT_HOST", "registry-1.docker.io")
       if (self.port is None):
          self.port = int(os.getenv("CH_REGY_DEFAULT_PORT", 443))
-      if (len(self.path) == 0):
-         self.path = os.getenv("CH_REGY_DEFAULT_PATH", [])
-         if (isinstance(self.path, str)):
-            self.path = self.path.split("/")
-         if (len(self.path) == 0 and self.host == "registry-1.docker.io"):
-            # FIXME: For Docker Hub only, images with no path need a path of
-            # "library" substituted. Need to understand/document rules here.
-            self.path = ["library"]
+      if (self.host == "registry-1.docker.io" and len(self.path) == 0):
+         # FIXME: For Docker Hub only, images with no path need a path of
+         # "library" substituted. Need to understand/document the rules here.
+         self.path = ["library"]
+      prefix = os.getenv("CH_REGY_PATH_PREFIX")
+      if (prefix is not None):
+         self.path = prefix.split("/") + self.path
       if (self.tag is None and self.digest is None): self.tag = "latest"
 
    def from_tree(self, t):

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -851,15 +851,15 @@ fields:
       "Set defaults for all empty fields."
       if (self.host is None):
          self.host = os.getenv("CH_REGY_DEFAULT_HOST", "registry-1.docker.io")
+         prefix = os.getenv("CH_REGY_PATH_PREFIX")
+         if (prefix is not None):
+            self.path = prefix.split("/") + self.path
       if (self.port is None):
          self.port = int(os.getenv("CH_REGY_DEFAULT_PORT", 443))
       if (self.host == "registry-1.docker.io" and len(self.path) == 0):
          # FIXME: For Docker Hub only, images with no path need a path of
          # "library" substituted. Need to understand/document the rules here.
          self.path = ["library"]
-      prefix = os.getenv("CH_REGY_PATH_PREFIX")
-      if (prefix is not None):
-         self.path = prefix.split("/") + self.path
       if (self.tag is None and self.digest is None): self.tag = "latest"
 
    def from_tree(self, t):

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -15,6 +15,7 @@ build/50_misc.bats \
 build/99_cleanup.bats \
 common.bash \
 fixtures/empty-file \
+fixtures/README \
 make-auto.d/build.bats.in \
 make-auto.d/build_custom.bats.in \
 make-auto.d/builder_to_archive.bats.in \
@@ -43,10 +44,6 @@ Build.docker_pull \
 Build.missing \
 docs-sane \
 make-perms-test
-
-# Stuff that doesn't need to be installed.
-EXTRA_DIST = \
-fixtures/README
 
 # Program and shared library used for testing shared library injection. It's
 # built according to the rules below. In principle, we could use libtool for
@@ -85,8 +82,8 @@ uninstall-hook:
 	rm -f $(DESTDIR)$(testdir)/fixtures/symlink-to-tmp
 	rmdir $(DESTDIR)$(testdir)/fixtures || true
 endif
-EXTRA_DIST += $(testfiles) $(testfiles_exec) \
-              docs-sane.py.in force-auto.py.in make-perms-test.py.in
+EXTRA_DIST = $(testfiles) $(testfiles_exec) \
+             docs-sane.py.in force-auto.py.in make-perms-test.py.in
 EXTRA_SCRIPTS = $(sobuilts)
 
 ## Python scripts - need text processing

--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -266,6 +266,9 @@ EOF
 }
 
 @test 'pull from public repos' {
+    if [[ -n $CH_REGY_DEFAULT_HOST ]]; then
+        skip 'default registry host set'  # avoid Docker Hub
+    fi
     if [[ -z $CI ]]; then
         # Verify we can reach the public internet, except on CI, where we
         # insist this should work.
@@ -413,6 +416,10 @@ EOF
 }
 
 @test 'pull images that do not exist' {
+    if [[ -n $CH_REGY_DEFAULT_HOST ]]; then
+        skip 'default registry host set'  # avoid Docker Hub
+    fi
+
     # name does not exist remotely, in library
     run ch-image pull doesnotexist:latest
     echo "$output"

--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -248,6 +248,9 @@ EOF
 
 @test 'pull image with manifest schema v1' {
     # Verify we handle images with manifest schema version one (v1).
+    if [[ -n $CH_REGY_DEFAULT_HOST ]]; then
+       skip 'default registry host set'  # only v1 on Docker Hub
+    fi
 
     unpack="${BATS_TMPDIR}/tmp"
     cache=$unpack/dlcache
@@ -415,9 +418,10 @@ EOF
     fi
 }
 
+
 @test 'pull images that do not exist' {
     if [[ -n $CH_REGY_DEFAULT_HOST ]]; then
-        skip 'default registry host set'  # avoid Docker Hub
+        skip 'default registry host set'  # errors are Docker Hub specific
     fi
 
     # name does not exist remotely, in library

--- a/test/build/50_ch-image.bats
+++ b/test/build/50_ch-image.bats
@@ -271,8 +271,6 @@ EOF
     run ch-image list scratch
     echo "$output"
     [[ $status -eq 0 ]]
-    #[[ $output = *'in local storage:    yes'* ]]  # varies
-    [[ $output = *'full remote ref:     registry-1.docker.io:443/library/scratch:latest'* ]]
     [[ $output = *'available remotely:  yes'* ]]
     [[ $output = *'remote arch-aware:   no'* ]]
     [[ $output = *'archs available:     unknown'* ]]

--- a/test/build/50_localregistry.bats
+++ b/test/build/50_localregistry.bats
@@ -11,9 +11,9 @@ tag='ch-image push'
 setup () {
     scope standard
     [[ $CH_BUILDER = ch-image ]] || skip 'ch-image only'
-    # Skip unless CI or there is a listener on localhost:5000.
-    if [[ -z $CI ]] && ! (   command -v ss > /dev/null 2>&1 \
-                          && ss -lnt | grep -F :5000); then
+    # Skip unless GitHub Actions or there is a listener on localhost:5000.
+    if [[ -z $GITHUB_ACTIONS ]] && ! (   command -v ss > /dev/null 2>&1 \
+                                      && ss -lnt | grep -F :5000); then
         skip 'no local registry'
     fi
 

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -621,7 +621,7 @@ EOF
     [[ $status -eq 0 ]]
     ex='^(_|CH_RUNNING|HOME|PATH|SHLVL|TMPDIR)='  # expected to change
     diff -u <(env | grep -Ev "$ex" | sort) \
-	    <(echo "$output" | grep -Ev "$ex" | sort)
+            <(echo "$output" | grep -Ev "$ex" | sort)
 
     printf '\n# Everything\n\n'
     run ch-run --unset-env='*' "$ch_timg" -- env


### PR DESCRIPTION
This PR adds three environment variables to support default registries other than Docker Hub. Currently they are undocumented because I need them now for testing, but I'm not sure if this is the right way to do it.