### PR TITLE
add `WARNING` to `base.sh`

### DIFF
--- a/bin/ch-convert
+++ b/bin/ch-convert
@@ -474,7 +474,7 @@ chimage_out_validate () {
         FATAL "exists in ch-image storage, not deleting per --no-clobber: ${1}"
     fi
     if [ -n "$xattrs" ]; then
-        WARNING "--xattrs unsupported for out format \"ch-image\""
+        WARNING -- "--xattrs unsupported for out format \"ch-image\""
     fi
 }
 

--- a/lib/base.sh
+++ b/lib/base.sh
@@ -15,32 +15,36 @@ log_level=0
 
 DEBUG () {
     if [ "$log_level" -ge 2 ]; then
-        # shellcheck disable=SC2059
-        printf "$@" 1>&2
+        printf '%s' "$@" 1>&2
         printf '\n' 1>&2
     fi
 }
 
 FATAL () {
     printf 'error: ' 1>&2
-    # shellcheck disable=SC2059
-    printf "$@" 1>&2
+    printf '%s' "$@" 1>&2
     printf '\n' 1>&2
     exit 1
 }
 
 INFO () {
     if [ "$log_level" -ge 0 ]; then
-        # shellcheck disable=SC2059
-        printf "$@" 1>&2
+        printf '%s' "$@" 1>&2
         printf '\n' 1>&2
     fi
 }
 
 VERBOSE () {
     if [ "$log_level" -ge 1 ]; then
-        # shellcheck disable=SC2059
-        printf "$@" 1>&2
+        printf '%s' "$@" 1>&2
+        printf '\n' 1>&2
+    fi
+}
+
+WARNING () {
+    if [ "$log_level" -ge -1 ]; then
+        printf 'warning: ' 1>&2
+        printf '%s' "$@" 1>&2
         printf '\n' 1>&2
     fi
 }

--- a/lib/base.sh
+++ b/lib/base.sh
@@ -22,8 +22,7 @@ log_level=0
 # Implementing the suggestion in SC2059 would instead result in something like
 #
 #   >>> VERBOSE "foo %s" "bar"
-#   foo %s
-#   bar
+#   foo %sbar
 
 DEBUG () {
     if [ "$log_level" -ge 2 ]; then

--- a/lib/base.sh
+++ b/lib/base.sh
@@ -13,30 +13,46 @@ ch_lib=${ch_bin}/../lib
 # Python code.
 log_level=0
 
+# Logging functions. Note that we disable SC2059 because we want these functions
+# to behave exactly like printf(1), e.g. we want
+#
+#   >>> VERBOSE "foo %s" "bar"
+#   foo bar
+#
+# Implementing the suggestion in SC2059 would instead result in something like
+#
+#   >>> VERBOSE "foo %s" "bar"
+#   foo %s
+#   bar
+
 DEBUG () {
     if [ "$log_level" -ge 2 ]; then
-        printf '%s' "$@" 1>&2
+        # shellcheck disable=SC2059
+        printf "$@" 1>&2
         printf '\n' 1>&2
     fi
 }
 
 FATAL () {
     printf 'error: ' 1>&2
-    printf '%s' "$@" 1>&2
+    # shellcheck disable=SC2059
+    printf "$@" 1>&2
     printf '\n' 1>&2
     exit 1
 }
 
 INFO () {
     if [ "$log_level" -ge 0 ]; then
-        printf '%s' "$@" 1>&2
+        # shellcheck disable=SC2059
+        printf "$@" 1>&2
         printf '\n' 1>&2
     fi
 }
 
 VERBOSE () {
     if [ "$log_level" -ge 1 ]; then
-        printf '%s' "$@" 1>&2
+        # shellcheck disable=SC2059
+        printf "$@" 1>&2
         printf '\n' 1>&2
     fi
 }
@@ -44,7 +60,8 @@ VERBOSE () {
 WARNING () {
     if [ "$log_level" -ge -1 ]; then
         printf 'warning: ' 1>&2
-        printf '%s' "$@" 1>&2
+        # shellcheck disable=SC2059
+        printf "$@" 1>&2
         printf '\n' 1>&2
     fi
 }


### PR DESCRIPTION
In PR #1788, I added a `WARNING` logging function call to `ch-convert`, assuming such a function existed (in `lib/base.sh`). I was wrong. Oops.

I'll also be adding a comment explaining why we disable [SC2059](https://www.shellcheck.net/wiki/SC2059) in our logging functions, because I got confused about that.