### PR TITLE
don’t follow symlinks when setting xattrs

### DIFF
--- a/lib/build_cache.py
+++ b/lib/build_cache.py
@@ -488,7 +488,7 @@ class File_Metadata:
       elif (not self.path.git_compatible_p):
          self.path_abs.git_escaped.rename(self.path_abs)
       for (xattr, val) in self.xattrs.items():
-         self.path_abs.setxattr(xattr, val, follow_symlinks=False)
+         self.path_abs.setxattr(xattr, val)
       # Recurse children.
       if (len(self.children) > 0):
          for child in self.children.values():

--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -951,10 +951,10 @@ class Path(os.PathLike):
          ch.FATAL("can’t recursively delete directory %s: %s: %s"
                   % (self, x.filename, x.strerror))
 
-   def setxattr(self, name, value, follow_symlinks=True):
+   def setxattr(self, name, value):
       if (ch.save_xattrs):
          try:
-            os.setxattr(self, name, value, follow_symlinks)
+            os.setxattr(self, name, value, follow_symlinks=False)
          except OSError as x:
             if (x.errno == errno.ENOTSUP):  # no OSError subclass
                ch.WARNING("xattrs not supported on %s, setting --no-xattr"


### PR DESCRIPTION
The call to `os.setxattr` erroneously passed our `follow_symlinks` to `flags`, not `follow_symlinks`. Therefore, we always followed symlinks, and set `os.XATTR_CREATE` if our `follow_symlinks` was True. This caused failures with image `fedora:35` on a Fedora 38 host, which has xattrs on image `/etc/mtab`, which is a symlink to `../proc/self/mounts`, which is broken until containerized (see #1774).

We only ever call `Path.setxattr()` with `follow_symlinks=False`, so this PR removes the keyword argument and unconditionally does not follow symlinks.

