### PR TITLE
re-enable Spack tests on Cray

### DIFF
--- a/examples/spack/test.bats
+++ b/examples/spack/test.bats
@@ -6,7 +6,6 @@ load "${CHTEST_DIR}/common.bash"
 
 setup() {
     scope full
-    [[ -z $ch_cray ]] || skip 'issue #193 and Spack issue #8618'
     prerequisites_ok spack
     export PATH=/spack/bin:$PATH
 }


### PR DESCRIPTION
This PR addresses #193. Spack test works on cray again. There are some other issues with #1221, but it doesn't affect cray machines individually. 