### PR TITLE
`Dockerfile.metadata`: `LABEL`: remove underscores

### DIFF
--- a/test/Dockerfile.metadata
+++ b/test/Dockerfile.metadata
@@ -23,8 +23,7 @@ ENTRYPOINT ["/bin/echo","foo"]
 ENV ch_foo=foo-ev ch_bar=bar-ev
 EXPOSE 867 5309/udp
 HEALTHCHECK --interval=60s --timeout=5s CMD ["/bin/true"]
-LABEL ch-foo=foo-label \
-    ch-bar=bar-label
+LABEL ch-foo=foo-label ch-bar=bar-label
 MAINTAINER charlie@example.com
 ONBUILD RUN echo hello
 RUN echo hello

--- a/test/Dockerfile.metadata
+++ b/test/Dockerfile.metadata
@@ -23,7 +23,8 @@ ENTRYPOINT ["/bin/echo","foo"]
 ENV ch_foo=foo-ev ch_bar=bar-ev
 EXPOSE 867 5309/udp
 HEALTHCHECK --interval=60s --timeout=5s CMD ["/bin/true"]
-LABEL ch_foo=foo-label ch_bar=bar-label
+LABEL ch-foo=foo-label \
+    ch-bar=bar-label
 MAINTAINER charlie@example.com
 ONBUILD RUN echo hello
 RUN echo hello


### PR DESCRIPTION
Hi!
The Dockerfile placed at "test/Dockerfile.metadata" contains the best practice violation [DL3048](https://github.com/hadolint/hadolint/wiki/DL3048) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3048 occurs when the pattern used for the label keys does not match the format recommended by official guidelines.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, the label keys are refactored to match the correct format.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance.