### PR TITLE
GitHub CI cleanups

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,19 +150,11 @@ jobs:
         if: ${{ matrix.pack_fmt == 'squash-mount' }}
         run: |
           set -x
-          sudo apt-get install -y libfuse3-dev
-          # Currently we need the master branch of SquashFUSE.
-          cd /usr/local/src
-          git clone https://github.com/vasi/squashfuse.git
-          cd squashfuse
-          ./autogen.sh
-          ./configure --prefix=/usr/local
-          make
-          sudo sh -c 'umask 0022 && make install'
-          sudo ldconfig
+          # Ubuntu’s SquashFUSE isn’t the necessary version, but it contains a
+          # patch to create the shared library we need.
+          sudo apt-get install -y libfuse3-dev libsquashfuse-dev
           # Unset setuid on all fusermount3(1) on the system.
           sudo chmod -v u-s /usr/bin/fusermount*
-          sudo find / -name 'fusermount*' -ls
           ls -lh $(command -v fusermount3)
           [[ ! -u $(command -v fusermount3) ]]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,23 +14,22 @@ jobs:
     strategy:
       fail-fast: false  # Actions seems kind of flaky lately
       matrix:
-        builder: [none, docker, ch-image]
+        builder:
+          - ch-image
         pack_fmt: [squash-mount, tar-unpack, squash-unpack]
         keep_sudo:   # if false, remove self from sudoers post-install/setup
           - false
-        cache: [enabled, disabled]
-        exclude:
-          - builder: none
-            cache: enabled
-          - builder: docker
-            cache: enabled
-          - builder: ch-image
-            cache: disabled
+        cache:
+          - enabled
         include:
+          - builder: none
+            pack_fmt: squash-mount
+            keep_sudo: false
+            cache: disabled
           - builder: docker
             pack_fmt: squash-mount
             keep_sudo: true
-            cache: disabled
+            cache: enabled
           - builder: ch-image
             pack_fmt: squash-mount
             keep_sudo: false
@@ -65,8 +64,8 @@ jobs:
           echo "PATH=$path_new" >> $GITHUB_ENV
           # Set sudo umask to something quite restrictive. The default is
           # 0022, but we had a "make install" bug (issue #947) that was
-          # tickled by 0027, which is a better setting. For reasons I don't
-          # understand, this only affects sudo, but since that's what we want,
+          # tickled by 0027, which is a better setting. For reasons I don’t
+          # understand, this only affects sudo, but since that’s what we want,
           # I left it. Note there are a few dependency installs below that
           # have similar permissions bugs; these relax the umask on a
           # case-by-case basis.
@@ -104,7 +103,7 @@ jobs:
 
       - name: install/configure dependencies, all
         run: |
-          # configure doesn't tell us about these.
+          # configure doesn’t tell us about these.
           sudo apt-get install attr pigz pv
           # configure does tell us about these.
           sudo apt-get install bats squashfs-tools
@@ -164,7 +163,7 @@ jobs:
         run: |
           sudo apt-get install -y musl-tools
           # At present we use argp to parse command line arguments. This is
-          # not portable; it's a glibc extension (see #1260). Thus, install a
+          # not portable; it’s a glibc extension (see #1260). Thus, install a
           # standalone argp.
           cd /usr/local/src
           git clone --depth=1 https://github.com/ericonr/argp-standalone.git
@@ -203,7 +202,9 @@ jobs:
           sudo usermod --add-subgids 10000-65536 $USER
 
       - name: disable bundled lark, ch-image
-        if: ${{ matrix.builder == 'ch-image' && matrix.cache == 'disabled' }}
+        if: ${{    matrix.builder == 'ch-image'
+                && matrix.pack_fmt == 'squash-mount'
+                && matrix.cache == 'disabled' }}
         run: |
           set -x
           # no install, disable
@@ -247,7 +248,7 @@ jobs:
           # workflow also use glibc.
           if [[ $CH_TEST_PACK_FMT == tar-unpack ]]; then
               export CC=musl-gcc
-              # GNU ldd(1) doesn't work on musl binaries.
+              # GNU ldd(1) doesn’t work on musl binaries.
               LDD='/lib/ld-musl-x86_64.so.1 --list'
           else
               LDD=ldd
