### PR TITLE
add `--debug` to `ch-image` docs

### DIFF
--- a/doc/ch-image.rst
+++ b/doc/ch-image.rst
@@ -76,6 +76,10 @@ Common options placed before or after the sub-command:
     **Experimental.** See section :ref:`Large file threshold
     <ch-image_bu-large>` for details.
 
+  :code:`--debug`
+    Add a stack trace to fatal error hints. This can also be done by setting
+    the environment variable `CH_IMAGE_DEBUG`.
+
   :code:`--no-cache`
     Disable build cache. Default if a sufficiently new Git is not available.
     This option turns off the cache completely; if you want to re-execute a


### PR DESCRIPTION
It looks like `--debug` was somehow excluded from the section on `ch-image` on our documentation page. This PR fixes that.