### PR TITLE
remove some test overhead bottlenecks

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -37,6 +37,13 @@ fi
 export ch_bin
 export ch_lib
 
+if docker info > /dev/null 2>&1; then
+    ch_docker_nosudo=yes
+else
+    ch_docker_nosudo=
+fi
+export ch_docker_nosudo
+
 # shellcheck disable=SC2034
 usage=$(cat <<EOF
 Run some or all of the Charliecloud test suite.

--- a/test/common.bash
+++ b/test/common.bash
@@ -108,17 +108,6 @@ crayify_mpi_or_skip () {
     fi
 }
 
-# Do we need sudo to run docker?
-if docker info > /dev/null 2>&1; then
-    docker_ () {
-        docker "$@"
-    }
-else
-    docker_ () {
-        sudo docker "$@"
-    }
-fi
-
 env_require () {
     if [[ -z ${!1} ]]; then
         printf '$%s is empty or not set\n\n' "$1" >&2
@@ -255,6 +244,17 @@ unpack_img_all_nodes () {
     fi
 }
 
+# Do we need sudo to run docker?
+if [[ -n $ch_docker_nosudo ]]; then
+    docker_ () {
+        docker "$@"
+    }
+else
+    docker_ () {
+        sudo docker "$@"
+    }
+fi
+
 # Do we have what we need?
 env_require CH_TEST_TARDIR
 env_require CH_TEST_IMGDIR
@@ -275,8 +275,6 @@ export BATS_TMPDIR=$btnew
 
 # shellcheck disable=SC2034
 ch_runfile=$(command -v ch-run)
-# shellcheck disable=SC2034
-ch_lib=$(ch-convert --_lib-path)
 
 # Charliecloud version.
 ch_version=$(ch-run --version 2>&1)


### PR DESCRIPTION
Closes #186.

```
$ time ch-test -b docker -s quick all
real	0m55.863s
user	0m42.032s
sys	0m15.867s
$ time ch-test -f build/55_cache.bats:doesnotexist
real	0m2.135s
user	0m1.563s
sys	0m0.770s
```