### PR TITLE
fine-grained locking for storage directory (broken!)

### DIFF
--- a/doc/ch-image_desc.rst
+++ b/doc/ch-image_desc.rst
@@ -224,9 +224,9 @@ Python's :code:`fnctl.flock()` function, which I believe boils down to
 <http://0pointer.de/blog/projects/locking.html>`_ but should work for our
 purposes. In particular, it should work for a storage directory on NFS. Some
 operations lock the entire storage directory, while others only part of it;
-for example, during instruction execution, :code:`ch-image build` locks only
-the image being modified. Over time, we hope to increase concurrency by
-decreasing locking granularity.
+for example, during :code:`RUN` instruction execution, :code:`ch-image build`
+locks only the image being modified. Over time, we hope to increase
+concurrency by decreasing locking granularity.
 
 While you can currently explore the storage directory and find unpacked images
 runnable with :code:`ch-run`, this is not a supported use case. The supported

--- a/doc/ch-image_desc.rst
+++ b/doc/ch-image_desc.rst
@@ -218,10 +218,20 @@ for this; tmpfs'es such as :code:`/var/tmp` are a good choice if you have
 enough RAM (:code:`/tmp` is not recommended because :code:`ch-run` bind-mounts
 it into containers by default).
 
-While you can currently poke around in the storage directory and find unpacked
-images runnable with :code:`ch-run`, this is not a supported use case. The
-supported workflow uses :code:`ch-convert` to obtain a packed image; see the
-tutorial for details.
+Concurrent access to the same storage directory is managed by file locks using
+Python's :code:`fnctl.flock()` function, which I believe boils down to
+:code:`fnctl(2)` style POSIX locking, which has `major disadvantages
+<http://0pointer.de/blog/projects/locking.html>`_ but should work for our
+purposes. In particular, it should work for a storage directory on NFS. Some
+operations lock the entire storage directory, while others only part of it;
+for example, during instruction execution, :code:`ch-image build` locks only
+the image being modified. Over time, we hope to increase concurrency by
+decreasing locking granularity.
+
+While you can currently explore the storage directory and find unpacked images
+runnable with :code:`ch-run`, this is not a supported use case. The supported
+workflow uses :code:`ch-convert` to obtain a packed image; see the tutorial
+for details.
 
 The storage directory format changes on no particular schedule. Often
 :code:`ch-image` is able to upgrade the directory; however, downgrading is not
@@ -1078,4 +1088,4 @@ Environment variables
 
 
 ..  LocalWords:  tmpfs'es bigvendor AUTH auth bucache buc bigfile df rfc
-..  LocalWords:  dlcache graphviz
+..  LocalWords:  dlcache graphviz lockf

--- a/lib/build.py
+++ b/lib/build.py
@@ -943,11 +943,13 @@ class Run(Instruction):
       return super().str_name + (".F" if cli.force else "")
 
    def execute(self):
+      ch.storage.lock_narrow(ch.Storage.Lock_Image(self.image))
       rootfs = self.image.unpack_path
       fakeroot_config.init_maybe(rootfs, self.cmd, self.env_build)
       cmd = fakeroot_config.inject_run(self.cmd)
       exit_code = ch.ch_run_modify(rootfs, cmd, self.env_build, self.workdir,
                                    cli.bind, fail_ok=True)
+      ch.storage.lock_widen()
       if (exit_code != 0):
          msg = "build failed: RUN command exited with %d" % exit_code
          if (cli.force):

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -1819,7 +1819,7 @@ class Storage:
          return "image %s" % self.image.ref
       @property
       def lockfile(self):
-         return storage.unpack(self.image) + ",lock"
+         return str(self.image.unpack_path) + ",lock"
 
    def __init__(self, storage_cli):
       self.locks = [self.Lock_None()]


### PR DESCRIPTION
Closes #1398 (or it would, if it worked).

This is irretrievably broken, because locking an individual image needs to conflict with locking the whole storage directory, but it doesn't. However, I thought it was worth recording the effort.