### PR TITLE
`ch-completion`: `ch-run` CLI parser bug fix

### DIFF
--- a/bin/ch-completion.bash
+++ b/bin/ch-completion.bash
@@ -517,7 +517,9 @@ _ch_run_image_finder () {
                     && ${wrds[$ct-1]} != --mount \
                     && ${wrds[$ct-1]} != -m \
                     && ${wrds[$ct-1]} != --bind \
-                    && ${wrds[$ct-1]} != -b ) ]]; then
+                    && ${wrds[$ct-1]} != -b \
+                    && ${wrds[$ct-1]} != -c \
+                    && ${wrds[$ct-1]} != --cd ) ]]; then
                 cli_img="${wrds[$ct]}"
             fi
             if [[ ${wrds[$ct]} == "--" ]]; then


### PR DESCRIPTION
Looks like when I wrote the command line parser for `ch-run` completion I forgot to include the `--cd` option, which led to a bug.