### PR TITLE
packaging: update spec files for 0.26 release

### DIFF
--- a/packaging/fedora/charliecloud.spec
+++ b/packaging/fedora/charliecloud.spec
@@ -19,9 +19,6 @@ Source0:       https://github.com/hpc/%{name}/releases/downloads/v%{version}/%{n
 BuildRequires: gcc rsync bash
 Requires:      squashfuse squashfs-tools
 Patch1:        el7-pkgdir.patch
-# Suggests:    name-builder docker buildah
-Obsoletes:     %{name}-runtime
-Obsoletes:     %{name}-common
 
 %description
 Charliecloud uses Linux user namespaces to run containers with no privileged
@@ -39,11 +36,12 @@ Summary:       Charliecloud container image building tools
 License:       ASL 2.0 and MIT
 BuildArch:     noarch
 BuildRequires: python3-devel
+BuildRequires: python%{python3_pkgversion}-lark-parser
 BuildRequires: python%{python3_pkgversion}-requests
 Requires:      %{name}
 Requires:      python3
+Requires:      python%{python3_pkgversion}-lark-parser
 Requires:      python%{python3_pkgversion}-requests
-Obsoletes:     %{name}-builders
 Provides:      bundled(python%{python3_pkgversion}-lark-parser) = 0.11.3
 
 %description builder

--- a/packaging/fedora/printf.patch
+++ b/packaging/fedora/printf.patch
@@ -1,0 +1,12 @@
+diff -ur charliecloud/bin/ch_misc.c charliecloud-patch/bin/ch_misc.c
+--- charliecloud/bin/ch_misc.c	2022-01-24 13:12:23.980046774 -0500
++++ charliecloud-patch/bin/ch_misc.c	2022-01-24 13:25:34.854133321 -0500
+@@ -252,7 +252,7 @@
+    if (path == NULL) {
+       T_ (where = strdup(line));
+    } else {
+-      T_ (1 <= asprintf(&where, "%s:%lu", path, lineno));
++      T_ (1 <= asprintf(&where, "%s:%zu", path, lineno));
+    }
+ 
+    // Split line into variable name and value.

--- a/packaging/fedora/upstream.spec
+++ b/packaging/fedora/upstream.spec
@@ -19,6 +19,7 @@ Source0:       https://github.com/hpc/%{name}/releases/downloads/v%{version}/%{n
 BuildRequires: gcc rsync bash
 Requires:      squashfuse squashfs-tools
 Patch1:        el7-pkgdir.patch
+Patch2:        printf.patch
 
 %description
 Charliecloud uses Linux user namespaces to run containers with no privileged
@@ -75,6 +76,8 @@ Test fixtures for %{name}.
 %if 0%{?el7}
 %patch1 -p1
 %endif
+
+%patch2 -p1
 
 %build
 # Use old inlining behavior, see:
@@ -180,17 +183,20 @@ ln -s "${sphinxdir}/js"    %{buildroot}%{_pkgdocdir}/html/_static/js
 %{_pkgdocdir}/html
 %{?el7:%exclude %{_pkgdocdir}/examples/*/__pycache__}
 
-
 %files test
 %{_bindir}/ch-test
 %{_libexecdir}/%{name}/test
 %{_mandir}/man1/ch-test.1*
 
-
 %changelog
 * Mon Jan 24 2022 Jordan Ogas <jogas@lanl.gov 0.26-1
+- add printf patch for 32-bit
 - add ch-convert script
 - new version 0.26
+
+* Wed Jan 19 2022 Fedora Release Engineering <releng@fedoraproject.org> - 0.25-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_36_Mass_Rebuild
+
 * Mon Sep 20 2021 Jordan Ogas <jogas@lanl.gov 0.25-1
 - bundle python lark parser
 - new version

--- a/packaging/fedora/upstream.spec
+++ b/packaging/fedora/upstream.spec
@@ -10,7 +10,7 @@
 %{?el7:%global __python %__python3}
 
 Name:          charliecloud
-Version:       0.25
+Version:       0.26
 Release:       1%{?dist}
 Summary:       Lightweight user-defined software stacks for high-performance computing
 License:       ASL 2.0
@@ -130,31 +130,29 @@ ln -s "${sphinxdir}/js"    %{buildroot}%{_pkgdocdir}/html/_static/js
 %{_bindir}/ch-builder2squash
 %{_bindir}/ch-builder2tar
 %{_bindir}/ch-checkns
+%{_bindir}/ch-convert
 %{_bindir}/ch-dir2squash
 %{_bindir}/ch-fromhost
-%{_bindir}/ch-mount
 %{_bindir}/ch-pull2dir
 %{_bindir}/ch-pull2tar
 %{_bindir}/ch-run
 %{_bindir}/ch-run-oci
 %{_bindir}/ch-ssh
-%{_bindir}/ch-umount
 %{_bindir}/ch-tar2dir
 %{_mandir}/man1/ch-build.1*
 %{_mandir}/man1/ch-build2dir.1*
 %{_mandir}/man1/ch-builder2squash.1*
 %{_mandir}/man1/ch-builder2tar.1*
 %{_mandir}/man1/ch-checkns.1*
+%{_mandir}/man1/ch-convert.1*
 %{_mandir}/man1/ch-dir2squash.1*
 %{_mandir}/man1/ch-fromhost.1*
-%{_mandir}/man1/ch-mount.1*
 %{_mandir}/man1/ch-pull2dir.1*
 %{_mandir}/man1/ch-pull2tar.1*
 %{_mandir}/man1/ch-run.1*
 %{_mandir}/man1/ch-run-oci.1*
 %{_mandir}/man1/ch-ssh.1*
 %{_mandir}/man1/ch-tar2dir.1*
-%{_mandir}/man1/ch-umount.1*
 %{_mandir}/man7/charliecloud.7*
 %{_prefix}/lib/%{name}/base.sh
 %{_prefix}/lib/%{name}/contributors.bash
@@ -190,6 +188,9 @@ ln -s "${sphinxdir}/js"    %{buildroot}%{_pkgdocdir}/html/_static/js
 
 
 %changelog
+* Mon Jan 24 2021 Jordan Ogas <jogas@lanl.gov 0.26-1
+- add ch-convert script
+- new version 0.26
 * Mon Sep 20 2021 Jordan Ogas <jogas@lanl.gov 0.25-1
 - bundle python lark parser
 - new version

--- a/packaging/fedora/upstream.spec
+++ b/packaging/fedora/upstream.spec
@@ -188,7 +188,7 @@ ln -s "${sphinxdir}/js"    %{buildroot}%{_pkgdocdir}/html/_static/js
 
 
 %changelog
-* Mon Jan 24 2021 Jordan Ogas <jogas@lanl.gov 0.26-1
+* Mon Jan 24 2022 Jordan Ogas <jogas@lanl.gov 0.26-1
 - add ch-convert script
 - new version 0.26
 * Mon Sep 20 2021 Jordan Ogas <jogas@lanl.gov 0.25-1


### PR DESCRIPTION
This PR updates the `upstream.spec` with our fedora build targeting 0.26. Note the `printf.patch` was required to address warnings treated as errors (#1274). When the issue is fixed we will want to remove the patch for the 0.27 update, thus I don't update the `charliecloud.spec` for CI testing because: 1) the change is trivial, and 2) it will just be reverted anyway. Instead I've included the patch in the packaging directory as a record/reference.