### PR TITLE
re-order arguments for `ch.ossafe`

### DIFF
--- a/bin/ch-run-oci.py.in
+++ b/bin/ch-run-oci.py.in
@@ -173,7 +173,7 @@ def op_create():
    # Start dummy supervisor.
    if (state.pid is not None):
       ch.FATAL("container already created")
-   pid = ch.ossafe(os.fork, "can’t fork")
+   pid = ch.ossafe("can’t fork", os.fork)
    if (pid == 0):
       # Child; the only reason to exist is so Buildah sees a process when it
       # looks for one. Sleep until told to exit.
@@ -311,7 +311,7 @@ def state_load():
 
    try:
       fp = open(args.pid_file, "rt")
-      st.pid = int(ch.ossafe(fp.read, "can’t read: %s" % args.pid_file))
+      st.pid = int(ch.ossafe("can’t read: %s" % args.pid_file, fp.read))
       ch.VERBOSE("found supervisor pid: %d" % st.pid)
    except FileNotFoundError:
       st.pid = None

--- a/lib/build.py
+++ b/lib/build.py
@@ -136,12 +136,12 @@ def main(cli_):
 
    # Read input file.
    if (cli.file == "-" or cli.context == "-"):
-      text = ch.ossafe(sys.stdin.read, "can’t read stdin")
+      text = ch.ossafe("can’t read stdin", sys.stdin.read)
    elif (not os.path.isdir(cli.context)):
       ch.FATAL("context must be a directory: %s" % cli.context)
    else:
       fp = fs.Path(cli.file).open_("rt")
-      text = ch.ossafe(fp.read, "can’t read: %s" % cli.file)
+      text = ch.ossafe("can’t read: %s" % cli.file, fp.read)
       ch.close_(fp)
 
    # Parse it.
@@ -829,12 +829,11 @@ class I_copy(Copy):
             # If destination directory doesn’t exist, create it.
             if (not os.path.exists(dst_path)):
                ch.TRACE("mkdir dst_path")
-               ch.ossafe(os.mkdir, "can’t mkdir: %s" % dst_path, dst_path)
+               ch.ossafe("can’t mkdir: %s" % dst_path, os.mkdir, dst_path)
             # Copy metadata, now that we know the destination exists and is a
             # directory.
-            ch.ossafe(shutil.copystat,
-                      "can’t copy metadata: %s -> %s" % (src_path, dst_path),
-                      src_path, dst_path, follow_symlinks=False)
+            ch.ossafe("can’t copy metadata: %s -> %s" % (src_path, dst_path),
+                      shutil.copystat, src_path, dst_path, follow_symlinks=False)
          for f in filenames:
             src_path = dirpath // f
             dst_path = dst_dir // f

--- a/lib/build_cache.py
+++ b/lib/build_cache.py
@@ -276,13 +276,14 @@ class File_Metadata:
       self.large_name = None
       self.xattrs = dict()
       if ch.save_xattrs:
-         for xattr in ch.ossafe(os.listxattr,
-                                "can’t list xattrs: %s" % self.path_abs,
-                                self.path_abs, follow_symlinks=False):
+         for xattr in ch.ossafe("can’t list xattrs: %s" % self.path_abs,
+                                os.listxattr, self.path_abs,
+                                follow_symlinks=False):
             self.xattrs[xattr] = \
-               ch.ossafe(os.getxattr, ("can’t get xattr: %s: %s"
+               ch.ossafe(("can’t get xattr: %s: %s"
                                        % (self.path_abs, xattr)),
-                         self.path_abs, xattr, follow_symlinks=False)
+                         os.getxattr, self.path_abs, xattr,
+                         follow_symlinks=False)
 
    def __getstate__(self):
       return { a:v for (a,v) in self.__dict__.items()
@@ -475,15 +476,15 @@ class File_Metadata:
          # to subsequent (unstored) links.
          target = self.image_root // self.hardlink_to
          ch.DEBUG("hard link: restoring: %s -> %s" % (self.path_abs, target))
-         ch.ossafe(os.link, "can’t hardlink: %s -> %s" % (self.path_abs,
-                                                          target),
-                   target, self.path_abs, follow_symlinks=False)
+         ch.ossafe("can’t hardlink: %s -> %s" % (self.path_abs,
+                                                       target),
+                   os.link, target, self.path_abs, follow_symlinks=False)
       elif (self.large_name is not None):
          self.large_restore()
       elif (self.empty_dir_p):
-         ch.ossafe(os.mkdir, "can’t mkdir: %s" % self.path, self.path_abs)
+         ch.ossafe("can’t mkdir: %s" % self.path, os.mkdir, self.path_abs)
       elif (stat.S_ISFIFO(self.mode)):
-         ch.ossafe(os.mkfifo, "can’t make FIFO: %s" % self.path, self.path_abs)
+         ch.ossafe("can’t make FIFO: %s" % self.path, os.mkfifo, self.path_abs)
       elif (self.path.git_incompatible_p):
          self.path_abs.git_escaped.rename_(self.path_abs)
       for (xattr, val) in self.xattrs.items():
@@ -498,9 +499,9 @@ class File_Metadata:
            or stat.S_ISDIR(self.mode)        # maybe just created or modified
            or stat.S_ISFIFO(self.mode))      # we just made the FIFO
           and not stat.S_ISLNK(self.mode)):  # can’t not follow symlinks
