### PR TITLE
`cmd_base()`: one environment variable per line

### DIFF
--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -494,7 +494,8 @@ def cmd_base(argv, fail_ok=False, **kwargs):
    argv = [str(i) for i in argv]
    VERBOSE("executing: %s" % argv_to_string(argv))
    if ("env" in kwargs):
-      VERBOSE("environment: %s" % kwargs["env"])
+      for (k,v) in sorted(kwargs["env"].items()):
+         VERBOSE("env: %s=%s" % (k,v))
    if ("stderr" not in kwargs):
       if (verbose <= 1):  # VERBOSE or lower: capture for printing on fail only
          kwargs["stderr"] = subprocess.PIPE


### PR DESCRIPTION
Closes #1672.