### PR TITLE
move storage directory to new path

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -117,7 +117,7 @@ builder_set () {
     fi
     printf "%-*s %s (%s)\n" "$width" 'builder:' "$CH_BUILDER" "$method"
     if [[ $CH_BUILDER == ch-image ]]; then
-        vset CH_IMAGE_STORAGE '' "$CH_IMAGE_STORAGE" "/var/tmp/$USER/ch-image" \
+        vset CH_IMAGE_STORAGE '' "$CH_IMAGE_STORAGE" "/var/tmp/${USER}.ch" \
                               "$width" 'ch-image storage'
     fi
 }

--- a/doc/ch-image_desc.rst
+++ b/doc/ch-image_desc.rst
@@ -139,8 +139,10 @@ In descending order of priority, this directory is located at:
   :code:`$CH_IMAGE_STORAGE`
     Environment variable.
 
-  :code:`/var/tmp/$USER/ch-image`
-    Default.
+  :code:`/var/tmp/$USER.ch`
+    Default. (Previously, the default was :code:`/var/tmp/$USER/ch-image`. If
+    a valid storage directory is found at the old default path,
+    :code:`ch-image` tries to move it to the new default path.)
 
 Unlike many container implementations, there is no notion of storage drivers,
 graph drivers, etc., to select and/or configure.

--- a/lib/build.py
+++ b/lib/build.py
@@ -58,7 +58,7 @@ ARG_DEFAULTS = { "HTTP_PROXY": os.environ.get("HTTP_PROXY"),
                  # GNU tar, when it thinks it's running as root, tries to
                  # chown(2) and chgrp(2) files to whatever's in the tarball.
                  "TAR_OPTIONS": "--no-same-owner",
-                 "USER": os.environ.get("USER") }
+                 "USER": ch.user() }
 
 
 ## Main ##

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -1564,7 +1564,7 @@ class Storage:
       ossafe(os.rmdir, "can't rmdir: %s" % old.root, old.root)
       if (len(ossafe(os.listdir, "can't list: %s" % old.root.parent,
                      old.root.parent)) == 0):
