### PR TITLE
autotools: add missing fedora package files to `make dist`

### DIFF
--- a/packaging/Makefile.am
+++ b/packaging/Makefile.am
@@ -2,4 +2,6 @@ EXTRA_DIST = \
 README \
 fedora/build \
 fedora/charliecloud.rpmlintrc \
-fedora/charliecloud.spec
+fedora/charliecloud.spec \
+fedora/el7-pkgdir.patch \
+fedora/upstream.spec


### PR DESCRIPTION
Closes #943. 