### PR TITLE
cache gc: use topological sort

### DIFF
--- a/lib/build_cache.py
+++ b/lib/build_cache.py
@@ -794,7 +794,8 @@ class Enabled_Cache:
                      "-c", "gc.reflogExpire=now", "gc"], cwd=self.root)
       t.log("collected garbage")
       t = ch.Timer()
-      digests = ch.cmd_stdout(["git", "rev-list", "--all", "--reflog"],
+      digests = ch.cmd_stdout(["git", "rev-list",
+                               "--all", "--reflog", "--date-order"],
                               cwd=self.root).stdout.split("\n")
       assert (digests[-1] == "")  # trailing newline
       digests[-2:] = []           # discard root commit and trailing newline


### PR DESCRIPTION
This PR adds topological commit sort to the “`git rev-list`” call in garbage collection that enumerates the commits, which discards the very first commit, assuming this is the root commit.

Git only records timestamps with one-second granularity. Previously, if the cache (and its root commit) was created, then received its first real commit within the same second (e.g., the test suite makes commits really fast), those two commits appear in arbitrary order, making the above assumption a race condition. 