-         WARNING("storage dir: parent of old now empty: %s" % old.root.parent,
+         WARNING("parent of old storage dir now empty: %s" % old.root.parent,
                  hint="consider deleting it")
 
    def manifest_for_download(self, image_ref, digest):

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -1498,7 +1498,7 @@ class Storage:
    def init(self):
       """Ensure the storage directory exists, contains all the appropriate
          top-level directories & metadata, and is the appropriate version."""
-      self.init_move_old()  # see issues #1160 and #FIXME
+      self.init_move_old()  # see issues #1160 and #1243
       if (not os.path.isdir(self.root)):
          op = "initializing"
          v_found = None
@@ -1525,9 +1525,7 @@ class Storage:
 
    def init_move_old(self):
       """If appropriate, move storage directory from old default path to new.
-         See issues #1160 and #FIXME."""
-      # Move storage directory from old default path to new, if appropriate.
-      # See issues #1160 and #FIXME.
+         See issues #1160 and #1243."""
       old = Storage("/var/tmp/%s/ch-image" % user())
       moves = ( "dlcache", "img", "ulcache", "version" )
       if (self.root != self.root_default()):

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -1539,7 +1539,7 @@ class Storage:
       if (not os.path.exists(self.root)):
          mkdir(self.root)
       elif (self.valid_p):
-         WARNING("storage dir: also valid at new default: %s" % old.root,
+         WARNING("storage dir: also valid at new default: %s" % self.root,
                  hint="consider deleting the old one")
          return
       elif (not os.path.isdir(self.root)):

--- a/lib/misc.py
+++ b/lib/misc.py
@@ -65,7 +65,7 @@ def list_(cli):
       # list all images
       if (not os.path.isdir(ch.storage.root)):
          ch.FATAL("does not exist: %s" % ch.storage.root)
-      if (not ch.storage.valid_p()):
+      if (not ch.storage.valid_p):
          ch.FATAL("not a storage directory: %s" % ch.storage.root)
       imgs = ch.ossafe(os.listdir, "can't list directory: %s" % ch.storage.root, imgdir)
       for img in sorted(imgs):

--- a/test/build/50_ch-image.bats
+++ b/test/build/50_ch-image.bats
@@ -489,14 +489,14 @@ EOF
          pedantic_fail 'old default storage dir exists'
     fi
 
-    # move real storage dir out of the way
+    printf '\n*** move real storage dir out of the way\n'
     echo 'WARNING: If this test fails, your storage directory may be broken'
     if [[ -e $new ]]; then
         [[ ! -e $new_bak ]]
         mv -v "$new" "$new_bak"
     fi
 
-    # old valid and needs upgrade
+    printf '\n*** old valid and needs upgrade\n'
     [[ -d "$old_parent" ]] || mkdir "$old_parent"
     mkdir "$old"
     mkdir "$old"/{dlcache,img,ulcache}
@@ -510,7 +510,7 @@ EOF
     [[ $output = *"moving: ${old}/img -> ${new}/img"* ]]
     [[ $output = *"moving: ${old}/ulcache -> ${new}/ulcache"* ]]
     [[ $output = *"moving: ${old}/version -> ${new}/version"* ]]
-    [[ $output = *"warning: storage dir: parent of old now empty: ${old_parent}"* ]]
+    [[ $output = *"warning: parent of old storage dir now empty: ${old_parent}"* ]]
     [[ $output = *'hint: consider deleting it'* ]]
     [[ $output = *"upgrading storage directory: v2 ${new}"* ]]
     [[ ! -e $old ]]
@@ -519,13 +519,17 @@ EOF
     [[ -d ${new}/ulcache ]]
     [[ -f ${new}/version ]]
 
-    # old and new both valid
+    printf '\n*** old and new both valid\n'
     mkdir "$old"
     mkdir "$old"/{dlcache,img,ulcache}
     echo 2 > "$old"/version
     run ch-image -vv list
     echo "$output"
     [[ $status -eq 0 ]]
+    [[ $output = *"storage dir: valid at old default: ${old}"* ]]
+    [[ $output = *"warning: storage dir: also valid at new default: ${new}"* ]]
+    [[ $output = *'hint: consider deleting the old one'* ]]
+    [[ $output = *"found storage dir v2: ${new}"* ]]
     [[ -d $old ]]
     [[ -d ${new}/dlcache ]]
     [[ -d ${new}/img ]]
@@ -533,7 +537,7 @@ EOF
     [[ -f ${new}/version ]]
     rm -Rfv --one-file-system "$new"
 
-    # old is invalid, new absent
+    printf '\n*** old is invalid, new absent\n'
     rmdir "$old"/img
     run ch-image -vv list
     echo "$output"
@@ -547,7 +551,7 @@ EOF
     [[ -f ${new}/version ]]
     rm -Rfv --one-file-system "$new"
 
-    # old is valid, new exists but is regular file
+    printf '\n*** old is valid, new exists but is regular file\n'
     mkdir "$old"/img
     echo weirdal > "$new"
     run ch-image -vv list
@@ -560,7 +564,7 @@ EOF
     [[ -f $new ]]
     rm -v "$new"
 
-    # old is valid, new exists and is empty directory
+    printf '\n*** old is valid, new exists and is empty directory\n'
     run ch-image -vv list
     echo "$output"
     [[ $status -eq 0 ]]
@@ -570,7 +574,7 @@ EOF
     [[ $output = *"moving: ${old}/img -> ${new}/img"* ]]
     [[ $output = *"moving: ${old}/ulcache -> ${new}/ulcache"* ]]
     [[ $output = *"moving: ${old}/version -> ${new}/version"* ]]
-    [[ $output = *"warning: storage dir: parent of old now empty: ${old_parent}"* ]]
+    [[ $output = *"warning: parent of old storage dir now empty: ${old_parent}"* ]]
     [[ $output = *'hint: consider deleting it'* ]]
     [[ $output = *"found storage dir v2: ${new}"* ]]
     [[ ! -e $old ]]
@@ -579,7 +583,7 @@ EOF
     [[ -d ${new}/ulcache ]]
     [[ -f ${new}/version ]]
 
-    # old is valid, new exists and is invalid but has one of the moved items
+    printf '\n*** old is valid, new exists, is invalid with one moved item\n'
     mkdir "$old"
     mkdir "$old"/{dlcache,img,ulcache}
     echo 2 > "$old"/version
@@ -597,7 +601,7 @@ EOF
     rm -Rfv --one-file-system "$old"
     rm -Rfv --one-file-system "$new"
 
-    # put real storage dir back
+    printf '\n*** put real storage dir back\n'
     if [[ -e $new_bak ]]; then
         rm -Rfv --one-file-system "$new"
         mv -v "$new_bak" "$new"

--- a/test/build/50_ch-image.bats
+++ b/test/build/50_ch-image.bats
@@ -497,6 +497,7 @@ EOF
     fi
 
     # old valid and needs upgrade
+    [[ -d "$old_parent" ]] || mkdir "$old_parent"
     mkdir "$old"
     mkdir "$old"/{dlcache,img,ulcache}
     echo 1 > "$old"/version

--- a/test/build/50_ch-image.bats
+++ b/test/build/50_ch-image.bats
@@ -594,6 +594,7 @@ EOF
     [[ -d ${new}/img ]]
     [[ ! -e ${new}/ulcache ]]
     [[ ! -e ${new}/version ]]
+    rm -Rfv --one-file-system "$old"
     rm -Rfv --one-file-system "$new"
 
     # put real storage dir back
@@ -601,5 +602,4 @@ EOF
         rm -Rfv --one-file-system "$new"
         mv -v "$new_bak" "$new"
     fi
-    false
 }

--- a/test/build/50_ch-image.bats
+++ b/test/build/50_ch-image.bats
@@ -476,3 +476,129 @@ EOF
    [[ $output = *"upgrading storage directory: v${v_current} ${CH_IMAGE_STORAGE}"* ]]
    [[ $(cat "$CH_IMAGE_STORAGE"/version) -eq "$v_current" ]]
 }
