### PR TITLE
`ch-image`: crashes if requests is not installed, instead of proper error message

### DIFF
--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -2004,7 +2004,7 @@ def FATAL(msg, hint=None, **kwargs):
                                    f.lineno, f.name)
                      for f in reversed(traceback.extract_stack()[1:-1]))
       hint = tr if hint is None else "%s: %s" % (hint, tr)
-   log(msg, hint, "1;31m", "error: ", **kwargs)  # bold red
+   ERROR(msg, hint, **kwargs)
    sys.exit(1)
 
 def INFO(msg, hint=None, **kwargs):
@@ -2023,7 +2023,7 @@ def WARNING(msg, hint=None, **kwargs):
    log(msg, hint, "31m", "warning: ", **kwargs)  # red
 
 def ERROR(msg, hint=None, **kwargs):
-   log(msg, hint, "31m", "error: ", **kwargs)  # red
+   log(msg, hint, "1;31m", "error: ", **kwargs)  # bold red
 
 def arch_host_get():
    "Return the registry architecture of the host."

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -2022,6 +2022,9 @@ def VERBOSE(msg, hint=None, **kwargs):
 def WARNING(msg, hint=None, **kwargs):
    log(msg, hint, "31m", "warning: ", **kwargs)  # red
 
+def ERROR(msg, hint=None, **kwargs):
+   log(msg, hint, "31m", "error: ", **kwargs)  # red
+
 def arch_host_get():
    "Return the registry architecture of the host."
    arch_uname = platform.machine()


### PR DESCRIPTION
When trying to build charliecloud, the requests library was missing, causing the below error:
```
checking builder ...
Traceback (most recent call last):
  File "/home/znhounshel/Projects/charliecloud/bin/ch-image", line 240, in <module>
    main()
  File "/home/znhounshel/Projects/charliecloud/bin/ch-image", line 226, in main
    cli = ap.parse_args()
  File "/usr/lib64/python3.6/argparse.py", line 1734, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/lib64/python3.6/argparse.py", line 1766, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/lib64/python3.6/argparse.py", line 1972, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/lib64/python3.6/argparse.py", line 1912, in consume_optional
    take_action(action, args, option_string)
  File "/usr/lib64/python3.6/argparse.py", line 1840, in take_action
    action(self, namespace, argument_values, option_string)
  File "/home/znhounshel/Projects/charliecloud/bin/../lib/charliecloud/misc.py", line 25, in __call__
    ch.dependencies_check()
  File "/home/znhounshel/Projects/charliecloud/bin/../lib/charliecloud/charliecloud.py", line 1832, in dependencies_check
    ERROR("%s dependency: %s" % (p, v))
NameError: name 'ERROR' is not defined
error: builder: ch-image: missing dependencies
```

After this change, the output looks like:
```
error: missing dependency: Python module "requests"
```