### PR TITLE
add `--write-fake` via unprivileged overlayfs

### DIFF
--- a/bin/ch-run.c
+++ b/bin/ch-run.c
@@ -27,6 +27,9 @@ char *JOIN_CT_ENV[] =  { "OMPI_COMM_WORLD_LOCAL_SIZE",
 char *JOIN_TAG_ENV[] = { "SLURM_STEP_ID",
                          NULL };
 
+/* Default overlaid tmpfs size. */
+char *WRITE_FAKE_DEFAULT = "12%";
+
 
 /** Command line options **/
 
@@ -75,7 +78,9 @@ const struct argp_option options[] = {
    { "verbose",       'v', 0,      0, "be more verbose (can be repeated)" },
    { "version",       'V', 0,      0, "print version and exit" },
    { "warnings",      -16, "NUM",  0, "log NUM warnings and exit" },
-   { "write",         'w', 0,      0, "mount image read-write"},
+   { "write",         'w', 0,      0, "mount image read-write (avoid)"},
+   { "write-fake",    'W', "SIZE", OPTION_ARG_OPTIONAL,
+                           "overlay read-write tmpfs on top of image" },
    { 0 }
 };
 
@@ -155,6 +160,7 @@ int main(int argc, char *argv[])
                                .join_ct = 0,
                                .join_pid = 0,
                                .join_tag = NULL,
+                               .overlay_size = NULL,
                                .private_passwd = false,
                                .private_tmp = false,
                                .type = IMG_NONE,
@@ -173,7 +179,7 @@ int main(int argc, char *argv[])
       argp_help_fmt_set = true;
    else {
       argp_help_fmt_set = false;
-      Z_ (setenv("ARGP_HELP_FMT", "opt-doc-col=25,no-dup-args-note", 0));
+      Z_ (setenv("ARGP_HELP_FMT", "opt-doc-col=27,no-dup-args-note", 0));
    }
    Z_ (argp_parse(&argp, argc, argv, 0, &arg_next, &args));
    if (!argp_help_fmt_set)
@@ -457,6 +463,8 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
       break;
    case -12: // --home
       Tf (args->c.host_home = getenv("HOME"), "--home failed: $HOME not set");
+      if (args->c.overlay_size == NULL)
+         args->c.overlay_size = WRITE_FAKE_DEFAULT;
       break;
    case -13: // --unsafe
       args->unsafe = true;
@@ -533,6 +541,9 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
       break;
    case 'w':  // --write
       args->c.writable = true;
+      break;
+   case 'W':  // --write-fake
+      args->c.overlay_size = arg != NULL ? arg : WRITE_FAKE_DEFAULT;
       break;
    case ARGP_KEY_NO_ARGS:
       argp_state_help(state, stderr, (  ARGP_HELP_SHORT_USAGE

--- a/bin/ch-run.c
+++ b/bin/ch-run.c
@@ -463,8 +463,10 @@ static error_t parse_opt(int key, char *arg, struct argp_state *state)
       break;
    case -12: // --home
       Tf (args->c.host_home = getenv("HOME"), "--home failed: $HOME not set");
-      if (args->c.overlay_size == NULL)
+      if (args->c.overlay_size == NULL) {
+         VERBOSE("--home specified; also setting --write-fake");
          args->c.overlay_size = WRITE_FAKE_DEFAULT;
+      }
       break;
    case -13: // --unsafe
       args->unsafe = true;

--- a/bin/ch_core.c
+++ b/bin/ch_core.c
@@ -298,7 +298,7 @@ void enter_udss(struct container *c)
    // https://www.kernel.org/doc/html/v5.11/filesystems/tmpfs.html
    // https://www.kernel.org/doc/html/v5.11/filesystems/overlayfs.html
    if (c->overlay_size != NULL) {
-      VERBOSE("overlaying tmpfs for --write-fake");
+      VERBOSE("overlaying tmpfs for --write-fake (%s)", c->overlay_size);
       char *options;
       T_ (1 <= asprintf(&options, "size=%s", c->overlay_size));
       Zf (mount(NULL, "/mnt", "tmpfs", 0, options),  // host should have /mnt

--- a/bin/ch_core.c
+++ b/bin/ch_core.c
@@ -304,9 +304,9 @@ void enter_udss(struct container *c)
       Zf (mount(NULL, "/mnt", "tmpfs", 0, options),  // host should have /mnt
           "cannot mount tmpfs for overlay");
       free(options);
-      Z_ (mkdir("/mnt/upper", 0755));
-      Z_ (mkdir("/mnt/work", 0755));
-      Z_ (mkdir("/mnt/merged", 0755));
+      Z_ (mkdir("/mnt/upper", 0700));
+      Z_ (mkdir("/mnt/work", 0700));
+      Z_ (mkdir("/mnt/merged", 0700));
       T_ (1 <= asprintf(&options, "lowerdir=%s,upperdir=%s,workdir=%s,"
                                   "index=on,userxattr,volatile",
                                   newroot, "/mnt/upper", "/mnt/work"));

--- a/bin/ch_core.c
+++ b/bin/ch_core.c
@@ -174,9 +174,9 @@ char **bind_mount_paths = NULL;
 /** Function prototypes (private) **/
 
 void bind_mount(const char *src, const char *dst, enum bind_dep,
-                const char *newroot, unsigned long flags);
+                const char *newroot, unsigned long flags, const char *scratch);
 void bind_mounts(const struct bind *binds, const char *newroot,
-                 unsigned long flags);
+                 unsigned long flags, const char * scratch);
 void enter_udss(struct container *c);
 #ifdef HAVE_SECCOMP
 void iw(struct sock_fprog *p, int i,
@@ -197,7 +197,7 @@ void tmpfs_mount(const char *dst, const char *newroot, const char *data);
 
 /* Bind-mount the given path into the container image. */
 void bind_mount(const char *src, const char *dst, enum bind_dep dep,
-                const char *newroot, unsigned long flags)
+                const char *newroot, unsigned long flags, const char *scratch)
 {
    char *dst_fullc, *newrootc;
    char *dst_full = cat(newroot, dst);
@@ -218,7 +218,7 @@ void bind_mount(const char *src, const char *dst, enum bind_dep dep,
       case BD_OPTIONAL:
          return;
       case BD_MAKE_DST:
-         mkdirs(newroot, dst, bind_mount_paths);
+         mkdirs(newroot, dst, bind_mount_paths, scratch);
          break;
       }
 
@@ -235,10 +235,11 @@ void bind_mount(const char *src, const char *dst, enum bind_dep dep,
 
 /* Bind-mount a null-terminated array of struct bind objects. */
 void bind_mounts(const struct bind *binds, const char *newroot,
-                 unsigned long flags)
+                 unsigned long flags, const char * scratch)
 {
    for (int i = 0; binds[i].src != NULL; i++)
-      bind_mount(binds[i].src, binds[i].dst, binds[i].dep, newroot, flags);
+      bind_mount(binds[i].src, binds[i].dst, binds[i].dep,
+                 newroot, flags, scratch);
 }
 
 /* Set up new namespaces or join existing namespaces. */
@@ -277,24 +278,24 @@ void containerize(struct container *c)
    in bin/ch-checkns.c. */
 void enter_udss(struct container *c)
 {
-   char *newroot_parent, *newroot_base;
+   char *nr_parent, *nr_base, *mkdir_scratch;
 
    LOG_IDS;
-   path_split(c->newroot, &newroot_parent, &newroot_base);
+   mkdir_scratch = NULL;
+   path_split(c->newroot, &nr_parent, &nr_base);
 
    // Claim new root for this namespace. Despite MS_REC in bind_mount(), we do
    // need both calls to avoid pivot_root(2) failing with EBUSY later.
    DEBUG("claiming new root for this namespace")
-   bind_mount(c->newroot, c->newroot, BD_REQUIRED, "/", MS_PRIVATE);
-   bind_mount(newroot_parent, newroot_parent, BD_REQUIRED, "/", MS_PRIVATE);
+   bind_mount(c->newroot, c->newroot, BD_REQUIRED, "/", MS_PRIVATE, NULL);
+   bind_mount(nr_parent, nr_parent, BD_REQUIRED, "/", MS_PRIVATE, NULL);
    // Re-mount new root read-only unless --write or already read-only.
    if (!c->writable && !(access(c->newroot, W_OK) == -1 && errno == EROFS)) {
       unsigned long flags =   path_mount_flags(c->newroot)
                             | MS_REMOUNT  // Re-mount ...
                             | MS_BIND     // only this mount point ...
                             | MS_RDONLY;  // read-only.
-      Zf (mount(NULL, c->newroot, NULL, flags, NULL),
-          "can't re-mount image read-only (is it on NFS?)");
+      Z_ (mount(NULL, c->newroot, NULL, flags, NULL));
    }
    // Overlay a tmpfs if --write-fake. See for useful details:
    // https://www.kernel.org/doc/html/v5.11/filesystems/tmpfs.html
@@ -309,22 +310,23 @@ void enter_udss(struct container *c)
       Z_ (mkdir("/mnt/upper", 0700));
       Z_ (mkdir("/mnt/work", 0700));
       Z_ (mkdir("/mnt/merged", 0700));
+      mkdir_scratch = "/mnt/mkdir_overmount";
+      Z_ (mkdir(mkdir_scratch, 0700));
       T_ (1 <= asprintf(&options, "lowerdir=%s,upperdir=%s,workdir=%s,"
                                   "index=on,userxattr,volatile",
                                   c->newroot, "/mnt/upper", "/mnt/work"));
       // update newroot
       c->newroot = "/mnt/merged";
-      free(newroot_parent);
-      free(newroot_base);
-      path_split(c->newroot, &newroot_parent, &newroot_base);
-      Zf (mount(NULL, c->newroot, "overlay", 0, options),
-          "cannot mount overlayfs");
+      free(nr_parent);
+      free(nr_base);
+      path_split(c->newroot, &nr_parent, &nr_base);
+      Zf (mount(NULL, c->newroot, "overlay", 0, options), "can't overlay");
       VERBOSE("newroot updated: %s", c->newroot);
       free(options);
    }
    DEBUG("starting bind-mounts");
    // Bind-mount default files and directories.
-   bind_mounts(BINDS_DEFAULT, c->newroot, MS_RDONLY);
+   bind_mounts(BINDS_DEFAULT, c->newroot, MS_RDONLY, NULL);
    // /etc/passwd and /etc/group.
    if (!c->private_passwd)
       setup_passwd(c);
@@ -332,25 +334,25 @@ void enter_udss(struct container *c)
    if (c->private_tmp) {
       tmpfs_mount("/tmp", c->newroot, NULL);
    } else {
-      bind_mount(host_tmp, "/tmp", BD_REQUIRED, c->newroot, 0);
+      bind_mount(host_tmp, "/tmp", BD_REQUIRED, c->newroot, 0, NULL);
    }
    // Bind-mount user’s home directory at /home/$USER if requested.
    if (c->host_home) {
       T_ (c->overlay_size != NULL);
       bind_mount(c->host_home, cat("/home/", username),
-                 BD_MAKE_DST, c->newroot, 0);
+                 BD_MAKE_DST, c->newroot, 0, mkdir_scratch);
    }
    // Bind-mount user-specified directories.
-   bind_mounts(c->binds, c->newroot, 0);
+   bind_mounts(c->binds, c->newroot, 0, mkdir_scratch);
    // Overmount / to avoid EINVAL if it’s a rootfs.
-   Z_ (chdir(newroot_parent));
-   Z_ (mount(newroot_parent, "/", NULL, MS_MOVE, NULL));
+   Z_ (chdir(nr_parent));
+   Z_ (mount(nr_parent, "/", NULL, MS_MOVE, NULL));
    Z_ (chroot("."));
    // Pivot into the new root. Use /dev because it’s available even in
    // extremely minimal images.
-   c->newroot = cat("/", newroot_base);
+   c->newroot = cat("/", nr_base);
    Zf (chdir(c->newroot), "can't chdir into new root");
-   Zf (syscall(SYS_pivot_root, c->newroot, cat(c->newroot, "/dev")),
+   Zf (syscall(SYS_pivot_root, c->newroot, path_join(c->newroot, "dev")),
        "can't pivot_root(2)");
    Zf (chroot("."), "can't chroot(2) into new root");
    Zf (umount2("/dev", MNT_DETACH), "can't umount old root");
@@ -725,7 +727,7 @@ void setup_passwd(const struct container *c)
       }
    }
    Z_ (close(fd));
-   bind_mount(path, "/etc/passwd", BD_REQUIRED, c->newroot, 0);
+   bind_mount(path, "/etc/passwd", BD_REQUIRED, c->newroot, 0, NULL);
    Z_ (unlink(path));
 
    // /etc/group
@@ -748,7 +750,7 @@ void setup_passwd(const struct container *c)
       }
    }
    Z_ (close(fd));
