### PR TITLE
make tests pass under ShellCheck 0.9.0

### DIFF
--- a/test/build/10_sanity.bats
+++ b/test/build/10_sanity.bats
@@ -104,7 +104,7 @@ load ../common
     # For awk program, see: https://unix.stackexchange.com/a/66099
     while IFS= read -r i; do
         echo "shellcheck: ${i}"
-        shellcheck -x -P "$ch_lib" -e SC1090,SC1112,SC2002,SC2154 "$i"
+        shellcheck -x -P "$ch_lib" -e SC1090,SC1112,SC2002,SC2154,SC2317 "$i"
     done < <( find "$ch_base" \
                    \(    -name .git \
                       -o -name build-aux \) -prune \
@@ -123,7 +123,7 @@ load ../common
         echo "shellcheck: ${i}"
           sed -r -e 's/@test (.+) \{/test_ () {/g' "$i" \
                  -e 's/%\(([a-zA-Z0-9_]+)\)/SUBST_\1/g' \
-        | shellcheck -s bash -e SC1090,SC1112,SC2002,SC2103,SC2154,SC2164 -
+        | shellcheck -s bash -e SC1090,SC1112,SC2002,SC2103,SC2154,SC2164,SC2317  -
     done < <( find "$ch_base" -name '*.bats' -o -name '*.bats.in' )
 }
 

--- a/test/run/ch-fromhost.bats
+++ b/test/run/ch-fromhost.bats
@@ -384,14 +384,14 @@ glibc_version_ok () {
     sample=/matrixMulCUBLAS
     # should fail without ch-fromhost --nvidia
     fromhost_clean "$img"
-    run ch-run "$img" -- $sample
+    run ch-run "$img" -- "$sample"
     echo "$output"
     [[ $status -eq 1 ]]
     [[ $output = *'CUDA error at'* ]]
     # should succeed with it
     fromhost_clean_p "$img"
     ch-fromhost --nvidia "$img"
-    run ch-run "$img" -- $sample
+    run ch-run "$img" -- "$sample"
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output =~ 'Comparing CUBLAS Matrix Multiply with CPU results: PASS' ]]

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -1018,19 +1018,19 @@ EOF
     gid_bad=8675310
 
     # UID
-    run ch-run -v --uid=$uid_bad "$ch_timg" -- /bin/true
+    run ch-run -v --uid="$uid_bad" "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output = *"UID ${uid_bad} not found; using dummy info"* ]]
 
     # GID
-    run ch-run -v --gid=$gid_bad "$ch_timg" -- /bin/true
+    run ch-run -v --gid="$gid_bad" "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output = *"GID ${gid_bad} not found; using dummy info"* ]]
 
     # both
-    run ch-run -v --uid=$uid_bad --gid=$gid_bad "$ch_timg" -- /bin/true
+    run ch-run -v --uid="$uid_bad" --gid="$gid_bad" "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $output = *"UID ${uid_bad} not found; using dummy info"* ]]


### PR DESCRIPTION
Makes the test suite pass. #1509 suggests a more permanent solution.