### PR TITLE
build cache: metadata instructions only commit what’s needed

### DIFF
--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -1157,6 +1157,16 @@ class Path(pathlib.PosixPath):
          others2.append(other)
       return self.joinpath(*others2)
 
+   def lstrip(self, n):
+      """Return a copy of myself with n leading components removed. E.g.:
+
+           >>> Path("a/b/c").lstrip(1)
+           Path("b/c")
+
+         It is an error if I don’t have at least n+1 components."""
+      assert (len(self.parts) >= n + 1)
+      return Path(".").joinpath(*self.parts[n:])
+
 
 class Progress:
    """Simple progress meter for countable things that updates at most once per


### PR DESCRIPTION
This PR optimizes metadata-only instructions (`ARG`, `ENV`, and `SHELL`) to skip the recursive image walk, instead processing only the file(s) that actually changed.

There are two more instructions with similar optimization opportunities not included here:

1. `WORKDIR` modifies only `ch/metadata.json` and (maybe) the directory operand. However, dealing with the directory is trickier than I thought. There are multiple cases to deal with, including at least: (a) all directories in specified path created by the instruction, (b) some directories created, (c) no directories created, (d) path traverses one or more symlinks. So, I'm putting it off.

2. `COPY` also modifies a known set of files. I didn't look into this in detail, but the number of files is going to be qualitatively different than the one or two so far.

Because of these future possible changes, `commit_files` is an instance attribute rather than a class attribute.