@@ -338,7 +339,7 @@ jobs:
         if: ${{ matrix.builder == 'docker' && matrix.keep_sudo }}
         run: |
           # Create and unpack tarball. The wildcard saves us having to put the
-          # version in a variable. This assumes there isn't already a tarball
+          # version in a variable. This assumes there isn’t already a tarball
           # or unpacked directory in $ch_prefix, which is true on the clean
           # VMs GitHub gives us. Note that cd fails if it gets more than one
           # argument, which helps, but this is probably kind of brittle.
@@ -373,7 +374,7 @@ jobs:
           $ch_prefix/from-tarball/bin/ch-run --version
 
       - name: run test suite (Git WD, quick)
-        if: ${{ matrix.builder == 'docker' && ! matrix.keep_sudo }}
+        if: ${{ matrix.builder == 'ch-image' && matrix.cache = 'enabled' }}
         run: |
           bin/ch-test --scope=quick all
 
@@ -382,14 +383,12 @@ jobs:
           bin/ch-test all
 
       - name: run test suite (installed from Git WD, standard)
-        if: ${{    ( matrix.builder == 'docker' && ! matrix.keep_sudo )
-                || (    matrix.builder == 'ch-image'
-                     && matrix.cache == 'disabled' ) }}
+        if: ${{ matrix.builder == ch-image && matrix.cache == 'enabled' }}
         run: |
           $ch_prefix/from-git/bin/ch-test all
 
       - name: run test suite (installed from tarball, standard)
-        if: ${{ matrix.builder == 'docker' && matrix.keep_sudo }}
+        if: ${{ matrix.cache == 'enabled' }}
         run: |
           $ch_prefix/from-tarball/bin/ch-test all
 
@@ -411,7 +410,7 @@ jobs:
           EOF
 
       - name: rebuild with most things --disable’d
-        if: ${{ matrix.builder == 'docker' && ! matrix.keep_sudo }}
+        if: ${{ matrix.builder == 'docker' }}
         run: |
           make distclean
           ./configure --prefix=/doesnotexist \
@@ -430,12 +429,12 @@ jobs:
           bin/ch-run --version
 
       - name: run test suite (Git WD, standard)
-        if: ${{ matrix.builder == 'docker' && ! matrix.keep_sudo }}
+        if: ${{ matrix.builder == 'docker' }}
         run: |
           bin/ch-test all
 
       - name: remove non-essential dependencies
-        if: ${{ matrix.builder == 'docker' && matrix.keep_sudo && matrix.pack_fmt == 'tar-unpack' }}
+        if: ${{ matrix.builder == 'docker' }}
         run: |
           set -x
           # This breaks lots of dependencies unrelated to our build but YOLO.
@@ -454,7 +453,7 @@ jobs:
           bin/ch-test -f test/build/10_sanity.bats  # issue #806
 
       - name: rebuild
-        if: ${{ matrix.builder == 'docker' && matrix.keep_sudo && matrix.pack_fmt == 'tar-unpack' }}
+        if: ${{ matrix.builder == 'docker' }}
         run: |
           make distclean
           ./configure --prefix=/doesnotexist
@@ -470,7 +469,7 @@ jobs:
           bin/ch-run --version
 
       - name: run test suite (Git WD, standard)
-        if: ${{ matrix.builder == 'docker' && matrix.keep_sudo && matrix.pack_fmt == 'tar-unpack' }}
+        if: ${{ matrix.builder == 'docker' }}
         run: |
           bin/ch-test all
 

--- a/test/force-auto.py.in
+++ b/test/force-auto.py.in
@@ -122,7 +122,8 @@ class Test(abc.ABC):
          print(f"\n# skip: {self}: --force=%s excluded" % self.force)
          return
       # scope
-      if (self.scope == Scope.STANDARD or self.run == Run.NEEDED):
+      if (    (self.scope == Scope.STANDARD or self.run == Run.NEEDED)
+          and self.force != "fakeroot"):
          scope = "standard"
       else:
          scope = "full"


### PR DESCRIPTION
Most notably:

1. Use system libsquashfuse.
2. Move some things from (ch-image, ... disabled), which is the slowest matrix item by a lot.
3. Remove several matrix items that I think aren’t telling us too much any more.
4. Only test `--force=fakeroot` in full scope (again for speed).

This should make the tests complete a lot faster (eliminating the intermittent timeouts) and reduce node time used.