-         ch.ossafe(os.utime, "can’t restore times: %s" % self.path_abs,
+         ch.ossafe("can’t restore times: %s" % self.path_abs, os.utime,
                    self.path_abs, ns=(self.atime_ns, self.mtime_ns))
-         ch.ossafe(os.chmod, "can’t restore mode: %s" % self.path_abs,
+         ch.ossafe("can’t restore mode: %s" % self.path_abs, os.chmod,
                    self.path_abs, stat.S_IMODE(self.mode))
 
    def large_name_get(self):
@@ -850,7 +851,7 @@ class Enabled_Cache:
          ch.VERBOSE("writing updated Git config")
          fp.seek(0)
          fp.truncate()
-         ch.ossafe(config.write, "can’t write Git config: %s" % path, fp)
+         ch.ossafe("can’t write Git config: %s" % path, config.write, fp)
       ch.close_(fp)
       # Ignore list entries:
       #
@@ -1100,7 +1101,7 @@ class Enabled_Cache:
          pid_path = ch.storage.build_cache // "gc.pid"
          try:
             fp = open(pid_path, "rt", encoding="UTF-8")
-            text = ch.ossafe(fp.read, "can’t read: %s" % pid_path)
+            text = ch.ossafe("can’t read: %s" % pid_path, fp.read)
             pid = int(text.split()[0])
             ch.INFO("stopping build cache garbage collection, PID %d" % pid)
             ch.kill_blocking(pid)

--- a/lib/charliecloud.py
+++ b/lib/charliecloud.py
@@ -379,7 +379,7 @@ class Progress_Reader:
          close_(self.fp)
 
    def read(self, size=-1):
-     data = ossafe(self.fp.read, "can’t read: %s" % self.fp.name, size)
+     data = ossafe("can’t read: %s" % self.fp.name, self.fp.read, size)
      self.progress.update(len(data))
      return data
 
@@ -440,7 +440,7 @@ class Progress_Writer:
 
    def write(self, data):
       self.progress.update(len(data))
-      ossafe(self.fp.write, "can’t write: %s" % self.path, data)
+      ossafe("can’t write: %s" % self.path, self.fp.write, data)
 
 
 class Timer:
@@ -528,7 +528,7 @@ def close_(fp):
       path = fp.name
    except AttributeError:
       path = "(no path)"
-   ossafe(fp.close, "can’t close: %s" % path)
+   ossafe("can’t close: %s" % path, fp.close)
 
 def cmd(argv, fail_ok=False, **kwargs):
    """Run command using cmd_base(). If fail_ok, return the exit code whether
@@ -776,7 +776,7 @@ def monkey_write_streams():
 def now_utc_iso8601():
    return datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z"
 
-def ossafe(f, msg, *args, **kwargs):
+def ossafe(msg, f, *args, **kwargs):
    """Call f with args and kwargs. Catch OSError and other problems and fail
       with a nice error message."""
    try:

--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -215,8 +215,8 @@ class Path(pathlib.PosixPath):
 
    def chdir(self):
       "Change CWD to path and return previous CWD. Exit on error."
-      old = ch.ossafe(os.getcwd, "can’t get cwd(2)")
-      ch.ossafe(os.chdir, "can’t chdir: %s" % self.name, self)
+      old = ch.ossafe("can’t get cwd(2)", os.getcwd)
+      ch.ossafe("can’t chdir: %s" % self.name, os.chdir, self)
       return Path(old)
 
    def chmod_min(self, st=None):
@@ -238,7 +238,7 @@ class Path(pathlib.PosixPath):
       if (perms_new != perms_old):
          ch.VERBOSE("fixing permissions: %s: %03o -> %03o"
                  % (self, perms_old, perms_new))
-         ch.ossafe(os.chmod, "can’t chmod: %s" % self, self, perms_new)
+         ch.ossafe("can’t chmod: %s" % self, os.chmod, self, perms_new)
       return (st.st_mode | perms_new)
 
    def copy(self, dst):
@@ -359,8 +359,8 @@ class Path(pathlib.PosixPath):
       # to ensure layer hash is consistent. See issue #1080.
       # [1]: https://datatracker.ietf.org/doc/html/rfc1952 §2.3.1
       fp = path_c.open_("r+b")
-      ch.ossafe(fp.seek, "can’t seek: %s" % fp, 4)
-      ch.ossafe(fp.write, "can’t write: %s" % fp, b'\x00\x00\x00\x00')
+      ch.ossafe("can’t seek: %s" % fp, fp.seek, 4)
+      ch.ossafe("can’t write: %s" % fp, fp.write, b'\x00\x00\x00\x00')
       ch.close_(fp)
       return path_c
 
@@ -370,7 +370,7 @@ class Path(pathlib.PosixPath):
       fp = self.open_("rb")
       h = hashlib.sha256()
       while True:
-         data = ch.ossafe(fp.read, "can’t read: %s" % self.name, 2**18)
+         data = ch.ossafe("can’t read: %s" % self.name, fp.read, 2**18)
          if (len(data) == 0):
             break  # EOF
          h.update(data)
@@ -387,13 +387,13 @@ class Path(pathlib.PosixPath):
          mode = "rb"
          encoding = None
       fp = self.open_(mode, encoding=encoding)
-      data = ch.ossafe(fp.read, "can’t read: %s" % self.name)
+      data = ch.ossafe("can’t read: %s" % self.name, fp.read)
       ch.close_(fp)
       return data
 
    def file_size(self, follow_symlinks=False):
       "Return the size of file at path in bytes."
-      st = ch.ossafe(os.stat, "can’t stat: %s" % self.name,
+      st = ch.ossafe("can’t stat: %s" % self.name, os.stat,
                   self, follow_symlinks=follow_symlinks)
       return st.st_size
 
@@ -401,7 +401,7 @@ class Path(pathlib.PosixPath):
       if (isinstance(content, str)):
          content = content.encode("UTF-8")
       fp = self.open_("wb")
-      ch.ossafe(fp.write, "can’t write: %s" % self.name, content)
+      ch.ossafe("can’t write: %s" % self.name, fp.write, content)
       ch.close_(fp)
 
    def grep_p(self, rx):
@@ -485,7 +485,7 @@ class Path(pathlib.PosixPath):
          and parent (..). We considered changing this to use os.scandir() for
          #992, but decided that the advantages it offered didn’t warrant the
          effort required to make the change."""
-      return set(ch.ossafe(os.listdir, "can’t list: %s" % self.name, self))
+      return set(ch.ossafe("can’t list: %s" % self.name, os.listdir, self))
 
    def mkdir_(self):
       ch.TRACE("ensuring directory: %s" % self)
@@ -506,9 +506,8 @@ class Path(pathlib.PosixPath):
                                                x.strerror))
 
    def open_(self, mode, *args, **kwargs):
