### PR TITLE
`ch-image`: always print version with -v or higher

### DIFF
--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -21,6 +21,7 @@ import traceback
 
 import filesystem as fs
 import registry as rg
+import version
 
 # Compatibility link. Sometimes we load pickled data from when Path was
 # defined in this file. This alias lets us still load such pickles.
@@ -608,6 +609,7 @@ def init(cli):
       verbose = max(verbose, 1)
       log_fp = file_.open_("at")
    atexit.register(color_reset, log_fp)
+   VERBOSE("version: %s" % version.VERSION)
    VERBOSE("verbose level: %d" % verbose)
    # storage directory
    global storage


### PR DESCRIPTION
We sometimes get debug logs from elsewhere, and it’s not always clear what version was in use. Therefore, just log the version at level `VERBOSE`.