### PR TITLE
`misc/version`: `.git` might not be a directory

### DIFF
--- a/misc/version
+++ b/misc/version
@@ -21,7 +21,7 @@ case $version_simple in
         ;;
 esac
 
-if [ ! -d "${ch_base}/.git" ] || [ -z "$prerelease" ]; then
+if [ ! -e "${ch_base}/.git" ] || [ -z "$prerelease" ]; then
     # no Git or release version; use simple version
     printf "%s\n" "$version_simple"
 else


### PR DESCRIPTION
Turns out `.git` is a plain file if the Git WD is a secondary worktree, so accept this when deciding if the source code is in a Git WD.