-      return ch.ossafe(super().open,
-                       "can’t open for %s: %s" % (mode, self.name),
-                       mode, *args, **kwargs)
+      return ch.ossafe("can’t open for %s: %s" % (mode, self.name),
+                       super().open, mode, *args, **kwargs)
 
    def relative_to(self, other):  # FIXME: does not support component-wise
       ret = super().relative_to(other)
@@ -518,9 +517,8 @@ class Path(pathlib.PosixPath):
    def rename_(self, name_new):
       if (Path(name_new).exists()):
          ch.FATAL("can’t rename: destination exists: %s" % name_new)
-      ch.ossafe(super().rename,
-                "can’t rename: %s -> %s" % (self.name, name_new),
-                name_new)
+      ch.ossafe("can’t rename: %s -> %s" % (self.name, name_new),
+                super().rename, name_new)
 
    def resolve(self, *args, **kwargs):
       ret = super().resolve(*args, **kwargs)
@@ -528,7 +526,7 @@ class Path(pathlib.PosixPath):
       return ret
 
    def rmdir_(self):
-      ch.ossafe(super().rmdir, "can’t rmdir: %s" % self.name)
+      ch.ossafe("can’t rmdir: %s" % self.name, super().rmdir)
 
    def rmtree(self):
       if (self.is_dir()):
@@ -567,7 +565,7 @@ class Path(pathlib.PosixPath):
          NOTE: We also cannot just call super().stat here because the
          follow_symlinks kwarg is absent in pathlib for Python 3.6, which we
          want to retain compatibility with."""
-      return ch.ossafe(os.stat, "can’t stat: %s" % self, self,
+      return ch.ossafe("can’t stat: %s" % self, self, os.stat,
                        follow_symlinks=links)
 
    def stat_bytes(self, links=False):
@@ -625,7 +623,7 @@ class Path(pathlib.PosixPath):
       # FIXME: Once we require Python 3.8, we can just pass through missing_ok.
       if (missing_ok and not self.exists_()):
          return
-      ch.ossafe(super().unlink, "can’t unlink: %s" % self.name)
+      ch.ossafe("can’t unlink: %s" % self.name, super().unlink)
 
 
 class Storage:

--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -565,7 +565,7 @@ class Path(pathlib.PosixPath):
          NOTE: We also cannot just call super().stat here because the
          follow_symlinks kwarg is absent in pathlib for Python 3.6, which we
          want to retain compatibility with."""
-      return ch.ossafe("can’t stat: %s" % self, self, os.stat,
+      return ch.ossafe("can’t stat: %s" % self, os.stat, self,
                        follow_symlinks=links)
 
    def stat_bytes(self, links=False):


### PR DESCRIPTION
closes #1761.