### PR TITLE
omit `RPATH` when not needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -362,7 +362,10 @@ AS_IF([   test $want_libsquashfuse = yes \
        && test $have_libsquashfuse_ll = yes \
        && test $have_ll_h = yes],
       [have_libsquashfuse=yes
-       CH_RUN_LIBS="-lsquashfuse_ll -lfuse3 -Wl,-rpath=$lib_libsquashfuse $CH_RUN_LIBS"],
+       AS_IF([test -n "$lib_libsquashfuse"],
+             [rpath_libsquashfuse=-Wl,-rpath=$lib_libsquashfuse],
+             [rpath_libsquashfuse=])
+       CH_RUN_LIBS="-lsquashfuse_ll -lfuse3 $rpath_libsquashfuse $CH_RUN_LIBS"],
       [have_libsquashfuse=no])
 AS_IF([   test $need_libsquashfuse = yes \
        && test $have_libsquashfuse = no],


### PR DESCRIPTION
Previously, `configure` built `ch-run` with an empty `RPATH` if `libsquashfuse` was found in a default location (e.g., `/usr/local/lib` or `/usr/lib`) and `--with-squashfuse` was either not specified or given with `yes`.

This generated a `scanelf(1)` warning, likely due to a long history of exploits related to `RPATH` and `RUNPATH`. We were unable to identify any specific vulnerability related to the empty `RPATH` on modern systems. Regardless, it’s a bug and we’re fixing it.

Thanks to @olifre for identifying the bug, and to @mej and @najones19746 for analyzing its impact.