### PR TITLE
enable Arch and Alpine fakeroot support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 90
     strategy:
-      fail-fast: true  # if any job fails, cancel the rest immediately
+      fail-fast: false  # Actions seems kind of flaky lately
       matrix:
         builder: [none, docker, ch-image]
         pack_fmt: [squash-mount, tar-unpack, squash-unpack]

--- a/configure.ac
+++ b/configure.ac
@@ -322,7 +322,8 @@ AC_MSG_RESULT($have_userns)
 AC_CHECK_DECL(FNM_EXTMATCH,
               [have_fnm_extmatch=yes],
               [have_fnm_extmatch=no],
-              [[#include <fnmatch.h>]])
+              [[#define _GNU_SOURCE
+#include <fnmatch.h>]])
 
 
 ### SquashFS #################################################################

--- a/configure.ac
+++ b/configure.ac
@@ -323,7 +323,7 @@ AC_CHECK_DECL(FNM_EXTMATCH,
               [have_fnm_extmatch=yes],
               [have_fnm_extmatch=no],
               [[#define _GNU_SOURCE
-#include <fnmatch.h>]])
+                #include <fnmatch.h>]])
 
 
 ### SquashFS #################################################################

--- a/examples/Dockerfile.nvidia
+++ b/examples/Dockerfile.nvidia
@@ -26,8 +26,8 @@ RUN apt-get update \
 WORKDIR /usr/local/src
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin \
  && mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 \
- && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub \
- && apt-key add 7fa2af80.pub \
+ && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub \
+ && apt-key add 3bf863cc.pub \
  && echo "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" >> /etc/apt/sources.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends cuda-toolkit-11-2 \

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -111,7 +111,11 @@ ARG_DEFAULTS_MAGIC = { k:v for (k,v) in ((m, os.environ.get(m))
 
 # ARGs with pre-defined default values that *are* saved with the image.
 ARG_DEFAULTS = \
-   { "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+   { # calls to chown/fchown withn a user namespace will fail with EINVAL for
+     # UID/GIDs besides the current one. This env var tells fakeroot to not
+     # try. Credit to Dave Dykstra for pointing us to this.
+     "FAKEROOTDONTTRYCHOWN": "1",
+     "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
      # GNU tar, when it thinks it’s running as root, tries to chown(2) and
      # chgrp(2) files to whatever is in the tarball.
      "TAR_OPTIONS": "--no-same-owner" }

--- a/lib/fakeroot.py
+++ b/lib/fakeroot.py
@@ -241,7 +241,7 @@ DEFAULT_CONFIGS = {
                 " > /etc/apt/apt.conf.d/no-sandbox"),
                 ("command -v fakeroot > /dev/null",
                  # update b/c base image ships with no package indexes
-                 "apt-get update && apt-get install -y pseudo") ],
+                 "apt-get update && apt-get install -y fakeroot") ],
      "cmds": ["apt", "apt-get", "dpkg"],
      "each": ["fakeroot"] },
 

--- a/lib/fakeroot.py
+++ b/lib/fakeroot.py
@@ -271,22 +271,21 @@ DEFAULT_CONFIGS = {
    # util-linux dependency.  We could add -u to update all installed
    # packages, but that may not be what a user wants.
    #
-   #"arch":
-   #{ "name": "Arch Linux",
-   # "match": ("/etc/os-release", r"ID=arch"),  # /etc/arch-release empty
-   # "init": [ ("command -v fakeroot > /dev/null",
-   #            "pacman -Syq --noconfirm glibc util-linux fakeroot") ],
-   # "cmds": ["pacman"],
-   # "each": ["fakeroot"] },
+   "arch":
+   { "name": "Arch Linux",
+   "match": ("/etc/os-release", r"ID=arch"),  # /etc/arch-release empty
+   "init": [ ("command -v fakeroot > /dev/null",
+              "pacman -Syq --noconfirm glibc util-linux fakeroot") ],
+   "cmds": ["pacman"],
+   "each": ["fakeroot"] },
 
-   # no worky; see #1296
-   #"alpine":
-   #{ "name": "Alpine, any version",
-   #  "match": ("/etc/alpine-release", r"[0-9]\.[0-9]+\.[0-9]+"),
-   #  "init": [ ("command -v fakeroot > /dev/null",
-   #             "apk update; apk add fakeroot") ],
-   #  "cmds": ["apk"],
-   #  "each": ["fakeroot"] },
+   "alpine":
+   { "name": "Alpine, any version",
+    "match": ("/etc/alpine-release", r"[0-9]\.[0-9]+\.[0-9]+"),
+    "init": [ ("command -v fakeroot > /dev/null",
+               "apk update; apk add fakeroot") ],
+    "cmds": ["apk"],
+    "each": ["fakeroot"] },
 }
 
 

--- a/lib/fakeroot.py
+++ b/lib/fakeroot.py
@@ -256,26 +256,17 @@ DEFAULT_CONFIGS = {
      "cmds": ["zypper", "rpm"],
      "each": ["fakeroot"] },
 
-   # no worky; see #1295
-   #
-   # [It seems to me (Dave Love) that it works sufficiently well, just
-   # failing to set filesystem ownership/permissions that presumably
-   # aren't necessary for what Charliecloud addresses.  Perhaps the spec
-   # could be extended to allow showing a message about such things.
-   # However, at least mostly, --force seems not to be necessary.]
-   #
-   # pacman doesn't seem to have proper dependencies like dpkg and
-   # rpm.  It happens that fakeroot can fail because the downloaded
-   # version is linked against a newer glibc (at least) than is in the
-   # base image. Thus update that too, and for safety also the
-   # util-linux dependency.  We could add -u to update all installed
-   # packages, but that may not be what a user wants.
-   #
+   # pacman doesn’t seem to have proper dependencies like dpkg and rpm. It
+   # happens that fakeroot can fail because the downloaded version is linked
+   # against a newer glibc (at least) than is in the base image. We could also
+   # update glibc (and its dependency util-linux), but that causes the tests
+   # to fail with fchownat() errors. Another possiblity is to add “-u” to
+   # update all installed packages, but that may not be what a user wants.
    "arch":
    { "name": "Arch Linux",
    "match": ("/etc/os-release", r"ID=arch"),  # /etc/arch-release empty
    "init": [ ("command -v fakeroot > /dev/null",
-              "pacman -Syq --noconfirm glibc util-linux fakeroot") ],
+              "pacman -Syq --noconfirm fakeroot") ],
    "cmds": ["pacman"],
    "each": ["fakeroot"] },
 

--- a/test/build/50_dockerfile.bats
+++ b/test/build/50_dockerfile.bats
@@ -124,6 +124,7 @@ EOF
 warning: not yet supported, ignored: issue #777: .dockerignore file
   1. FROM 00_tiny
 copying image ...
+available --force: alpine: Alpine, any version
   4. RUN true 
  13. RUN echo test1a
 test1a

--- a/test/build/60_force.bats
+++ b/test/build/60_force.bats
@@ -13,7 +13,7 @@ setup () {
 
     # without --force
     run ch-image -v build --no-cache -t tmpimg -f - . <<'EOF'
-FROM alpine:3.9
+FROM hello-world:latest
 EOF
     echo "$output"
     [[ $status -eq 0 ]]
@@ -21,7 +21,7 @@ EOF
 
     # with --force
     run ch-image -v build --force -t tmpimg -f - . <<'EOF'
-FROM alpine:3.9
+FROM hello-world:latest
 EOF
     echo "$output"
     [[ $status -eq 0 ]]

--- a/test/force-auto.py.in
+++ b/test/force-auto.py.in
@@ -278,13 +278,12 @@ class T_Debian_Latest(Debian):
    base = "debian:latest"
 class T_Ubuntu_16(Debian):
    base = "ubuntu:16.04"
-   arch_excludes = ["aarch64"]  # no pseudo package
 class T_Ubuntu_18(Debian):
    base = "ubuntu:18.04"
 class T_Ubuntu_21(Debian):
    base = "ubuntu:21.10"
-#class T_Ubuntu_Latest(Debian):  # no worky; see issue #1348
-#   base = "ubuntu:latest"
+class T_Ubuntu_Latest(Debian):
+   base = "ubuntu:latest"
 
 class SUSE(Test):
    config = "suse"

--- a/test/force-auto.py.in
+++ b/test/force-auto.py.in
@@ -303,13 +303,12 @@ class T_OpenSUSE_Leap_Latest(SUSE):
 class Arch_Latest(Test):
    config = "arch"
    base = "archlinux:latest"
-   arch_exclues = ["aarch64", "ppc64le"]  # base only amd64 pacman does not
-   # exit non-zero when installing openssh fails; work around this bug by
-   # grepping the pacman log.
+   arch_exclues = ["aarch64", "ppc64le"]  # base only amd64
+   # pacman does not exit non-zero when installing openssh fails; work
+   # around this bug by grepping the pacman log.
    runs = { **Test.runs, **{ Run.FAKE_NEEDED: "pacman -Syq --noconfirm ed; ! fgrep failed: /var/log/pacman.log",
                              Run.NEEDED:      "pacman -Syq --noconfirm openssh; ! fgrep failed: /var/log/pacman.log" } }
 
-# FIXME: no worky; still gets "failed to set ownership". See #1296
 class Alpine(Test):
    config = "alpine"
    # openssh does not need --force on Alpine

--- a/test/force-auto.py.in
+++ b/test/force-auto.py.in
@@ -304,8 +304,7 @@ class T_OpenSUSE_Leap_Latest(SUSE):
 
 # Arch has tons of old tags, versioned by date, on Docker Hub. However, only
 # :latest (or equivalently :base) is documented.
-# FIXME: does not currently work; still gets fchownat() errors. See #1295
-class Arch_Latest(Test):
+class T_Arch_Latest(Test):
    config = "arch"
    base = "archlinux:latest"
    arch_exclues = ["aarch64", "ppc64le"]  # base only amd64
@@ -319,9 +318,9 @@ class Alpine(Test):
    # openssh does not need --force on Alpine
    runs = { **Test.runs, **{ Run.FAKE_NEEDED: "apk add ed",
                              Run.NEEDED:      "apk add dbus" } }
-class Alpine_39(Alpine):
+class T_Alpine_39(Alpine):
    base = "alpine:3.9"
-class Alpine_Latest(Alpine):
+class T_Alpine_Latest(Alpine):
    base = "alpine:latest"
 
 


### PR DESCRIPTION
This gets the fakeroot support working using FAKEROOTDONTTRYCHOWN
(which I'll try to get documented) from #1362.  However, running
`ch-test build -b ch-image` fails with
```
...
error: scope '' invalid
found: /home/mdehsdl3/.local/share/doc/charliecloud/examples/serial/obspy/Dockerfile.skipped
found: /home/mdehsdl3/.local/share/doc/charliecloud/examples/chtest/Build

generate build_auto.bats ...
ok

executing build phase tests ...
Error: Duplicate test name(s) in file "/tmp/ch-test.tmp.mdehsdl3/build_auto.bats": test_build_hello test_builder_to_archive_hello
```
I haven't taken time to understand the test setup so I don't have a fix.  I have
tested the change separately, though.

Also there's a configure change to fix the test for FNM_EXTMATCH and
allow the build to work (on Debian 11) with current source.  Otherwise it fails
redefining FNM_EXTMATCH in ch_misc.c.