### PR TITLE
print grouped common option help in subcommands

### DIFF
--- a/bin/ch-image.py.in
+++ b/bin/ch-image.py.in
@@ -79,7 +79,7 @@ def main():
    # [2]: https://docs.python.org/3/library/argparse.html#parents
    # [3]: https://stackoverflow.com/a/54936198
    common_opts = \
-      { "bucache": [
+      { ("bucache", "build cache common options"): [
            [["--cache"],
             { "action": "store_const",
               "const": ch.Build_Mode.ENABLED,
@@ -95,7 +95,7 @@ def main():
               "const": ch.Build_Mode.REBUILD,
               "dest": "bucache",
               "help": "force cache misses for non-FROM instructions" }] ],
-        None: [
+        (None, "misc common options"): [
            [["-a", "--arch"],
             { "metavar": "ARCH",
               "default": "host",
@@ -145,19 +145,14 @@ def main():
          p.set_defaults(func=dispatch)
          dependencies_check[dispatch] = deps_check
          storage_init[dispatch] = stog_init
-      for (name, group) in common_opts.items():
+      for ((name, title), group) in common_opts.items():
          if (name is None):
-            p2 = p
+            p2 = p.add_argument_group(title=title)
          else:
-            p2 = p.add_mutually_exclusive_group()
+            p2 = p.add_argument_group(title=title)
+            p2 = p2.add_mutually_exclusive_group()
          for (args, kwargs) in group:
-            if (help_):
-               kwargs2 = kwargs
-            else:
-               kwargs2 = { **kwargs,
-                           "default": argparse.SUPPRESS,
-                           "help": argparse.SUPPRESS }
-            p2.add_argument(*args, **kwargs2)
+            p2.add_argument(*args, **kwargs)
 
    # main parser
    add_opts(ap, None, deps_check=False, stog_init=False, help_=True)


### PR DESCRIPTION
Closes #1372.

This works around an `argparse` bug by changing our approach to subcommand help. Specifically, this PR adds help for common options in the help for each subcommand, though segregated into groups. The bug was triggered by suppressing help for the common options.

I don't love it. The usage string is too long and messy. However, I don't have good ideas about a different workaround.