-   bind_mount(path, "/etc/group", BD_REQUIRED, c->newroot, 0);
+   bind_mount(path, "/etc/group", BD_REQUIRED, c->newroot, 0, NULL);
    Z_ (unlink(path));
 }
 

--- a/bin/ch_core.c
+++ b/bin/ch_core.c
@@ -274,74 +274,84 @@ void containerize(struct container *c)
    in bin/ch-checkns.c. */
 void enter_udss(struct container *c)
 {
-   char *newroot_parent, *newroot_base;
+   char *newroot, *newroot_parent, *newroot_base;
 
    LOG_IDS;
-   path_split(c->newroot, &newroot_parent, &newroot_base);
+   newroot = c->newroot;
+   path_split(newroot, &newroot_parent, &newroot_base);
 
-   // Overlay a tmpfs for --write-fake. See for useful details:
-   // https://www.kernel.org/doc/html/v5.7/filesystems/tmpfs.html
-   // https://www.kernel.org/doc/html/v5.7/filesystems/overlayfs.html
+   // Claim new root for this namespace. Despite MS_REC in bind_mount(), we do
+   // need both calls to avoid pivot_root(2) failing with EBUSY later.
+   DEBUG("claiming new root for this namespace")
+   bind_mount(newroot, newroot, BD_REQUIRED, "/", MS_PRIVATE);
+   bind_mount(newroot_parent, newroot_parent, BD_REQUIRED, "/", MS_PRIVATE);
+   // Re-mount new root read-only unless --write or already read-only.
+   if (!c->writable && !(access(newroot, W_OK) == -1 && errno == EROFS)) {
+      unsigned long flags =   path_mount_flags(newroot)
+                            | MS_REMOUNT  // Re-mount ...
+                            | MS_BIND     // only this mount point ...
+                            | MS_RDONLY;  // read-only.
+      Zf (mount(NULL, newroot, NULL, flags, NULL),
+          "can't re-mount image read-only (is it on NFS?)");
+   }
+   // Overlay a tmpfs if --write-fake. See for useful details:
+   // https://www.kernel.org/doc/html/v5.11/filesystems/tmpfs.html
+   // https://www.kernel.org/doc/html/v5.11/filesystems/overlayfs.html
    if (c->overlay_size != NULL) {
+      VERBOSE("overlaying tmpfs for --write-fake");
       char *options;
       T_ (1 <= asprintf(&options, "size=%s", c->overlay_size));
       Zf (mount(NULL, "/mnt", "tmpfs", 0, options),  // host should have /mnt
           "cannot mount tmpfs for overlay");
       free(options);
-      Z_ (mkdir("/mnt/upper", 0700));
-      Z_ (mkdir("/mnt/work", 0700));
+      Z_ (mkdir("/mnt/upper", 0755));
+      Z_ (mkdir("/mnt/work", 0755));
+      Z_ (mkdir("/mnt/merged", 0755));
       T_ (1 <= asprintf(&options, "lowerdir=%s,upperdir=%s,workdir=%s,"
-                                  "redirect_dir=on,metacopy=on",
-                        c->newroot, "/mnt/upper", "/mnt/work"));
-      Zf (mount(NULL, c->newroot, "overlay", 0, options),
+                                  "index=on,userxattr,volatile",
+                                  newroot, "/mnt/upper", "/mnt/work"));
+      // update newroot
+      newroot = "/mnt/merged";
+      free(newroot_parent);
+      free(newroot_base);
+      path_split(newroot, &newroot_parent, &newroot_base);
+      Zf (mount(NULL, newroot, "overlay", 0, options),
           "cannot mount overlayfs");
       free(options);
    }
