### PR TITLE
support storage directories up to 1 year old

### DIFF
--- a/doc/ch-image.rst
+++ b/doc/ch-image.rst
@@ -264,7 +264,7 @@ The storage directory format changes on no particular schedule.
 :code:`ch-image` is normally able to upgrade directories produced by a given
 Charliecloud version up to one year after that version's release. Upgrades
 outside this window and downgrades are not supported. In these cases,
-:code:`ch-image` will refuse to fun until you delete and re-initialize the
+:code:`ch-image` will refuse to run until you delete and re-initialize the
 storage directory with :code:`ch-image reset`.
 
 .. warning::

--- a/doc/ch-image.rst
+++ b/doc/ch-image.rst
@@ -225,8 +225,8 @@ Storage directory
 =================
 
 :code:`ch-image` maintains state using normal files and directories located in
-its *storage directory*; contents include temporary images used for building
-and various caches.
+its *storage directory*; contents include various caches and temporary images
+used for building.
 
 In descending order of priority, this directory is located at:
 
@@ -260,11 +260,12 @@ images runnable with :code:`ch-run`, this is not a supported use case. The
 supported workflow uses :code:`ch-convert` to obtain a packed image; see the
 tutorial for details.
 
-The storage directory format changes on no particular schedule. Often
-:code:`ch-image` is able to upgrade the directory; however, downgrading is not
-supported and sometimes upgrade is not possible. In these cases,
-:code:`ch-image` will refuse to run until you delete and re-initialize the
-directory with :code:`ch-image reset`.
+The storage directory format changes on no particular schedule.
+:code:`ch-image` is normally able to upgrade directories produced by a given
+Charliecloud version up to one year after that version's release. Upgrades
+outside this window and downgrades are not supported. In these cases,
+:code:`ch-image` will refuse to fun until you delete and re-initialize the
+storage directory with :code:`ch-image reset`.
 
 .. warning::
 

--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -20,6 +20,10 @@ import charliecloud as ch
 # Storage directory format version. We refuse to operate on storage
 # directories with non-matching versions. Increment this number when the
 # format changes non-trivially.
+#
+# To see the directory formats in released versions:
+#
+#   $ git grep -F 'STORAGE_VERSION =' $(git tag | sort -V)
 STORAGE_VERSION = 5
 
 


### PR DESCRIPTION
Previously, we did not commit to any particular duration for support of old storage directories. The disadvantage is that we're growing an increasing amount of compatibility code and testing. This documents a 1-year support period.

One potential problem is distribution-packaged versions. Currently these tend to lag rather a lot (e.g. Debian stable has 0.21, which is about two years old and has storage version 1). I’m not *too* worried about that since everything in storage can be rebuilt, but I would like to gather comment on it. If we did want to support e.g. Debian stable-to-stable upgrades, we’re looking at 3 years or more of support.

If this passes review, I’ll also create child bugs to retire storage versions 1–4, and update the release instructions to create new such bugs upon release of each relevant version.