### PR TITLE
`ch-image`: error out when `CMD` not specified

### DIFF
--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -601,6 +601,8 @@ def exit(code):
 def init(cli):
    # logging
    global log_festoon, log_fp, trace_fatal, verbose
+   if (not hasattr(cli, "func")):
+      FATAL("CMD not specified, try “ch-image --help”")
    assert (0 <= cli.verbose <= 3)
    verbose = cli.verbose
    trace_fatal = (cli.debug or bool(os.environ.get("CH_IMAGE_DEBUG", False)))

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -211,6 +211,8 @@ class ArgumentParser(argparse.ArgumentParser):
 
    def parse_args(self, *args, **kwargs):
       cli = super().parse_args(*args, **kwargs)
+      if (not hasattr(cli, "func")):
+         self.error("CMD not specified")
       # Bring in environment variables that set options.
       if (cli.bucache is None and "CH_IMAGE_CACHE" in os.environ):
          try:
@@ -601,8 +603,6 @@ def exit(code):
 def init(cli):
    # logging
    global log_festoon, log_fp, trace_fatal, verbose
-   if (not hasattr(cli, "func")):
-      FATAL("CMD not specified, try “ch-image --help”")
    assert (0 <= cli.verbose <= 3)
    verbose = cli.verbose
    trace_fatal = (cli.debug or bool(os.environ.get("CH_IMAGE_DEBUG", False)))


### PR DESCRIPTION
closes #1691