### PR TITLE
tutorial: `ch-convert` instead of `ch-image convert`

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -418,7 +418,7 @@ Let’s pull that image and see how it looks::
   almalinux:8
   hello
   hello.2
-  $ ch-image convert hello.2 ./hello.2
+  $ ch-convert hello.2 ./hello.2
   $ ls ./hello.2
   bin    etc    lib    mnt    proc   run    srv    tmp    var
   dev    home   media  opt    root   sbin   sys    usr


### PR DESCRIPTION
Solves an error when working through the tutorial:

> "ch-image: error: argument CMD: invalid choice: 'convert'"