-
-   // Claim new root for this namespace. We do need both calls to avoid
-   // pivot_root(2) failing with EBUSY later.
-   bind_mount(c->newroot, c->newroot, BD_REQUIRED, "/", MS_PRIVATE);
-   bind_mount(newroot_parent, newroot_parent, BD_REQUIRED, "/", MS_PRIVATE);
+   DEBUG("starting bind-mounts");
    // Bind-mount default files and directories.
-   bind_mounts(BINDS_DEFAULT, c->newroot, MS_RDONLY);
+   bind_mounts(BINDS_DEFAULT, newroot, MS_RDONLY);
    // /etc/passwd and /etc/group.
    if (!c->private_passwd)
       setup_passwd(c);
    // Container /tmp.
    if (c->private_tmp) {
-      tmpfs_mount("/tmp", c->newroot, NULL);
+      tmpfs_mount("/tmp", newroot, NULL);
    } else {
-      bind_mount(host_tmp, "/tmp", BD_REQUIRED, c->newroot, 0);
+      bind_mount(host_tmp, "/tmp", BD_REQUIRED, newroot, 0);
    }
    // Bind-mount user’s home directory at /home/$USER if requested.
    if (c->host_home) {
       T_ (c->overlay_size != NULL);
-      bind_mount(c->host_home, cat("/home/", username), BD_MAKE_DST,
-                 c->newroot, 0);
-   }
-   // Re-mount new root read-only unless --write or already read-only.
-   if (!c->writable && !(access(c->newroot, W_OK) == -1 && errno == EROFS)) {
-      unsigned long flags =   path_mount_flags(c->newroot)
-                            | MS_REMOUNT  // Re-mount ...
-                            | MS_BIND     // only this mount point ...
-                            | MS_RDONLY;  // read-only.
-      Zf (mount(NULL, c->newroot, NULL, flags, NULL),
-          "can't re-mount image read-only (is it on NFS?)");
+      bind_mount(c->host_home, cat("/home/", username),
+                 BD_MAKE_DST, newroot, 0);
    }
    // Bind-mount user-specified directories.
-   bind_mounts(c->binds, c->newroot, 0);
-   // Overmount / to avoid EINVAL if it's a rootfs.
+   bind_mounts(c->binds, newroot, 0);
+   // Overmount / to avoid EINVAL if it’s a rootfs.
    Z_ (chdir(newroot_parent));
    Z_ (mount(newroot_parent, "/", NULL, MS_MOVE, NULL));
    Z_ (chroot("."));
-   c->newroot = cat("/", newroot_base);
-   // Pivot into the new root. Use /dev because it's available even in
+   // Pivot into the new root. Use /dev because it’s available even in
    // extremely minimal images.
-   Zf (chdir(c->newroot), "can't chdir into new root");
-   Zf (syscall(SYS_pivot_root, c->newroot, cat(c->newroot, "/dev")),
+   newroot = cat("/", newroot_base);
+   Zf (chdir(newroot), "can't chdir into new root");
+   Zf (syscall(SYS_pivot_root, newroot, cat(newroot, "/dev")),
        "can't pivot_root(2)");
    Zf (chroot("."), "can't chroot(2) into new root");
    Zf (umount2("/dev", MNT_DETACH), "can't umount old root");
+   DEBUG("pivot_root(2) dance successful")
 }
 
 /* Return image type of path, or exit with error if not a valid type. */

--- a/bin/ch_core.h
+++ b/bin/ch_core.h
@@ -39,6 +39,7 @@ struct container {
    int join_ct;          // number of peers in a synchronized join
    pid_t join_pid;       // process in existing namespace to join
    char *join_tag;       // identifier for synchronized join
+   char *overlay_size;   // size of overlaid tmpfs (NULL for no overlay)
    bool private_passwd;  // don't bind custom /etc/{passwd,group}
    bool private_tmp;     // don't bind host's /tmp
    enum img_type type;   // directory, SquashFS, etc.

--- a/bin/ch_fuse.c
+++ b/bin/ch_fuse.c
@@ -120,7 +120,7 @@ void sq_fork(struct container *c)
       T_ (asprintf(&subdir, "/%s.ch/mnt", username) > 0);
       c->newroot = cat("/var/tmp", subdir);
       VERBOSE("using default mount point: %s", c->newroot);
-      mkdirs("/var/tmp", subdir, NULL);
+      mkdirs("/var/tmp", subdir, NULL, NULL);
    }
 
    // Verify mount point exists and is a directory. (SquashFS file path

--- a/bin/ch_misc.c
+++ b/bin/ch_misc.c
@@ -483,7 +483,7 @@ void mkdir_overmount(const char *path, const char *scratch)
          // Linux should always have the d_type field (if not, this won’t
          // compile), but on some common filesystems (e.g. NFS?) it does not
          // return a meaningful value, so we have to fall back to lstat(2).
-         if (entries[i]->d_type == DT_UNKNOWN)
+         if (entries[i]->d_type != DT_UNKNOWN)
             st.st_mode = DTTOIF(entries[i]->d_type);
          else
             Zf (lstat(src, &st), "can't stat", src);

--- a/bin/ch_misc.c
+++ b/bin/ch_misc.c
@@ -3,6 +3,7 @@
 #define _GNU_SOURCE
 #include <ctype.h>
 #include <dirent.h>
+#include <fcntl.h>
 #include <fnmatch.h>
 #include <libgen.h>
 #include <stdarg.h>

