### PR TITLE
fix `realpath(3)` error handling

### DIFF
--- a/bin/ch_misc.c
+++ b/bin/ch_misc.c
@@ -589,7 +589,7 @@ char *realpath_(const char *path, bool fail_ok)
    errno = 0;
    pathc = realpath(path, NULL);
 
-   if (errno != 0) {
+   if (pathc == NULL && errno != 0) {
       if (fail_ok) {
          T_ (pathc = strdup(path));
       } else {

--- a/bin/ch_misc.c
+++ b/bin/ch_misc.c
@@ -586,10 +586,9 @@ char *realpath_(const char *path, bool fail_ok)
    if (path == NULL)
       return NULL;
 
-   errno = 0;
    pathc = realpath(path, NULL);
 
-   if (pathc == NULL && errno != 0) {
+   if (pathc == NULL) {
       if (fail_ok) {
          T_ (pathc = strdup(path));
       } else {


### PR DESCRIPTION
glibc's realpath may set errno also on success. Since POSIX specifies errno should only be checked after realpath if the return value is not NULL, this should be checked first. 

See for example:
 https://bugzilla.redhat.com/show_bug.cgi?id=1916968

An example is the following program:
```
#include <errno.h>
#include <stdio.h>
#include <stdlib.h>

int main() {
  char *pathc = realpath("/home/", NULL);
  printf("%s\n", pathc);
  printf("%d\n", errno);
  return 0;
}
```
On my Gentoo system using `glibc-2.36`, it echoes upon executing:
```
/home
22
```