+
+
+@test 'storage directory default path move' {
+    unset CH_IMAGE_STORAGE
+
+    old=/var/tmp/${USER}/ch-image
+    old_parent=$(dirname "$old")
+    new=/var/tmp/${USER}.ch
+    new_bak=/var/tmp/${USER}.ch.test-save
+    if [[ -e $old ]]; then
+         pedantic_fail 'old default storage dir exists'
+    fi
+
+    # move real storage dir out of the way
+    echo 'WARNING: If this test fails, your storage directory may be broken'
+    if [[ -e $new ]]; then
+        [[ ! -e $new_bak ]]
+        mv -v "$new" "$new_bak"
+    fi
+
+    # old valid and needs upgrade
+    mkdir "$old"
+    mkdir "$old"/{dlcache,img,ulcache}
+    echo 1 > "$old"/version
+    run ch-image -vv list
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *"storage dir: valid at old default: ${old}"* ]]
+    [[ $output = *"storage dir: moving to new default path: ${new}"* ]]
+    [[ $output = *"moving: ${old}/dlcache -> ${new}/dlcache"* ]]
+    [[ $output = *"moving: ${old}/img -> ${new}/img"* ]]
+    [[ $output = *"moving: ${old}/ulcache -> ${new}/ulcache"* ]]
+    [[ $output = *"moving: ${old}/version -> ${new}/version"* ]]
+    [[ $output = *"warning: storage dir: parent of old now empty: ${old_parent}"* ]]
+    [[ $output = *'hint: consider deleting it'* ]]
+    [[ $output = *"upgrading storage directory: v2 ${new}"* ]]
+    [[ ! -e $old ]]
+    [[ -d ${new}/dlcache ]]
+    [[ -d ${new}/img ]]
+    [[ -d ${new}/ulcache ]]
+    [[ -f ${new}/version ]]
+
+    # old and new both valid
+    mkdir "$old"
+    mkdir "$old"/{dlcache,img,ulcache}
+    echo 2 > "$old"/version
+    run ch-image -vv list
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ -d $old ]]
+    [[ -d ${new}/dlcache ]]
+    [[ -d ${new}/img ]]
+    [[ -d ${new}/ulcache ]]
+    [[ -f ${new}/version ]]
+    rm -Rfv --one-file-system "$new"
+
+    # old is invalid, new absent
+    rmdir "$old"/img
+    run ch-image -vv list
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *"warning: storage dir: invalid at old default, ignoring: ${old}"* ]]
+    [[ $output = *"initializing storage directory: v2 ${new}"* ]]
+    [[ -d $old ]]
+    [[ -d ${new}/dlcache ]]
+    [[ -d ${new}/img ]]
+    [[ -d ${new}/ulcache ]]
+    [[ -f ${new}/version ]]
+    rm -Rfv --one-file-system "$new"
+
+    # old is valid, new exists but is regular file
+    mkdir "$old"/img
+    echo weirdal > "$new"
+    run ch-image -vv list
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *"storage dir: valid at old default: ${old}"* ]]
+    [[ $output = *"initializing storage directory: v2 ${new}"* ]]
+    [[ $output = *"error: can't mkdir: exists and not a directory: ${new}"* ]]
+    [[ -d $old ]]
+    [[ -f $new ]]
+    rm -v "$new"
+
+    # old is valid, new exists and is empty directory
+    run ch-image -vv list
+    echo "$output"
+    [[ $status -eq 0 ]]
+    [[ $output = *"storage dir: valid at old default: ${old}"* ]]
+    [[ $output = *"storage dir: moving to new default path: ${new}"* ]]
+    [[ $output = *"moving: ${old}/dlcache -> ${new}/dlcache"* ]]
+    [[ $output = *"moving: ${old}/img -> ${new}/img"* ]]
+    [[ $output = *"moving: ${old}/ulcache -> ${new}/ulcache"* ]]
+    [[ $output = *"moving: ${old}/version -> ${new}/version"* ]]
+    [[ $output = *"warning: storage dir: parent of old now empty: ${old_parent}"* ]]
+    [[ $output = *'hint: consider deleting it'* ]]
+    [[ $output = *"found storage dir v2: ${new}"* ]]
+    [[ ! -e $old ]]
+    [[ -d ${new}/dlcache ]]
+    [[ -d ${new}/img ]]
+    [[ -d ${new}/ulcache ]]
+    [[ -f ${new}/version ]]
+
+    # old is valid, new exists and is invalid but has one of the moved items
+    mkdir "$old"
+    mkdir "$old"/{dlcache,img,ulcache}
+    echo 2 > "$old"/version
+    rm -Rfv --one-file-system "$new"/{dlcache,ulcache,version}
+    run ch-image -vv list
+    echo "$output"
+    [[ $status -eq 1 ]]
+    [[ $output = *"storage dir: valid at old default: ${old}"* ]]
+    [[ $output = *"error: storage directory seems invalid: ${new}"* ]]
+    [[ -d $old ]]
+    [[ ! -e ${new}/dlcache ]]
+    [[ -d ${new}/img ]]
+    [[ ! -e ${new}/ulcache ]]
+    [[ ! -e ${new}/version ]]
+    rm -Rfv --one-file-system "$new"
+
+    # put real storage dir back
+    if [[ -e $new_bak ]]; then
+        rm -Rfv --one-file-system "$new"
+        mv -v "$new_bak" "$new"
+    fi
+    false
+}


### PR DESCRIPTION
This PR updates the default `ch-image` storage directory to `/var/tmp/$USER.ch` (e.g., `/var/tmp/reidpr.ch`). If the storage directory path in use is the default, and a valid storage directory exists at the old default path, move it to the new default path.