--- a/bin/ch_misc.c
+++ b/bin/ch_misc.c
@@ -605,9 +605,11 @@ void path_split(const char *path, char **dir, char **base)
    char *path2;
 
    T_ (path2 = strdup(path));
-   *dir = dirname(path2);
+   T_ (*dir = strdup(dirname(path2)));
+   free(path2);
    T_ (path2 = strdup(path));
-   *base = basename(path2);
+   T_ (*base = strdup(basename(path2)));
+   free(path2);
 }
 
 /* Return true if path is a subdirectory of base, false otherwise. Acts on the

--- a/bin/ch_misc.h
+++ b/bin/ch_misc.h
@@ -5,9 +5,10 @@
    libraries that ch_core requires. */
 
 #define _GNU_SOURCE
+#include <dirent.h>
 #include <errno.h>
-#include <sys/stat.h>
 #include <stdbool.h>
+#include <sys/stat.h>
 
 
 /** Macros **/
@@ -117,6 +118,9 @@ char *argv_to_string(char **argv);
 int buf_strings_count(char *str, size_t s);
 bool buf_zero_p(void *buf, size_t size);
 char *cat(const char *a, const char *b);
+int dir_ls(const char *path, struct dirent ***namelist);
+int dir_ls_count(const char *path);
+int dir_ls_filter(const struct dirent *e);
 struct env_var *env_file_read(const char *path, int delim);
 void env_set(const char *name, const char *value, const bool expand);
 void env_unset(const char *glob);
@@ -124,12 +128,14 @@ struct env_var env_var_parse(const char *line, const char *path, size_t lineno);
 void list_append(void **ar, void *new, size_t size);
 void *list_new(size_t size, size_t ct);
 void log_ids(const char *func, int line);
-void mkdirs(const char *base, const char *path, char **denylist);
+void mkdirs(const char *base, const char *path, char **denylist,
+            const char *scratch);
 void msg(enum log_level level, const char *file, int line, int errno_,
          const char *fmt, ...);
 noreturn void msg_fatal(const char *file, int line, int errno_,
                         const char *fmt, ...);
 bool path_exists(const char *path, struct stat *statbuf, bool follow_symlink);
+char *path_join(const char *a, const char *b);
 unsigned long path_mount_flags(const char *path);
 void path_split(const char *path, char **dir, char **base);
 bool path_subdir_p(const char *base, const char *path);

--- a/configure.ac
+++ b/configure.ac
@@ -335,6 +335,83 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
   [AC_MSG_ERROR([cross-compilation not supported])])
 AC_MSG_RESULT($have_userns)
 
+# overlayfs
+AC_DEFUN([CH_OVERLAY_C], [[
+  #define _GNU_SOURCE
+  #include <errno.h>
+  #include <sched.h>
+  #include <stdio.h>
+  #include <stdlib.h>
+  #include <string.h>
+  #include <sys/mount.h>
+  #include <sys/stat.h>
+  #include <unistd.h>
+
+  #define T_(x) if (!(x)) fatal_(__FILE__, __LINE__, errno, #x)
+  #define Z_(x) if (x) fatal_(__FILE__, __LINE__, errno, #x)
+
+  void fatal_(const char *file, int line, int errno_, const char *str)
+  {
+     fprintf(stderr, "error: %s: %d: %s\n", file, line, str);
+     fprintf(stderr, "errno: %d: %s\n", errno_, strerror(errno_));
+     exit(1);
+  }
+
+  int main(void)
+  {
+     int fd;
+     uid_t euid = geteuid();
+     gid_t egid = getegid();
+
+     // enter namespaces
+     Z_ (unshare(CLONE_NEWNS|CLONE_NEWUSER));
+
+     // set up ID maps
+     T_ (-1 != (fd = open("/proc/self/uid_map", O_WRONLY)));
+     T_ (1 <= dprintf(fd, "%d %d 1\n", 0, euid));
+     Z_ (close(fd));
+     T_ (-1 != (fd = open("/proc/self/setgroups", O_WRONLY)));
+     T_ (1 <= dprintf(fd, "deny\n"));
+     Z_ (close(fd));
+     T_ (-1 != (fd = open("/proc/self/gid_map", O_WRONLY)));
+     T_ (1 <= dprintf(fd, "%d %d 1\n", 0, egid));
+     Z_ (close(fd));
+
+     // set up overlayfs
+     Z_ (mount("/", "/", NULL, MS_BIND | MS_REC | MS_PRIVATE, NULL));
+     Z_ (mount(NULL, "/mnt", "tmpfs", 0, NULL));
+     Z_ (mkdir("/mnt/upper", 0700));
+     Z_ (mkdir("/mnt/lower", 0700));
+     Z_ (mkdir("/mnt/lower/test", 0700));
+     Z_ (mkdir("/mnt/work", 0700));
+     Z_ (mkdir("/mnt/merged", 0700));
+     Z_ (mount(NULL, "/mnt/merged", "overlay", MS_NOATIME,
+               "lowerdir=/mnt/lower,"
+               "upperdir=/mnt/upper,"
+               "workdir=/mnt/work,"
+               "index=on,userxattr,volatile"));
+
+     // test if user xattrs are working
+  #ifdef XATTRS
+     Z_ (rmdir("/mnt/merged/test"));
+     Z_ (mkdir("/mnt/merged/test", 0700));
+  #endif
+  }
+]])
+AC_MSG_CHECKING([for unprivileged overlayfs])
+AC_RUN_IFELSE([AC_LANG_SOURCE(CH_OVERLAY_C)],
+              [have_overlayfs=yes],
+              [have_overlayfs=no],
+              [AC_MSG_ERROR([cross-compilation not supported])])
+AC_MSG_RESULT($have_overlayfs)
+AC_MSG_CHECKING([for tmpfs user xattrs])
+AC_RUN_IFELSE([#define XATTRS
+               AC_LANG_SOURCE(CH_OVERLAY_C)],
+              [have_tmpfs_xattrs=yes],
+              [have_tmpfs_xattrs=no],
+              [AC_MSG_ERROR([cross-compilation not supported])])
+AC_MSG_RESULT($have_tmpfs_xattrs)
+
 
 ### ch-run optional ##########################################################
 
@@ -847,10 +924,6 @@ Building Charliecloud
     libsquashfuse_ll ... ${have_libsquashfuse_ll}
     ll.h header ... ${have_ll_h}
 
-  fake system calls with seccomp(2): ${have_seccomp}
-    enabled ... ${msg_seccomp}
-    tested working ... ${test_seccomp}
-
   documentation: ${have_docs}
     sphinx-build(1) ≥ $vmin_sphinx ... ${SPHINX_VERSION_NOTE}
     sphinx-build(1) Python ... ${sphinx_python:-n/a}
@@ -902,6 +975,13 @@ Running containers
   run SquashFS images: ${have_any_squashfuse}
     manual mount with SquashFUSE ≥ $vmin_squashfuse ... ${SQUASHFUSE_VERSION_NOTE}
     internal mount with libsquashfuse ... ${have_libsquashfuse}
+
+  fake system calls with seccomp(2): ${have_seccomp}
+    enabled ... ${msg_seccomp}
+    tested working ... ${test_seccomp}
+
+  writeable overlay (--write-fake): ${have_overlayfs}
+    fully functional ... ${have_tmpfs_xattrs}
 
   inject nVidia GPU libraries: ${have_nvidia}
     nvidia-container-cli(1) ≥ $vmin_nvidia_cli ... ${NVIDIA_CLI_VERSION_NOTE}

