### PR TITLE
remove content-free Docker Hub rate limit message

### DIFF
--- a/lib/registry.py
+++ b/lib/registry.py
@@ -361,7 +361,7 @@ class HTTP:
             else:
                # Overall limits yield HTTP 429 so warning seems legitimate?
                ch.WARNING("can’t parse Docker-RateLimit-Source: %s" % h)
-      if (any(i != "???" for i in (used_ct, period, left_ct,reason))):
+      if (any(i != "???" for i in (used_ct, period, left_ct))):
          ch.INFO("Docker Hub rate limit: %s pulls left of %s per %s hours (%s)"
                  % (used_ct, period, left_ct, reason))
 


### PR DESCRIPTION
Fix a bug where dockerhub ratelimit info is displated with (almost) all fields being `???`, as seen in the example below
```
GET: https://registry-1.docker.io:443/v2/library/alpine/manifests/latest
response status: 401
content-type: application/json
docker-distribution-api-version: registry/2.0
www-authenticate: Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/alpine:pull"
date: Wed, 21 Dec 2022 23:03:23 GMT
content-length: 157
strict-transport-security: max-age=31536000
docker-ratelimit-source: 192.12.184.6
Docker Hub rate limit: ??? pulls left of ??? per ??? hours (192.12.184.6)
```