### PR TITLE
use kernel fast paths for file copying

### DIFF
--- a/lib/build.py
+++ b/lib/build.py
@@ -206,7 +206,7 @@ def main(cli_):
            % (ml.instruction_total_ct, ml.inst_prev.image))
    # FIXME: remove when we’re done encouraging people to use the build cache.
    if (isinstance(bu.cache, bu.Disabled_Cache)):
-      ch.INFO("build slow? consider enabling the new build cache",
+      ch.INFO("build slow? consider enabling the build cache",
               "https://hpc.github.io/charliecloud/command-usage.html#build-cache")
 
 

--- a/lib/build.py
+++ b/lib/build.py
@@ -767,7 +767,7 @@ class I_copy(Instruction):
                   dst_path.rmtree()
                else:
                   dst_path.unlink_()
-            ch.copy2(src_path, dst_path, follow_symlinks=False)
+            src_path.copy(dst_path)
 
    def copy_src_file(self, src, dst):
       """Copy file src to dst. src might be a symlink, but dst is a canonical
@@ -789,8 +789,11 @@ class I_copy(Instruction):
       assert (not dst.is_symlink())
       assert (   (dst.exists() and (dst.is_dir() or dst.is_file()))
               or (not dst.exists() and dst.parent.is_dir()))
+      if (dst.is_dir()):
+         dst = dst.parent // src.name
+      src = src.resolve()
       ch.DEBUG("copying named file: %s -> %s" % (src, dst))
-      ch.copy2(src, dst, follow_symlinks=True)
+      src.copy(dst)
 
    def dest_realpath(self, unpack_path, dst):
       """Return the canonicalized version of path dst within (canonical) image

--- a/lib/build.py
+++ b/lib/build.py
@@ -790,7 +790,7 @@ class I_copy(Instruction):
       assert (   (dst.exists() and (dst.is_dir() or dst.is_file()))
               or (not dst.exists() and dst.parent.is_dir()))
       if (dst.is_dir()):
-         dst = dst.parent // src.name
+         dst //= src.name
       src = src.resolve()
       ch.DEBUG("copying named file: %s -> %s" % (src, dst))
       src.copy(dst)

--- a/lib/build_cache.py
+++ b/lib/build_cache.py
@@ -538,10 +538,10 @@ class File_Metadata:
       return large_name
 
    def large_restore(self):
-      "Hard link my file to the copy in large file storage."
+      "Restore large file from OOB storage."
       target = ch.storage.build_large_path(self.large_name)
       ch.DEBUG("large file: %s: copying: %s" % (self.path_abs, self.large_name))
-      ch.copy2(target, self.path_abs)
+      fs.copy(target, self.path_abs)
 
    def pickle(self):
       (self.image_root // PICKLE_PATH) \

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -609,10 +609,6 @@ def color_set(color, fp):
    if (fp.isatty()):
       print("\033[" + color, end="", flush=True, file=fp)
 
-def copy2(src, dst, **kwargs):
-   "Wrapper for shutil.copy2() with error checking."
-   ossafe(shutil.copy2, "can’t copy: %s -> %s" % (src, dst), src, dst, **kwargs)
-
 def dependencies_check():
    """Check more dependencies. If any dependency problems found, here or above
       (e.g., lark module checked at import time), then complain and exit."""

--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -245,18 +245,20 @@ class Path(pathlib.PosixPath):
             os.close(src_fd)
             os.close(dst_fd)
          except OSError as x:
-            FATAL("can’t copy (fast): %s -> %s: %s" % (self, dst, x.strerror))
+            ch.FATAL("can’t copy data (fast): %s -> %s: %s"
+                     % (self, dst, x.strerror))
       else:
          # Slow path.
          try:
             shutil.copyfile(self, dst, follow_symlinks=False)
          except OSError as x:
-            FATAL("can’t copy (slow): %s -> %s: %s" % (self, dst, x.strerror))
+            ch.FATAL("can’t copy data (slow): %s -> %s: %s"
+                     % (self, dst, x.strerror))
       try:
          # Metadata.
          shutil.copystat(self, dst, follow_symlinks=False)
       except OSError as x:
-         FATAL("can’t copy metadata: %s -> %s" % (self, dst, x.strerror))
+         ch.FATAL("can’t copy metadata: %s -> %s" % (self, dst, x.strerror))
 
    def copytree(self, *args, **kwargs):
       "Wrapper for shutil.copytree() that exits on the first error."

--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -32,6 +32,16 @@ STORAGE_VERSION = 7
 storage_lock = True
 
 
+### Functions ###
+
+def copy(src, dst, follow_symlinks=False):
+   """Copy file src to dst. Wrapper function providing same signature as
+      shutil.copy2(). See Path.copy() for lots of gory details. Accepts
+      follow_symlinks, but the only valid value is False."""
+   assert (not follow_symlinks)
+   src.copy(dst)
+
+
 ## Classes ##
 
 class Path(pathlib.PosixPath):
@@ -187,9 +197,67 @@ class Path(pathlib.PosixPath):
          ch.ossafe(os.chmod, "can’t chmod: %s" % self, self, perms_new)
       return (st.st_mode | perms_new)
 
+   def copy(self, dst):
+      """Copy file myself to dst, including metadata, overwriting dst if it
+         exists. dst must be the actual destination path, i.e., it may not be
+         a directory. Does not follow symlinks.
+
+         If (a) src is a regular file, (b) src and dst are on the same
+         filesystem, and (c) Python is version ≥3.8, then use
+         os.copy_file_range() [1,2], which at a minimum does an in-kernel data
+         transfer. If that filesystem also (d) supports copy-on-write [3],
+         then this is a very fast lazy reflink copy.
+
+         [1]: https://docs.python.org/3/library/os.html#os.copy_file_range
+         [2]: https://man7.org/linux/man-pages/man2/copy_file_range.2.html
+         [3]: https://elixir.bootlin.com/linux/latest/A/ident/remap_file_range
+      """
+      assert (not follow_symlinks)
+      src_st = self.stat_(follow_symlinks=False)
+      # dst is not a directory, so parent must be on the same filesystem. We
+      # *do* want to follow symlinks on the parent.
+      dst_dev = dst.parent.stat_(follow_symlinks=True).st_dev
+      if (    stat.S_ISREG(src_st.st_mode)
+          and src_st.st_dev == dst_dev
+          and hasattr(os, "copy_file_range")):
+         # Fast path. The same-filesystem restriction is because reliable
+         # copy_file_range(2) between filesystems seems quite new (maybe
+         # kernel 5.18?).
+         try:
+            if (dst.exists()):
+               # If dst is a symlink, we get OLOOP from os.open(). Delete it
+               # unconditionally though, for simplicity.
+               dst.unlink()
+            src_fd = os.open(self, os.O_RDONLY|os.O_NOFOLLOW)
+            dst_fd = os.open(dst, os.O_WRONLY|os.O_NOFOLLOW|os.O_CREAT)
+            # I’m not sure why we need to loop this -- there’s no explanation
+            # of *when* fewer bytes than requested would be copied -- but the
+            # man page example does.
+            remaining = src_st.st_size
+            while (remaining > 0):
+               copied = os.copy_file_range(src_fd, dst_fd, sys.maxsize)
+               if (copied == 0):
+                  ch.FATAL("zero bytes copied: %s -> %s" % (self, dst))
+               remaining -= copied
+            os.close(src_fd)
+            os.close(dst_fd)
+         except OSError as x:
+            FATAL("can’t copy (fast): %s -> %s: %s" % (self, dst, x.strerror))
+      else:
+         # Slow path.
+         try:
+            shutil.copyfile(self, dst, follow_symlinks=False)
+         except OSError as x:
+            FATAL("can’t copy (slow): %s -> %s: %s" % (self, dst, x.strerror))
+      try:
+         # Metadata.
+         shutil.copystat(self, dst, follow_symlinks=False)
+      except OSError as x:
+         FATAL("can’t copy metadata: %s -> %s" % (self, dst, x.strerror))
+
    def copytree(self, *args, **kwargs):
       "Wrapper for shutil.copytree() that exits on the first error."
-      shutil.copytree(str(self), copy_function=ch.copy2, *args, **kwargs)
+      shutil.copytree(str(self), copy_function=copy, *args, **kwargs)
 
    def disk_bytes(self):
       """Return the number of disk bytes consumed by path. Note this is
@@ -435,7 +503,7 @@ class Path(pathlib.PosixPath):
          follow_symlinks kwarg is absent in pathlib for Python 3.6, which we
          want to retain compatibility with."""
       return ch.ossafe(os.stat, "can’t stat: %s" % self, self,
-                    follow_symlinks=links)
+                       follow_symlinks=links)
 
    def strip(self, left=0, right=0):
       """Return a copy of myself with n leading components removed. E.g.:

--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -212,11 +212,10 @@ class Path(pathlib.PosixPath):
          [2]: https://man7.org/linux/man-pages/man2/copy_file_range.2.html
          [3]: https://elixir.bootlin.com/linux/latest/A/ident/remap_file_range
       """
-      assert (not follow_symlinks)
-      src_st = self.stat_(follow_symlinks=False)
+      src_st = self.stat_(False)
       # dst is not a directory, so parent must be on the same filesystem. We
       # *do* want to follow symlinks on the parent.
-      dst_dev = dst.parent.stat_(follow_symlinks=True).st_dev
+      dst_dev = dst.parent.stat_(True).st_dev
       if (    stat.S_ISREG(src_st.st_mode)
           and src_st.st_dev == dst_dev
           and hasattr(os, "copy_file_range")):
@@ -235,7 +234,7 @@ class Path(pathlib.PosixPath):
             # man page example does.
             remaining = src_st.st_size
             while (remaining > 0):
-               copied = os.copy_file_range(src_fd, dst_fd, sys.maxsize)
+               copied = os.copy_file_range(src_fd, dst_fd, remaining)
                if (copied == 0):
                   ch.FATAL("zero bytes copied: %s -> %s" % (self, dst))
                remaining -= copied

--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -39,6 +39,10 @@ def copy(src, dst, follow_symlinks=False):
       shutil.copy2(). See Path.copy() for lots of gory details. Accepts
       follow_symlinks, but the only valid value is False."""
    assert (not follow_symlinks)
+   if (isinstance(src, str)):
+      src = Path(src)
+   if (isinstance(dst, str)):
+      dst = Path(dst)
    src.copy(dst)
 
 
@@ -256,7 +260,7 @@ class Path(pathlib.PosixPath):
 
    def copytree(self, *args, **kwargs):
       "Wrapper for shutil.copytree() that exits on the first error."
-      shutil.copytree(str(self), copy_function=copy, *args, **kwargs)
+      shutil.copytree(self, copy_function=copy, *args, **kwargs)
 
    def disk_bytes(self):
       """Return the number of disk bytes consumed by path. Note this is

--- a/lib/image.py
+++ b/lib/image.py
@@ -396,7 +396,7 @@ class Image:
       else:
          # Copy pulled config file into the image so we still have it.
          path = self.metadata_path // "config.pulled.json"
-         ch.copy2(config_json, path)
+         config_json.copy(path)
          ch.VERBOSE("pulled config path: %s" % path)
          self.metadata_merge_from_config(path.json_from_file("config"))
       self.metadata_save()

--- a/test/build/50_dockerfile.bats
+++ b/test/build/50_dockerfile.bats
@@ -159,7 +159,7 @@ test 7a
 test 7 b
 --force=seccomp: modified 0 RUN instructions
 grown in 16 instructions: tmpimg
-build slow? consider enabling the new build cache
+build slow? consider enabling the build cache
 hint: https://hpc.github.io/charliecloud/command-usage.html#build-cache
 warning: reprinting 1 warning(s)
 warning: not yet supported, ignored: issue #777: .dockerignore file

--- a/test/build/55_cache.bats
+++ b/test/build/55_cache.bats
@@ -1326,7 +1326,7 @@ EOF
     [[ -z $output ]]
 
     echo
-    echo '*** threshold = 4'
+    echo '*** threshold = 5'
     ch-image build-cache --reset
     echo "$df" | ch-image build --cache-large=5 -t tmpimg -
     run ls "$CH_IMAGE_STORAGE"/bularge
@@ -1337,7 +1337,7 @@ b2dbc2a2bb35d6d0d5590aedc122cab6%bigfile5
 EOF
 
     echo
-    echo '*** threshold = 3, rebuild'
+    echo '*** threshold = 4, rebuild'
     echo "$df" | ch-image build --rebuild --cache-large=4 -t tmpimg -
     run ls "$CH_IMAGE_STORAGE"/bularge
     echo "$output"
@@ -1349,7 +1349,7 @@ b2dbc2a2bb35d6d0d5590aedc122cab6%bigfile5
 EOF
 
     echo
-    echo '*** threshold = 3, reset'
+    echo '*** threshold = 4, reset'
     ch-image build-cache --reset
     echo "$df" | ch-image build --rebuild --cache-large=4 -t tmpimg -
     run ls "$CH_IMAGE_STORAGE"/bularge


### PR DESCRIPTION
`ch-image` does a lot of file copying. In particular, as of PR #1741, build cache large files that are stored OOB are copied instead of hard-linked.

The Linux kernel has two fast paths for copying regular files:

1. Make a *reflink* copy, where the destination file gets a new inode but shares all the data extents of the source file in a copy-on-write manner. Some filesystems support this.
 
2. Copy data in-kernel without passing through user-space. All filesystems support this.

Python ≥3.8 introduces `os.copy_file_range()` that wraps the underlying system call [`copy_file_range(2)`](https://man7.org/linux/man-pages/man2/copy_file_range.2.html), which does #1 if possible and silently falls back to #2 if not.

This PR implements a fast-path copy that calls `os.copy_file_range()` if available and the source and destination are on the same filesystem. This should mitigate the performance loss in #1741 to some degree.