### PR TITLE
Actions: Update checkout to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       ch_prefix: /var/tmp
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: early setup & validation
         run: |


### PR DESCRIPTION
This should silence a warning in the Actions tab.