--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,10 @@ AC_ARG_ENABLE([html],
   AS_HELP_STRING([--disable-html], [HTML documentation]),
   [], [enable_html=yes])
 
+AC_ARG_ENABLE([impolite-checks],
+  AS_HELP_STRING([--disable-impolite-checks], [potentially troublesome informational checks]),
+  [], [enable_impolite_checks=yes])
+
 AC_ARG_ENABLE([man],
   AS_HELP_STRING([--disable-man], [man pages]),
   [], [enable_man=yes])
@@ -405,17 +409,21 @@ AC_DEFUN([CH_OVERLAY_C], [[
   }
 ]])
 AC_MSG_CHECKING([for unprivileged overlayfs])
-AC_RUN_IFELSE([AC_LANG_SOURCE(CH_OVERLAY_C)],
-              [have_overlayfs=yes],
-              [have_overlayfs=no],
-              [AC_MSG_ERROR([cross-compilation not supported])])
+have_overlayfs="check disabled"
+AS_IF([test $enable_impolite_checks = yes],
+      [AC_RUN_IFELSE([AC_LANG_SOURCE(CH_OVERLAY_C)],
+                     [have_overlayfs=yes],
+                     [have_overlayfs=no],
+                     [AC_MSG_ERROR([cross-compilation not supported])])])
 AC_MSG_RESULT($have_overlayfs)
+have_tmpfs_xattrs="check disabled"
 AC_MSG_CHECKING([for tmpfs user xattrs])
-AC_RUN_IFELSE([#define XATTRS
-               AC_LANG_SOURCE(CH_OVERLAY_C)],
-              [have_tmpfs_xattrs=yes],
-              [have_tmpfs_xattrs=no],
-              [AC_MSG_ERROR([cross-compilation not supported])])
+AS_IF([test $enable_impolite_checks = yes],
+      [AC_RUN_IFELSE([#define XATTRS
+                      AC_LANG_SOURCE(CH_OVERLAY_C)],
+                     [have_tmpfs_xattrs=yes],
+                     [have_tmpfs_xattrs=no],
+                     [AC_MSG_ERROR([cross-compilation not supported])])])
 AC_MSG_RESULT($have_tmpfs_xattrs)
 
 

--- a/doc/ch-run.rst
+++ b/doc/ch-run.rst
@@ -29,16 +29,18 @@ mounting SquashFS images with FUSE.
     not specified is to use the same path as the host; i.e., the default is
     :code:`--bind=SRC:SRC`. Can be repeated.
 
-    If :code:`--write` or :code:`--write-fake` are given and :code:`DST` does
-    not exist, it will be created as an empty directory. However, :code:`DST`
-    must be entirely within the image itself; :code:`DST` cannot enter a
+    With a read-only image (the default), :code:`DST` must exist. However, if
+    :code:`--write` or :code:`--write-fake` are given, :code:`DST` will be
+    created as an empty directory (possibly with the tmpfs overmount trick
+    described in :ref:`faq_mkdir-ro`). In this case, :code:`DST` must be
+    entirely within the image itself, i.e., :code:`DST` cannot enter a
     previous bind mount. For example, :code:`--bind /foo:/tmp/foo` will fail
     because :code:`/tmp` is shared with the host via bind-mount (unless
     :code:`$TMPDIR` is set to something else or :code:`--private-tmp` is
     given).
 
-    Most images do have ten directories :code:`/mnt/[0-9]` already available
-    as mount points.
+    Most images have ten directories :code:`/mnt/[0-9]` already available as
+    mount points.
 
     Symlinks in :code:`DST` are followed, and absolute links can have
     surprising behavior. Bind-mounting happens after namespace setup but
@@ -67,8 +69,8 @@ mounting SquashFS images with FUSE.
 
   :code:`--home`
     Bind-mount your host home directory (i.e., :code:`$HOME`) at guest
-    :code:`/home/$USER` (hiding any image content that exists at that path)
-    Implies :code:`--write-fake`.
+    :code:`/home/$USER`, hiding any existing image content at that path.
+    Implies :code:`--write-fake` so the mount point can be created if needed.
 
   :code:`-j`, :code:`--join`
     Use the same container (namespaces) as peer :code:`ch-run` invocations.
@@ -149,8 +151,9 @@ mounting SquashFS images with FUSE.
     specification acceptable to :code:`tmpfs`, e.g. :code:`4m` for 4MiB or
     :code:`50%` for half of physical memory. If this option is specified
     without :code:`SIZE`, the default is :code:`12%`. Note (1) this limit is a
-    maximum — only actually stored files consume virtual memory, and
-    (2) :code:`SIZE` larger than memory can be requested without error.
+    maximum — only actually stored files consume virtual memory — and
+    (2) :code:`SIZE` larger than memory can be requested without error (the
+    failure happens later if the actual contents become too large).
 
     This requires kernel support and there are some caveats. See section
     “:ref:`ch-run_overlay`” below for details.

--- a/doc/ch-run.rst
+++ b/doc/ch-run.rst
@@ -29,12 +29,13 @@ mounting SquashFS images with FUSE.
     not specified is to use the same path as the host; i.e., the default is
     :code:`--bind=SRC:SRC`. Can be repeated.
 
-    If :code:`--write` is given and :code:`DST` does not exist, it will be
-    created as an empty directory. However, :code:`DST` must be entirely
-    within the image itself; :code:`DST` cannot enter a previous bind mount.
-    For example, :code:`--bind /foo:/tmp/foo` will fail because :code:`/tmp`
-    is shared with the host via bind-mount (unless :code:`$TMPDIR` is set to
-    something else or :code:`--private-tmp` is given).
+    If :code:`--write` or :code:`--write-fake` are given and :code:`DST` does
+    not exist, it will be created as an empty directory. However, :code:`DST`
+    must be entirely within the image itself; :code:`DST` cannot enter a
+    previous bind mount. For example, :code:`--bind /foo:/tmp/foo` will fail
+    because :code:`/tmp` is shared with the host via bind-mount (unless
+    :code:`$TMPDIR` is set to something else or :code:`--private-tmp` is
+    given).
 
     Most images do have ten directories :code:`/mnt/[0-9]` already available
     as mount points.
@@ -132,8 +133,26 @@ mounting SquashFS images with FUSE.
   :code:`-v`, :code:`--verbose`
     Be more verbose (can be repeated).
 
+  :code:`-W`, :code:`--write-fake[=SIZE]`
+    Overlay a writeable tmpfs over the image. This makes the image appear
+    read-write, but it actually remains read-only and unchanged. All data
+    written are discarded when the container exits. The size of the writeable
+    filesystem :code:`SIZE` is any :code:`size` specification acceptable to
+    :code:`tmpfs`, e.g. :code:`4m` for 4MiB or :code:`50%` for half of
+    physical memory. The default is :code:`12%`. Note that this limit is a
+    maximum: only actually stored files consume virtual memory. This requires
+    a kernel that supports unprivileged overlayfs (`upstream 5.11
+    <https://kernelnewbies.org/Linux_5.11#Unprivileged_Overlayfs_mounts>`_,
+    but distributions vary considerably).
+
   :code:`-w`, :code:`--write`
