### PR TITLE
fakeroot: switch deb/ubuntu from pseudo to fakeroot

### DIFF
--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -111,7 +111,11 @@ ARG_DEFAULTS_MAGIC = { k:v for (k,v) in ((m, os.environ.get(m))
 
 # ARGs with pre-defined default values that *are* saved with the image.
 ARG_DEFAULTS = \
-   { "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+   { # calls to chown/fchown withn a user namespace will fail with EINVAL for
+     # UID/GIDs besides the current one. This env var tells fakeroot to not
+     # try. Credit to Dave Dykstra for pointing us to this.
+     "FAKEROOTDONTTRYCHOWN": "1",
+     "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
      # GNU tar, when it thinks it’s running as root, tries to chown(2) and
      # chgrp(2) files to whatever is in the tarball.
      "TAR_OPTIONS": "--no-same-owner" }

--- a/lib/fakeroot.py
+++ b/lib/fakeroot.py
@@ -241,7 +241,7 @@ DEFAULT_CONFIGS = {
                 " > /etc/apt/apt.conf.d/no-sandbox"),
                 ("command -v fakeroot > /dev/null",
                  # update b/c base image ships with no package indexes
-                 "apt-get update && apt-get install -y pseudo") ],
+                 "apt-get update && apt-get install -y fakeroot") ],
      "cmds": ["apt", "apt-get", "dpkg"],
      "each": ["fakeroot"] },
 

--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -367,6 +367,7 @@ EOF
 {
   "arch": "amd64",
   "arg": {
+    "FAKEROOTDONTTRYCHOWN": "1",
     "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     "TAR_OPTIONS": "--no-same-owner"
   },

--- a/test/build/50_ch-image.bats
+++ b/test/build/50_ch-image.bats
@@ -441,6 +441,7 @@ EOF
 {
   "arch": "amd64",
   "arg": {
+    "FAKEROOTDONTTRYCHOWN": "1",
     "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     "TAR_OPTIONS": "--no-same-owner"
   },

--- a/test/force-auto.py.in
+++ b/test/force-auto.py.in
@@ -278,13 +278,12 @@ class T_Debian_Latest(Debian):
    base = "debian:latest"
 class T_Ubuntu_16(Debian):
    base = "ubuntu:16.04"
-   arch_excludes = ["aarch64"]  # no pseudo package
 class T_Ubuntu_18(Debian):
    base = "ubuntu:18.04"
 class T_Ubuntu_21(Debian):
    base = "ubuntu:21.10"
-#class T_Ubuntu_Latest(Debian):  # no worky; see issue #1348
-#   base = "ubuntu:latest"
+class T_Ubuntu_Latest(Debian):
+   base = "ubuntu:latest"
 
 class SUSE(Test):
    config = "suse"


### PR DESCRIPTION
Resolves #1348 

This PR switches debian/ubuntu from using the psuedo package to fakeroot to resolve errors seen with Ubuntu 22.04. The PR also sets the env variable `FAKEROOTDONTTRYCHOWN` to `1` to tell fakeroot to not attempt to chown/fchown as this can fail with a `EINVAL` within a user namespace. Credit to Dave Dykstra for pointing us in the right direction on this.

See this PR for further details: https://salsa.debian.org/clint/fakeroot/-/merge_requests/4