### PR TITLE
clean up after failed instructions

### DIFF
--- a/test/build/50_ch-image.bats
+++ b/test/build/50_ch-image.bats
@@ -629,13 +629,18 @@ EOF
 @test 'ch-image build: failed RUN' {
     ch-image delete tmpimg || true
 
-    df=$(cat <<'EOF'
+    # tr(1) works around a bug in Bash ≤4.4 (I think) that causes here docs
+    # containing literal backslashes to parse incorrectly. See item “aa” in
+    # the changelog [1] for version bash-5.0-alpha.
+    #
+    # [1]: https://git.savannah.gnu.org/cgit/bash.git/tree/CHANGES
+    df=$(cat <<'EOF' | tr '%' '\\'
 FROM 00_tiny
-RUN set -o noclobber \
- && echo hello > file_ \
- && mkdir dir_empty \
- && mkdir dir_nonempty \
- && mkfifo fifo_ \
+RUN set -o noclobber %
+ && echo hello > file_ %
+ && mkdir dir_empty %
+ && mkdir dir_nonempty %
+ && mkfifo fifo_ %
 EOF
         )
 

--- a/test/build/50_ch-image.bats
+++ b/test/build/50_ch-image.bats
@@ -634,6 +634,7 @@ EOF
     # the changelog [1] for version bash-5.0-alpha.
     #
     # [1]: https://git.savannah.gnu.org/cgit/bash.git/tree/CHANGES
+    # shellcheck disable=SC1003
     df=$(cat <<'EOF' | tr '%' '\\'
 FROM 00_tiny
 RUN set -o noclobber %


### PR DESCRIPTION
If an instruction fails for whatever reason, it leaves behind unknown state in the image in `img/`. This can cause various problems. For example:

```
RUN mkdir foo && touch foo/bar && false
```

will cause any subsequent `RUN mkdir foo` to fail because directory `foo` already exists.

This PR rolls back any changes made by a failed instruction.

I am a little leery about catching `SystemExit`, but it seems to work, and the alternative seemed to be a major rethink of how `FATAL()` works.