-    Mount image read-write (by default, the image is mounted read-only).
+    Mount image read-write. By default, the image is mounted read-only. *This
+    option should be avoided for most use cases,* because (1) changing images
+    live (as opposed to prescriptively with a Dockerfile) destroys their
+    provenance and (2) SquashFS images, which is the best-practice format on
+    parallel filesystems, must be read-only. It is better to use
+    `--write-fake` (for disposable data) or bind-mount host directories (for
+    retained data).
 
   :code:`-?`, :code:`--help`
     Print help and exit.
@@ -696,4 +715,4 @@ status is 1 regardless of the signal value.
 .. include:: ./see_also.rst
 
 ..  LocalWords:  mtune NEWROOT hugetlbfs UsrMerge fusermount mybox IMG HOSTPATH
-..  LocalWords:  noprofile norc SHLVL PWD
+..  LocalWords:  noprofile norc SHLVL PWD kernelnewbies

--- a/doc/ch-run.rst
+++ b/doc/ch-run.rst
@@ -345,13 +345,13 @@ requires kernel support. Specifically:
    this, the container will fail to start with error “operation not
    permitted”.
 
-2. To allow fully arbitrary changes in the overlay, you need a tmpfs that
-   supports xattrs in the :code:`user` namespace. This is available in
-   `upstream 6.6 <https://kernelnewbies.org/Linux_6.6#TMPFS>`_ (October 2023).
-   If you don’t have this, most things will work fine, but some operations
-   will fail with “I/O error”, for example creating a directory with the same
-   path as a previously deleted directory. There will also be syslog noise
-   about xattr problems.
+2. For a fully functional overlay, you need a tmpfs that supports xattrs in
+   the :code:`user` namespace. This is available in `upstream 6.6
+   <https://kernelnewbies.org/Linux_6.6#TMPFS>`_ (October 2023). If you don’t
+   have this, most things will work fine, but some operations will fail with
+   “I/O error”, for example creating a directory with the same path as a
+   previously deleted directory. There will also be syslog noise about xattr
+   problems.
 
    (overlayfs can also use xattrs in the :code:`trusted` namespace, but this
    requires :code:`CAP_SYS_ADMIN` `on the host

--- a/doc/ch-run.rst
+++ b/doc/ch-run.rst
@@ -67,10 +67,8 @@ mounting SquashFS images with FUSE.
 
   :code:`--home`
     Bind-mount your host home directory (i.e., :code:`$HOME`) at guest
-    :code:`/home/$USER`. This is accomplished by over-mounting a new
-    :code:`tmpfs` at :code:`/home`, which hides any image content under that
-    path. By default, neither of these things happens and the image’s
-    :code:`/home` is exposed unaltered.
+    :code:`/home/$USER` (hiding any image content that exists at that path)
+    Implies :code:`--write-fake`.
 
   :code:`-j`, :code:`--join`
     Use the same container (namespaces) as peer :code:`ch-run` invocations.
@@ -133,26 +131,31 @@ mounting SquashFS images with FUSE.
   :code:`-v`, :code:`--verbose`
     Be more verbose (can be repeated).
 
-  :code:`-W`, :code:`--write-fake[=SIZE]`
-    Overlay a writeable tmpfs over the image. This makes the image appear
-    read-write, but it actually remains read-only and unchanged. All data
-    written are discarded when the container exits. The size of the writeable
-    filesystem :code:`SIZE` is any :code:`size` specification acceptable to
-    :code:`tmpfs`, e.g. :code:`4m` for 4MiB or :code:`50%` for half of
-    physical memory. The default is :code:`12%`. Note that this limit is a
-    maximum: only actually stored files consume virtual memory. This requires
-    a kernel that supports unprivileged overlayfs (`upstream 5.11
-    <https://kernelnewbies.org/Linux_5.11#Unprivileged_Overlayfs_mounts>`_,
-    but distributions vary considerably).
-
   :code:`-w`, :code:`--write`
     Mount image read-write. By default, the image is mounted read-only. *This
     option should be avoided for most use cases,* because (1) changing images
     live (as opposed to prescriptively with a Dockerfile) destroys their
     provenance and (2) SquashFS images, which is the best-practice format on
     parallel filesystems, must be read-only. It is better to use
-    `--write-fake` (for disposable data) or bind-mount host directories (for
-    retained data).
+    :code:`--write-fake` (for disposable data) or bind-mount host directories
+    (for retained data).
+
+  :code:`-W`, :code:`--write-fake[=SIZE]`
+    Overlay a writeable tmpfs on top of the image. This makes the image appear
+    read-write, but it actually remains read-only and unchanged. All data
+    “written” to the image are discarded when the container exits.
+
+    The size of the writeable filesystem :code:`SIZE` is any size
+    specification acceptable to :code:`tmpfs`, e.g. :code:`4m` for 4MiB or
+    :code:`50%` for half of physical memory. If this option is specified
+    without :code:`SIZE`, the default is :code:`12%`. Note that this limit is
+    a maximum: only actually stored files consume virtual memory.
+
+    This requires a kernel that supports unprivileged overlayfs (`upstream
+    5.11
+    <https://kernelnewbies.org/Linux_5.11#Unprivileged_Overlayfs_mounts>`_,
+    but distributions vary considerably). If it does not, the error is
+    “operation not permitted”.
 
   :code:`-?`, :code:`--help`
     Print help and exit.
@@ -715,4 +718,4 @@ status is 1 regardless of the signal value.
 .. include:: ./see_also.rst
 
 ..  LocalWords:  mtune NEWROOT hugetlbfs UsrMerge fusermount mybox IMG HOSTPATH
-..  LocalWords:  noprofile norc SHLVL PWD kernelnewbies
+..  LocalWords:  noprofile norc SHLVL PWD kernelnewbies extglob

--- a/doc/ch-run.rst
+++ b/doc/ch-run.rst
@@ -148,8 +148,9 @@ mounting SquashFS images with FUSE.
     The size of the writeable filesystem :code:`SIZE` is any size
     specification acceptable to :code:`tmpfs`, e.g. :code:`4m` for 4MiB or
     :code:`50%` for half of physical memory. If this option is specified
-    without :code:`SIZE`, the default is :code:`12%`. Note that this limit is
-    a maximum: only actually stored files consume virtual memory.
+    without :code:`SIZE`, the default is :code:`12%`. Note (1) this limit is a
+    maximum — only actually stored files consume virtual memory, and
+    (2) :code:`SIZE` larger than memory can be requested without error.
 
     This requires kernel support and there are some caveats. See section
     “:ref:`ch-run_overlay`” below for details.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -358,9 +358,6 @@ create a new directory there::
 Recall that bind-mounting to a path that does not exist in a read-only image
 fails::
 
-  $ ls -R /tmp/foo
-  /tmp/foo:
-  file-in-foo
   $ ch-run -b /tmp/foo:/mnt/foo /var/tmp/image -- ls /mnt
   ch-run[40498]: error: can't mkdir: /var/tmp/image/mnt/foo: Read-only file system (ch_misc.c:582 30)
 
@@ -375,8 +372,8 @@ on the container. Then we can make any mount points we need. Right?
 
 Wait — why could we create a subdirectory of (container path) :code:`/` but
 not :code:`/mnt`? This is because the latter, which is at host path
