### PR TITLE
draft: update mpi examples and improve `ch-fromhost`'s robustness

### DIFF
--- a/bin/ch-fromhost
+++ b/bin/ch-fromhost
@@ -283,7 +283,9 @@ if [ $cray_mpich ]; then
     # shellcheck disable=SC2016
        [ "$CRAY_MPICH_DIR" ] \
     || fatal '$CRAY_MPICH_DIR not set; is module cray-mpich-abi loaded?'
-    cray_libmpi=$CRAY_MPICH_DIR/lib/libmpi.so.12
+       [ -d "$CRAY_MPICH_DIR/lib-abi-mpich" ] \
+    && cray_libmpi=$CRAY_MPICH_DIR/lib-abi-mpich/libmpi.so.12 \
+    || cray_libmpi=$CRAY_MPICH_DIR/lib/libmpi.so.12
        [ -f "$cray_libmpi" ] \
     || fatal "not found: ${cray_libmpi}; is module cray-mpich-abi loaded?"
 
@@ -300,10 +302,11 @@ if [ $cray_mpich ]; then
                    | grep -F /opt \
                    | sed -E 's/^.+ => (.+) \(0x.+\)$/\1/')"
     # dlopen(3)'ed dependencies. I don't know how to not hard-code these.
-    queue_files /opt/cray/alps/default/lib64/libalpsutil.so.0.0.0
-    queue_files /opt/cray/alps/default/lib64/libalpslli.so.0.0.0
-    queue_files /opt/cray/wlm_detect/default/lib64/libwlm_detect.so.0.0.0
-    #queue_files /opt/cray/alps/default/lib64/libalps.so.0.0.0
+       [ -d "/opt/cray/alps" ] \
+    && queue_files /opt/cray/alps/default/lib64/libalpsutil.so.0.0.0 \
+                   /opt/cray/alps/default/lib64/libalpslli.so.0.0.0
+       [ -d "/opt/cray/wlm_detect"] \
+    && queue_files /opt/cray/wlm_detect/default/lib64/libwlm_detect.so.0.0.0
 fi
 
 if [ $cray_openmpi ]; then
@@ -342,8 +345,10 @@ if [ $cray_mpi ]; then
     queue_mkdir /var/opt/cray/alps/spool
 
     # libwlm_detect.so requires this file to be present.
-    queue_mkdir /etc/opt/cray/wlm_detect
-    queue_files /etc/opt/cray/wlm_detect/active_wlm /etc/opt/cray/wlm_detect
+       [ -d "/etc/opt/cray/wlm_detect" ] \
+    && queue_mkdir /etc/opt/cray/wlm_detect \
+    && queue_files /etc/opt/cray/wlm_detect/active_wlm \
+                   /etc/opt/cray/wlm_detect
 
     # uGNI needs a pile of hugetlbfs filesystems at paths that are arbitrary
     # but in a specific order in /proc/mounts. ch-run bind-mounts here later.

--- a/bin/ch-fromhost
+++ b/bin/ch-fromhost
@@ -305,7 +305,7 @@ if [ $cray_mpich ]; then
        [ -d "/opt/cray/alps" ] \
     && queue_files /opt/cray/alps/default/lib64/libalpsutil.so.0.0.0 \
                    /opt/cray/alps/default/lib64/libalpslli.so.0.0.0
-       [ -d "/opt/cray/wlm_detect"] \
+       [ -d "/opt/cray/wlm_detect" ] \
     && queue_files /opt/cray/wlm_detect/default/lib64/libwlm_detect.so.0.0.0
 fi
 

--- a/examples/Dockerfile.mpich
+++ b/examples/Dockerfile.mpich
@@ -1,8 +1,9 @@
 # The MPICH example has a smaller scope than the OpenMPI example. We want to
-# provide an MPICH build that works on a single node and (via ch-fromhost
-# trickery) on Cray Aries systems. That's it for now.
+# provide an MPICH build that works (via ch-fromhost trickery) on Cray Aries
+# and Slingshot systems. That's it for now.
 #
-# We build MPICH rather than install the RPM to get a bare bones build.
+# We build MPICH rather than install the RPM so we have more control over build
+# options.
 #
 # ch-test-scope: full
 
@@ -15,7 +16,19 @@ RUN dnf install -y --setopt=install_weak_deps=false \
                 gcc-c++ \
                 gcc-gfortran \
                 git \
+                ibacm \
+                libevent-devel \
+                libtool \
+                libibumad \
+                libibumad-devel \
+                libibverbs \
+                libibverbs-devel \
+                libibverbs-utils \
+                librdmacm \
+                librdmacm-devel \
+                rdma-core \
                 make \
+                numactl-devel \
                 wget \
  && dnf clean all
 
@@ -30,26 +43,14 @@ RUN git clone https://github.com/hpc/patchelf.git \
  && make install \
  && rm -Rf ../patchelf
 
