### PR TITLE
re-enable Arch Linux rootemu tests

### DIFF
--- a/test/force-auto.py.in
+++ b/test/force-auto.py.in
@@ -300,10 +300,7 @@ class T_OpenSUSE_Leap_Latest(SUSE):
 
 # Arch has tons of old tags, versioned by date, on Docker Hub. However, only
 # :latest (or equivalently :base) is documented.
-#
-# FIXME: This is currently disabled due to GPG key problems (#1722)
-#class T_Arch_Latest(Test):
-class Arch_Latest(Test):
+class T_Arch_Latest(Test):
    config = "arch"
    base = "archlinux:latest"
    arch_excludes = ["aarch64", "ppc64le"]  # base only amd64


### PR DESCRIPTION
Closes #1722.

The problem seems to have been fixed upstream, so just revert PR #1723.