-:code:`/var/tmp/image/mnt`, is not writeable by us, despite the overlaid
-writeable tmpfs.
+:code:`/var/tmp/image/mnt`, is not writeable by us: the overlayfs propagates
+the directory’s no-write permissions.
 
 Despite this, we can in fact use paths that do not yet exist for bind-mount destinations::
 
@@ -387,7 +384,7 @@ Despite this, we can in fact use paths that do not yet exist for bind-mount dest
 
 What’s happening is bind-mount trickery. :code:`ch-run` creates a side
 directory on the overlaid tmpfs, bind-mounts the existing contents of (host
-path) :code:`/var/tmp/images/mnt` onto newly-created mount points in this new
+path) :code:`/var/tmp/images/mnt` to newly-created mount points in this new
 directory (up to a limit, hence the warning and :code:`0` is missing), and
 then bind-mounts this new (writeable!) directory on top of
 :code:`/var/tmp/images/mnt`. *Now* we can

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -199,6 +199,21 @@ The main use case for these options is to support package maintainers. If this
 is you and does not meet your needs, please get in touch with us and we will
 help.
 
+Avoid potentially troublesome informational tests: :code:`--disable-impolite-checks`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:code:`configure` performs a lot of checks that do not inform decisions but
+are simply informational, for the report at the end. These checks replicate
+run-time decisions; their purpose is to offer guidance on what to expect at
+run time.
+
+Some of these checks trigger alerts in some situations. for example, writing
+files in :code:`/proc` confuses the Gentoo package build `sandbox
+<https://wiki.gentoo.org/wiki/Project:Sandbox>`_.
+
+Option :code:`--disable-impolite-checks` skips these checks. The only
+consequence is a somewhat less informative report.
+
 
 Install with package manager
 ============================

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -200,7 +200,7 @@ is you and does not meet your needs, please get in touch with us and we will
 help.
 
 Avoid potentially troublesome informational tests: :code:`--disable-impolite-checks`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :code:`configure` performs a lot of checks that do not inform decisions but
 are simply informational, for the report at the end. These checks replicate

--- a/examples/chtest/Build
+++ b/examples/chtest/Build
@@ -91,9 +91,9 @@ chmod -R u+rw,ug-s img
 
 ## Install our test stuff.
 
-# Sentinel file for --bind test
-echo "tmpfs and host home are not overmounted" \
-  > img/home/overmount-me
+# Fixtures for --bind tests
+mkdir img/home/directory-in-home
+touch img/home/file-in-home
 
 # Test programs.
 cp -r "$srcdir" img/test

--- a/packaging/fedora/build
+++ b/packaging/fedora/build
@@ -101,8 +101,8 @@ rpmbuild root:      %(rpmbuild)s
    # pip3 expects $HOME, here /root, to be writeable for its cache. If not,
    # the warning is that the directory “is not owned by the current user”,
    # which is not true. The warning further claims that “*caching* wheels has