-# Forcing ch3 instead of the default ch4 as the latter requires ucx or
-# libfabric to be installed.
-ARG MPI_VERSION=3.4.1
+ARG MPI_VERSION=4.0.2
 ARG MPI_URL=http://www.mpich.org/static/downloads/${MPI_VERSION}
 RUN wget -nv ${MPI_URL}/mpich-${MPI_VERSION}.tar.gz \
  && tar xf mpich-${MPI_VERSION}.tar.gz \
  && cd mpich-${MPI_VERSION} \
- && CFLAGS=-O3 \
-    CXXFLAGS=-O3 \
-    ./configure --prefix=/usr/local \
-                --disable-cxx \
-                --disable-fortran \
-                --disable-threads \
-                --disable-rpath \
-                --disable-static \
-                --disable-wrapper-rpath \
-                --with-device=ch3 \
-                --without-ibverbs \
-                --without-libfabric \
-                --without-slurm \
+ && ./configure --prefix=/usr/local \
+                --enable-threads-multiple \
+                --with-device=ch4:ofi \
  && make -j$(getconf _NPROCESSORS_ONLN) install \
  && rm -Rf ../mpich-${MPI_VERSION}*
 RUN ldconfig

--- a/examples/Dockerfile.openmpi
+++ b/examples/Dockerfile.openmpi
@@ -91,7 +91,7 @@ WORKDIR /usr/local/src
 
 # UCX. There is a package but we want control over build options, specifically
 # multithreaded support.
-ARG UCX_VERSION=1.11.2
+ARG UCX_VERSION=1.12.1
 RUN git clone --branch v${UCX_VERSION} --depth 1 \
               https://github.com/openucx/ucx.git \
  && cd ucx \
@@ -117,8 +117,11 @@ RUN wget https://github.com/SchedMD/slurm/archive/slurm-${SLURM_VERSION}.tar.gz 
 #
 # Patch OpenMPI to disable UCX plugin on systems with Intel or Cray HSNs. UCX
 # has inferior performance than PSM2/uGNI but higher priority.
-ARG MPI_URL=https://www.open-mpi.org/software/ompi/v3.1/downloads
-ARG MPI_VERSION=3.1.6
+# Disable the uct btl as it can conflict with the malloc hooks in OMPI and
+# cause data corruption.
+# https://openucx.readthedocs.io/en/master/running.html#running-mpi
+ARG MPI_URL=https://www.open-mpi.org/software/ompi/v4.1/downloads
+ARG MPI_VERSION=4.1.4
 RUN wget -nv ${MPI_URL}/openmpi-${MPI_VERSION}.tar.gz \
  && tar xf openmpi-${MPI_VERSION}.tar.gz
 COPY dont-init-ucx-on-intel-cray.patch ./openmpi-${MPI_VERSION}
@@ -133,7 +136,7 @@ RUN cd openmpi-${MPI_VERSION} \
                 --with-pmix \
                 --with-ucx \
                 --disable-pty-support \
-                --enable-mca-no-build=btl-openib,plm-slurm \
+                --enable-mca-no-build=btl-openib,btl-uct,plm-slurm \
  && make -j$(getconf _NPROCESSORS_ONLN) install \
  && rm -Rf ../openmpi-${MPI_VERSION}*
 RUN ldconfig

--- a/examples/dont-init-ucx-on-intel-cray.patch
+++ b/examples/dont-init-ucx-on-intel-cray.patch
@@ -16,7 +16,7 @@ index ff0040f18c..e8cf903860 100644
  {
      int ret;
  
-+    if ((0 == access("/sys/class/ugni/", F_OK) || (0 == access("/sys/class/hfi1/", F_OK)))){
++    if ((0 == access("/sys/class/gni/", F_OK) || (0 == access("/sys/class/hfi1/", F_OK)))){
 +	     PML_UCX_VERBOSE(1, "Cray or Intel HSN detected, removing UCX from consideration");
 +	     return NULL;
 +    }

--- a/examples/paraview/test.bats
+++ b/examples/paraview/test.bats
@@ -49,6 +49,7 @@ setup () {
 }
 
 @test "${ch_tag}/cone serial PNG" {
+    [[ -z $ch_cray ]] || skip 'serial launches unsupported on Cray'
     pict_ok
     pict_assert_equal "${indir}/cone.png" "${outdir}/cone.serial.png" 1000
 }


### PR DESCRIPTION
This PR does the following:
 * Updates openmpi 3.1.6 -> 4.1.4
 * Updates ucx 1.11.2 -> 1.12.1
 * Updates mpich 3.1.4 -> 4.0.2
 * Builds ofi support in mpich for Slingshot systems
 * skips the `paraview/cone serial PNG` on Cray machines (oversight since the previous test is skipped)
 * tweaks `dont-init-ucx-on-intel-cray.patch` to use a updated ugni path (found during testing)
 * Makes `ch-fromhost` more robust by adding checks before trying to copy certain files.

@j-ogas I would appreciate your help testing this.