### PR TITLE
add nested namespaces for non-setuid `fusermount3`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,10 +144,6 @@ jobs:
           [[ $(command -v python3) == /usr/local/bin/python3 ]]
           # Use most current packages b/c new versions sometimes break things.
           sudo sh -c 'umask 0022 && pip3 install lark-parser requests wheel'
-          # Unset setuid on all fusermount3(1) on the system.
-          sudo find / -name fusermount3 -exec chmod -v u-s {} \;
-          ls -lh $(command -v fusermount3)
-          [[ ! -u $(command -v fusermount3) ]]
           # Configure Git and friends for build cache.
           if [[ $CH_IMAGE_CACHE = enabled ]]; then
               # Git
@@ -182,6 +178,11 @@ jobs:
           make
           sudo sh -c 'umask 0022 && make install'
           sudo ldconfig
+          # Unset setuid on all fusermount3(1) on the system.
+          sudo find / -name fusermount3 -exec chmod -v u-s {} \;
+          ls -lh $(command -v fusermount3)
+          [[ ! -u $(command -v fusermount3) ]]
+
 
       - name: install musl and friends
         if: ${{ matrix.pack_fmt == 'tar-unpack' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,10 @@ jobs:
           [[ $(command -v python3) == /usr/local/bin/python3 ]]
           # Use most current packages b/c new versions sometimes break things.
           sudo sh -c 'umask 0022 && pip3 install lark-parser requests wheel'
+          # Unset setuid on all fusermount3(1) on the system.
+          sudo find / -name fusermount3 -exec chmod -v u-s {} \;
+          ls -lh $(command -v fusermount3)
+          [[ ! -u $(command -v fusermount3) ]]
           # Configure Git and friends for build cache.
           if [[ $CH_IMAGE_CACHE = enabled ]]; then
               # Git

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
           sudo sh -c 'umask 0022 && make install'
           sudo ldconfig
           # Unset setuid on all fusermount3(1) on the system.
-          sudo find / -name fusermount3 -exec chmod -v u-s {} \;
+          sudo find / -name 'fusermount*' -exec chmod -v u-s {} \;
           ls -lh $(command -v fusermount3)
           [[ ! -u $(command -v fusermount3) ]]
 

--- a/bin/ch_fuse.c
+++ b/bin/ch_fuse.c
@@ -10,6 +10,7 @@
 #include <dirent.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/prctl.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -127,7 +128,9 @@ void sq_fork(struct container *c)
    Zf (stat(c->newroot, &st), "can't stat mount point: %s", c->newroot);
    Te (S_ISDIR(st.st_mode), "not a directory: %s", c->newroot);
 
-   // Mount SquashFS.
+   // Mount SquashFS. Use PR_SET_NO_NEW_PRIVS to actively reject running
+   // fusermount3(1) setuid, even if it’s installed that way.
+   Zf (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0), "can't set no_new_privs");
    sq_mount(c->img_path, c->newroot);
 
    // Now that the filesystem is mounted, we can fork without race condition.

--- a/doc/ch-run_desc.rst
+++ b/doc/ch-run_desc.rst
@@ -11,7 +11,8 @@ Description
 
 Run command :code:`CMD` in a fully unprivileged Charliecloud container using
 the image located at :code:`IMAGE`, which can be either a directory or, if the
-proper support is enabled, a SquashFS archive.
+proper support is enabled, a SquashFS archive. :code:`ch-run` does not use any
+setuid or setcap helpers, even for mounting SquashFS images with FUSE.
 
   :code:`-b`, :code:`--bind=SRC[:DST]`
     Bind-mount :code:`SRC` at guest :code:`DST`. The default destination if
@@ -158,10 +159,15 @@ can be accomplished by:
 * Any other workflow that produces an appropriate directory tree.
 
 The second is a SquashFS image archive mounted internally by :code:`ch-run`,
-available if it's linked with the optional :code:`libsquashfuse_ll`.
-:code:`ch-run` mounts the image filesystem, services all FUSE requests, and
-unmounts it, all within :code:`ch-run`. See :code:`--mount` above to set the
-mount point location.
+available if it's linked with the optional :code:`libsquashfuse_ll` shared
+library. :code:`ch-run` mounts the image filesystem, services all FUSE
+requests, and unmounts it, all within :code:`ch-run`. See :code:`--mount`
+above to set the mount point location.
+
+Like other FUSE implementations, Charliecloud calls the :code:`fusermount3(1)`
+utility to mount the SquashFS filesystem. However, **this executable does not
+need to be installed setuid root**, and in fact :code:`ch-run` actively
+suppresses its setuid bit if set (using :code:`prctl(2)`).
 
 Prior versions of Charliecloud provided wrappers for the :code:`squashfuse`
 and :code:`squashfuse_ll` SquashFS mount commands and :code:`fusermount -u`

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -455,17 +455,20 @@ The SquashFS workflow requires `SquashFS Tools
 
 To mount these archives using :code:`ch-run`'s internal code, you need:
 
-* `libfuse3 <https://github.com/libfuse/libfuse>`_ including development
-  files, which is probably available in your distribution (e.g.,
-  :code:`libfuse3-dev`), and
+1. `libfuse3 <https://github.com/libfuse/libfuse>`_, including:
 
-* a very recent version of `SquashFUSE <https://github.com/vasi/squashfuse>`_
-  that has the :code:`libsquashfuse_ll` shared library. At the time of this
-  writing (August 2021), this is probably `commit 56a24f6
-  <https://github.com/vasi/squashfuse/commit/56a24f6c7f6e5cfd0ce5185f175da223d00dc1ca>`_
-  or newer, and there is no versioned release yet. This must be installed,
-  though it can be a non-standard location; :code:`ch-run` can't link with
-  :code:`libsquashfuse` in the latter's build directory.
+   * development files, which are probably available in your distribution,
+     e.g., :code:`libfuse3-dev`. (Build time only.)
+
+   * The :code:`fusermount3` executable, which often comes in a distro package
+     called something like :code:`fuse3`. **This is typically installed
+     setuid, but Charliecloud does not need that**; you can :code:`chmod u-s`
+     the file or build/install as a normal user.
+
+2. `SquashFUSE <https://github.com/vasi/squashfuse>`_ v0.1.105 or later (we
+   need the :code:`libsquashfuse_ll` shared library). This must be installed,
+   not linked from its build directory, though it can be installed in a
+   non-standard location.
 
 Without these, you can still use a SquashFS workflow but must mount and
 unmount the filesystem archives manually. You can do this using the

--- a/test/force-auto.py.in
+++ b/test/force-auto.py.in
@@ -277,10 +277,6 @@ class T_Debian_Latest(Debian):
    base = "debian:latest"
 class T_Ubuntu_16(Debian):
    base = "ubuntu:16.04"
-class T_Ubuntu_18(Debian):
-   base = "ubuntu:18.04"
-class T_Ubuntu_21(Debian):
-   base = "ubuntu:21.10"
 class T_Ubuntu_Latest(Debian):
    base = "ubuntu:latest"
 

--- a/test/run/ch-run_escalated.bats
+++ b/test/run/ch-run_escalated.bats
@@ -74,3 +74,11 @@ load ../common
     [[ $status -eq 1 ]]
     [[ $output = *'please report this bug ('* ]]
 }
+
+@test 'non-setuid fusermount3' {
+    [[ $CH_TEST_PACK_FMT == squash-mount ]] || skip 'squash-mount format only'
+    if [[ -u $(command -v fusermount3) ]]; then
+        pedantic_fail 'fusermount3(1) is setuid'
+    fi
+    true  # other tests validate it actually works
+}

--- a/test/run/ch-run_escalated.bats
+++ b/test/run/ch-run_escalated.bats
@@ -78,6 +78,7 @@ load ../common
 @test 'non-setuid fusermount3' {
     [[ $CH_TEST_PACK_FMT == squash-mount ]] || skip 'squash-mount format only'
     if [[ -u $(command -v fusermount3) ]]; then
+        ls -lh "$(command -v fusermount3)"
         pedantic_fail 'fusermount3(1) is setuid'
     fi
     true  # other tests validate it actually works


### PR DESCRIPTION
This PR lets `ch-run`'s internal SquashFS work with non-setuid `fusermount3`.

If that executable is installed setuid, suppress the setuid bit with `prctl(2)`, i.e., `ch-run` now *never* escalates during SquashFUSE mount.