### PR TITLE
add podman check for docker_ command set

### DIFF
--- a/lib/base.sh
+++ b/lib/base.sh
@@ -147,8 +147,14 @@ vset () {
 }
 
 
+# Needs more testing but it appears podman doesn't ever need root
+# Podman will become preferred to Docker on a system with both
+if podman info > /dev/null 2>&1; then
+    docker_ () {
+        podman "$@"
+    }
 # Do we need sudo to run docker?
-if docker info > /dev/null 2>&1; then
+elif docker info > /dev/null 2>&1; then
     docker_ () {
         docker "$@"
     }


### PR DESCRIPTION
Addresses #1360

This will add a test to see if podman is available on the system. On systems with both Docker and Podman, Podman will be selected. If this is too clunky we could set this in configure instead. 