### PR TITLE
fix several CI bugs

### DIFF
--- a/examples/Dockerfile.mpich
+++ b/examples/Dockerfile.mpich
@@ -5,16 +5,17 @@ FROM libfabric
 
 WORKDIR /usr/local/src
 
-# Configure MPICH with OpenPMIx. Note we did attempt to configure MPICH against
-# both PMI2 and PMIx, as we do with OpenMPI, but the examples only pass testing
-# when pmix is specified.
+# Configure MPICH with OpenPMIx. Note we did attempt to configure MPICH
+# against both PMI2 and PMIx, as we do with OpenMPI, but the examples only
+# pass testing when pmix is specified.
 #
-# Note --with-pm=no disables the hydra and gforker process manager, this allows us
-# to launch parallel jobs with slurm using PMIx or PMI2. As a consequence, the
-# mpiexec exectuable is no longer compiled or installed; thus, single-node guest
-# launch using mpiexec inside container is not poassible.
+# Note --with-pm=no disables the hydra and gforker process manager; this
+# allows us to launch parallel jobs with slurm using PMIx or PMI2. As a
+# consequence, the mpiexec exectuable is no longer compiled or installed;
+# thus, single-node guest launch using mpiexec inside container is not
+# poassible.
 #
-# Slingshot cxi requires MPICH version 4.1 or greater.
+# Slingshot CXI requires MPICH version 4.1 or greater.
 ARG MPI_VERSION=4.1.1
 ARG MPI_URL=http://www.mpich.org/static/downloads/${MPI_VERSION}
 RUN wget -nv ${MPI_URL}/mpich-${MPI_VERSION}.tar.gz \
@@ -31,7 +32,7 @@ RUN wget -nv ${MPI_URL}/mpich-${MPI_VERSION}.tar.gz \
                 --with-device=ch4:ofi \
                 --with-libfabric=/usr/local \
                 --with-pm=no \
-                --with-pmix=/usr/local/lib \
+                --with-pmix=/usr/local/lib
 RUN cd mpich-${MPI_VERSION} \
  && make -j$(getconf _NPROCESSORS_ONLN) install \
  && rm -Rf ../mpich-${MPI_VERSION}* \

--- a/examples/Dockerfile.mpich
+++ b/examples/Dockerfile.mpich
@@ -29,7 +29,7 @@ RUN wget -nv ${MPI_URL}/mpich-${MPI_VERSION}.tar.gz \
                 --enable-threads=multiple \
                 --with-ch4-shmmods=posix \
                 --with-device=ch4:ofi \
-                --with-libfabric=/usr/local
+                --with-libfabric=/usr/local \
                 --with-pm=no \
                 --with-pmix=/usr/local/lib \
 RUN cd mpich-${MPI_VERSION} \

--- a/lib/build_cache.py
+++ b/lib/build_cache.py
@@ -409,8 +409,9 @@ class File_Metadata:
 
    def git_restore(self, quick):
       #ch.TRACE(self.str_for_log())  # output is extreme even for TRACE?
-      # Do-nothing case.
-      if (self.dont_restore):
+      # Do-nothing case. Exclude RPM databases explicitly because old caches
+      # can have them left over without being tagged don’t restore.
+      if (self.dont_restore or self.path.match("var/lib/rpm/__db.*")):
          if (not quick and self.path != im.GIT_DIR):
             ch.WARNING("ignoring un-restorable file: /%s" % self.path)
          return

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -720,7 +720,7 @@ def monkey_write_streams():
                "“”’".encode(encoding=encoding)
             except UnicodeEncodeError:
                monkey_write_insert(stream)
-               break
+            break
 
 def now_utc_iso8601():
    return datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z"

--- a/test/old-storage
+++ b/test/old-storage
@@ -100,7 +100,7 @@ for oldtar in $oldtars; do
 
     case ${storage#*-} in
         0.29|0.30|0.31)
-            INFO "working around issue #1662"
+            INFO "working around bug fixed by PR #1662"
             (cd "$storage"/bucache && git branch -D alpine+latest)
             ;;
     esac

--- a/test/old-storage
+++ b/test/old-storage
@@ -98,6 +98,13 @@ for oldtar in $oldtars; do
     export CH_IMAGE_STORAGE=$storage
     INFO "unpacked: $(du -sh "$storage" | cut -f1) bytes in $(du --inodes -sh "$storage" | cut -f1) inodes"
 
+    case ${storage#*-} in
+        0.29|0.30|0.31)
+            INFO "working around issue #1662"
+            (cd "$storage"/bucache && git branch -D alpine+latest)
+            ;;
+    esac
+
     INFO "upgrading"
     ch-image list
 

--- a/test/old-storage
+++ b/test/old-storage
@@ -107,9 +107,6 @@ for oldtar in $oldtars; do
 
     INFO "upgrading"
     ch-image list
-    # These are images that contain references to things on the internet that
-    # go out of date. Re-pull them to get a current base image.
-    ch-image pull centos:7
 
     INFO "testing"
     ch-test -b ch-image --pedantic=no -s "$scope" all

--- a/test/old-storage
+++ b/test/old-storage
@@ -72,7 +72,7 @@ PATH=$(cd "$(dirname "$0")" && pwd)/../bin:$PATH
 export PATH
 
 if [[ -d $1 ]]; then
-    oldtars=$(find "$1" -mindepth 1 -mtime -365 -print)
+    oldtars=$(find "$1" -mindepth 1 -mtime -365 -print | sort)
 else
     oldtars=$(printf '%s ' "$@")  # https://www.shellcheck.net/wiki/SC2124
 fi
@@ -107,6 +107,10 @@ for oldtar in $oldtars; do
 
     INFO "upgrading"
     ch-image list
+    # These are images that contain references to things on the internet that
+    # go out of date, so builds based on them fail. Re-pull them to get a
+    # current base image.
+    ch-image pull archlinux:latest
 
     INFO "testing"
     ch-test -b ch-image --pedantic=no -s "$scope" all

--- a/test/old-storage
+++ b/test/old-storage
@@ -107,6 +107,9 @@ for oldtar in $oldtars; do
 
     INFO "upgrading"
     ch-image list
+    # These are images that contain references to things on the internet that
+    # go out of date. Re-pull them to get a current base image.
+    ch-image pull centos:7
 
     INFO "testing"
     ch-test -b ch-image --pedantic=no -s "$scope" all


### PR DESCRIPTION
This PR fixes multiple bugs that prevent internal and external full-scope tests from passing.

1. Our old-storage storage directories are x86-64, but some versions contain an ARM `alpine:latest` in the cache left over from one test that gets caught by another. Remove it.

2. Fix some typos and word-wrapping in `Dockerfile.mpich`.

3. Don’t restore RPM databases if found in the cache (presumably left over from before PR #1356).

4. Fix indentation error in PR #1631 so it’s applied only when needed, instead of unconditionally.

5. Re-pull some base images (currently only `archlinux:latest`) that break downstream builds if out of date, fixing `old-storage` failures.