-   # been disabled”, but in fact wheels are disabled entirely, so autogen.sh
-   # fails with “embedded Lark is broken”. Thanks pip!
+   # been disabled” (emphasis added), but in fact wheels are disabled
+   # entirely, so autogen.sh fails with “embedded Lark is broken”. Thanks pip!
    cmd(CH_RUN, "-b", "%s:/mnt/0" % git_tmp, "-b", "%s:/root" % rpm_pips,
                "-c", "/mnt/0", args.image, "--", "./autogen.sh")
    cmd(CH_RUN, "-b", "%s:/mnt/0" % git_tmp, "-c", "/mnt/0", args.image,

--- a/packaging/fedora/build
+++ b/packaging/fedora/build
@@ -97,8 +97,7 @@ rpmbuild root:      %(rpmbuild)s
 
    # Build tarball.
    print("# building source tarball")
-   # FIXME: Why does this need --home?
-   cmd(CH_RUN, "--home", "-b", "%s:/mnt/0" % git_tmp, "-c", "/mnt/0", args.image,
+   cmd(CH_RUN, "-b", "%s:/mnt/0" % git_tmp, "-c", "/mnt/0", args.image,
        "--", "./autogen.sh")
    cmd(CH_RUN, "-b", "%s:/mnt/0" % git_tmp, "-c", "/mnt/0", args.image,
        "--", "./configure")

--- a/packaging/fedora/build
+++ b/packaging/fedora/build
@@ -72,7 +72,8 @@ rpmbuild root:      %(rpmbuild)s
    # Create rpmbuild root
    rpm_sources = args.rpmbuild + '/SOURCES'
    rpm_specs   = args.rpmbuild + '/SPECS'
-   for d in (rpm_sources, rpm_specs):
+   rpm_pips    = args.rpmbuild + '/pip'
+   for d in (rpm_sources, rpm_specs, rpm_pips):
       print("# mkdir -p %s" % d)
       try:
          os.makedirs(d)
@@ -97,8 +98,13 @@ rpmbuild root:      %(rpmbuild)s
 
    # Build tarball.
    print("# building source tarball")
-   cmd(CH_RUN, "-b", "%s:/mnt/0" % git_tmp, "-c", "/mnt/0", args.image,
-       "--", "./autogen.sh")
+   # pip3 expects $HOME, here /root, to be writeable for its cache. If not,
+   # the warning is that the directory “is not owned by the current user”,
+   # which is not true. The warning further claims that “*caching* wheels has
+   # been disabled”, but in fact wheels are disabled entirely, so autogen.sh
+   # fails with “embedded Lark is broken”. Thanks pip!
+   cmd(CH_RUN, "-b", "%s:/mnt/0" % git_tmp, "-b", "%s:/root" % rpm_pips,
+               "-c", "/mnt/0", args.image, "--", "./autogen.sh")
    cmd(CH_RUN, "-b", "%s:/mnt/0" % git_tmp, "-c", "/mnt/0", args.image,
        "--", "./configure")
    cmd(CH_RUN, "-b", "%s:/mnt/0" % git_tmp, "-c", "/mnt/0", args.image,

--- a/test/common.bash
+++ b/test/common.bash
@@ -352,7 +352,6 @@ ch_version_docker=$(echo "$ch_version" | tr '~+' '--')
 # [2]: http://man7.org/linux/man-pages/man1/readlink.1.html
 ch_imgdir=$(readlink -m "$CH_TEST_IMGDIR")
 ch_tardir=$(readlink -m "$CH_TEST_TARDIR")
-ch_mounts="${ch_imgdir}/mounts"
 
 # Image information.
 ch_tag=${CH_TEST_TAG:-NO_TAG_SET}  # set by Makefile; many tests don’t need it

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -12,7 +12,7 @@ setup () {
 
 
 demand-overlayfs () {
-    ch-run -W "$ch_timg" -- true || pedantic_fail 'no unpriv overlayfs'
+    ch-run -W "$ch_timg" -- true || skip 'no unpriv overlayfs'
 }
 
 
@@ -77,6 +77,7 @@ EOF
 
 @test "\$HOME" {
     [[ $CH_TEST_BUILDER != 'none' ]] || skip 'image builder required'
+    demand-overlayfs
     LC_ALL=C
 
     scope quick
@@ -109,11 +110,9 @@ EOF
     run ch-run --home "$ch_timg" -- ls -1 /home
     echo "$output"
     [[ $status -eq 0 ]]
-    cat <<EOF | diff -u - <(echo "$output")
-directory-in-home
-file-in-home
-reidpr
-EOF
+    [[ $output = *directory-in-home* ]]
+    [[ $output = *file-in-home* ]]
+    [[ $output = *"$USER"* ]]
 
     # puke if $HOME not set
     home_tmp=$HOME

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -259,7 +259,8 @@ EOF
 
     rm-img () {
         # Remove existing fixture, avoiding “sudo rm -Rf” b/c it’s too scary.
-        sudo rm -f "$img"/foo/*
+        sudo rm -f "$img"/foo/file-in-foo
+        sudo rmdir "$img"/foo/directory-in-foo || true
         sudo rmdir "$img"/foo || true
         sudo rm -f "$img"/home/file-in-home
         sudo rmdir "$img"/home/directory-in-home || true
@@ -270,10 +271,9 @@ EOF
     rm-img
     ch-convert "$ch_tardir"/chtest.* "$img"
     ls -l "$img"
-    mkdir -m 755 "$img"/foo
-    for i in {1..16}; do  # MKDIRS_OVERMOUNT_ENTRY_MAX + 1
-        touch "${img}/foo/${i}"
-    done
+    mkdir "$img"/foo
+    touch "$img"/foo/file-in-foo
+    mkdir "$img"/foo/directory-in-foo
     sudo chown root:root "$img"/foo "$img"/home
     sudo chmod 755 "$img"/foo "$img"/home
     ls -ld "$img"/foo "$img"/home
@@ -286,13 +286,12 @@ EOF
     ls -l "$src"
 
     # --bind
-    run ch-run -W -b "$src":/foo/bar "$img" -- ls -xw 78 /foo /foo/bar
+    run ch-run -W -b "$src":/foo/bar "$img" -- ls -lahR /foo
     echo "$output"
     [[ $status -eq 0 ]]
-    [[ $output = *'warning: mkdir overmount: 16 entries > limit 15, skipping extras'* ]]
 
     # --home
-    run ch-run --home "$img" -- ls -1 /home
+    run ch-run --home "$img" -- ls -lah /home
     echo "$output"
     [[ $status -eq 0 ]]
     [[ $(echo "$output" | wc -l) -eq 3 ]]

--- a/test/run/ch-run_misc.bats
+++ b/test/run/ch-run_misc.bats
@@ -349,13 +349,13 @@ EOF
     run ch-run -b "${bind1_dir}:/.." "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = *"can't bind: /var/tmp/${USER}.ch not subdirectory of /var/tmp/${USER}.ch/mnt"* ]]
+    [[ $output = *"can't bind: "*"/${USER}.ch not subdirectory of "*"/${USER}.ch/mnt"* ]]
 
     # destination climbs out of image, does not exist
     run ch-run -b "${bind1_dir}:/../doesnotexist/a" "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = *"can't mkdir: /var/tmp/${USER}.ch/doesnotexist not subdirectory of /var/tmp/${USER}.ch/mnt"* ]]
+    [[ $output = *"can't mkdir: "*"/${USER}.ch/doesnotexist not subdirectory of "*"/${USER}.ch/mnt"* ]]
     [[ ! -e ${ch_imgdir}/doesnotexist ]]
 
     # source does not exist
@@ -368,7 +368,7 @@ EOF
     run ch-run -b "${bind1_dir}:/doesnotexist" "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = *"can't mkdir: /var/tmp/${USER}.ch/mnt/doesnotexist: Read-only file system"* ]]
+    [[ $output = *"can't mkdir: "*"/${USER}.ch/mnt/doesnotexist: Read-only file system"* ]]
 
     # neither source nor destination exist
     run ch-run -b /doesnotexist-out:/doesnotexist-in "$ch_timg" -- /bin/true
@@ -387,13 +387,13 @@ EOF
                "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = *"can't mkdir: /var/tmp/${USER}.ch/mnt/doesnotexist: Read-only file system"* ]]
+    [[ $output = *"can't mkdir: "*"/${USER}.ch/mnt/doesnotexist: Read-only file system"* ]]
 
     # destination is broken symlink
     run ch-run -b "${bind1_dir}:/mnt/link-b0rken-abs" "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = *"can't mkdir: symlink not relative: /var/tmp/${USER}.ch/mnt/mnt/link-b0rken-abs"* ]]
+    [[ $output = *"can't mkdir: symlink not relative: "*"/${USER}.ch/mnt/mnt/link-b0rken-abs"* ]]
 
     # destination is absolute symlink outside image
     run ch-run -b "${bind1_dir}:/mnt/link-bad-abs" "$ch_timg" -- /bin/true
@@ -411,20 +411,20 @@ EOF
     run ch-run -b "${bind1_dir}:/proc/doesnotexist" "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = *"can't mkdir: /var/tmp/${USER}.ch/mnt/proc/doesnotexist under existing bind-mount /var/tmp/${USER}.ch/mnt/proc "* ]]
+    [[ $output = *"can't mkdir: "*"/${USER}.ch/mnt/proc/doesnotexist under existing bind-mount "*"/${USER}.ch/mnt/proc "* ]]
 
     # mkdir(2) under existing bind-mount, user-supplied, first level
     run ch-run -b "${bind1_dir}:/mnt/0" \
                -b "${bind2_dir}:/mnt/0/foo" "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = *"can't mkdir: /var/tmp/${USER}.ch/mnt/mnt/0/foo under existing bind-mount /var/tmp/${USER}.ch/mnt/mnt/0 "* ]]
+    [[ $output = *"can't mkdir: "*"/${USER}.ch/mnt/mnt/0/foo under existing bind-mount "*"/${USER}.ch/mnt/mnt/0 "* ]]
 
     # mkdir(2) under existing bind-mount, default, 2nd level
     run ch-run -b "${bind1_dir}:/proc/sys/doesnotexist" "$ch_timg" -- /bin/true
     echo "$output"
     [[ $status -eq 1 ]]
-    [[ $output = *"can't mkdir: /var/tmp/${USER}.ch/mnt/proc/sys/doesnotexist under existing bind-mount /var/tmp/${USER}.ch/mnt/proc "* ]]
+    [[ $output = *"can't mkdir: "*"/${USER}.ch/mnt/proc/sys/doesnotexist under existing bind-mount "*"/${USER}.ch/mnt/proc "* ]]
 }
 
 

--- a/test/run_first.bats
+++ b/test/run_first.bats
@@ -1,14 +1,5 @@
 load common
 
-@test 'prepare images directory' {
-    scope quick
-    mkdir -p "${ch_imgdir}/bind1"
-    touch "${ch_imgdir}/bind1/file1"
-    mkdir -p "${ch_imgdir}/bind2"
-    touch "${ch_imgdir}/bind2/file2"
-    mkdir -p "${ch_imgdir}/mounts"
-}
-
 @test 'permissions test directories exist' {
     scope standard
     [[ $CH_TEST_PERMDIRS = skip ]] && skip 'user request'


### PR DESCRIPTION
This pull request implements `ch-run --write-fake`, which overlayfs a writeable tmpfs atop a read-only image. This makes the image appear writeable when it really is not (all writes are discarded on container exit). Needs a recent kernel: upstream 5.11 for the feature to work at all, and upstream 6.6 to avoid some weirdness (distros vary).

Closes #96, but I'm tagging it as a stand-alone PR because I think its scope exceeds that of #96.