### PR TITLE
copy large files instead of hard linking

### DIFF
--- a/lib/build_cache.py
+++ b/lib/build_cache.py
@@ -537,8 +537,8 @@ class File_Metadata:
    def large_restore(self):
       "Hard link my file to the copy in large file storage."
       target = ch.storage.build_large_path(self.large_name)
-      ch.DEBUG("large file: %s: linking: %s" % (self.path_abs, self.large_name))
-      self.path_abs.hardlink(target)
+      ch.DEBUG("large file: %s: copying: %s" % (self.path_abs, self.large_name))
+      ch.copy2(target, self.path_abs)
 
    def pickle(self):
       (self.image_root // PICKLE_PATH) \


### PR DESCRIPTION
Closes #1740.

Turns out hard links are not copy-on-write like we (implicitly) assumed. 🙄 Therefore we must copy the large files back.

In a future PR I hope to have some performance improvements for this.