### PR TITLE
block `mknod(2)` only if creating a device

### DIFF
--- a/doc/ch-image.rst
+++ b/doc/ch-image.rst
@@ -788,11 +788,12 @@ This mode uses the kernel’s :code:`seccomp(2)` system call filtering to
 intercept certain privileged system calls, do absolutely nothing, and return
 success to the program.
 
-The quashed system calls are: :code:`capset(2)`; :code:`chown(2)` and friends;
-:code:`kexec_load(2)` (used to validate the filter itself); :code:`mknod(2)`
-and :code:`mknodat(2)`; and :code:`setuid(2)`, :code:`setgid(2)`, and
-:code:`setgroups(2)` along with the other system calls that change user or
-group.
+Some system calls are quashed regardless of their arguments:
+:code:`capset(2)`; :code:`chown(2)` and friends; :code:`kexec_load(2)` (used
+to validate the filter itself); ; and :code:`setuid(2)`, :code:`setgid(2)`,
+and :code:`setgroups(2)` along with the other system calls that change user or
+group. :code:`mknod(2)` and :code:`mknodat(2)` are quashed if they try to
+create a device file (e.g., creating FIFOs works normally).
 
 The advantages of this approach is that it’s much simpler, it’s faster, it’s
 completely agnostic to libc, and it’s mostly agnostic to distribution. The

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -74,6 +74,9 @@ paraview/cone.nranks.vtk \
 paraview/cone.png \
 paraview/cone.py \
 paraview/cone.serial.vtk \
+seccomp/Dockerfile \
+seccomp/mknods.c \
+seccomp/test.bats \
 spack/Dockerfile \
 spark/Dockerfile \
 spark/slurm.sh

--- a/examples/paraview/Dockerfile
+++ b/examples/paraview/Dockerfile
@@ -1,4 +1,4 @@
-# ch-test-scope: full
+# ch-test-scope: skip  #1810
 FROM openmpi
 WORKDIR /usr/local/src
 

--- a/examples/seccomp/Dockerfile
+++ b/examples/seccomp/Dockerfile
@@ -1,0 +1,10 @@
+# ch-test-builder-include: ch-image
+FROM alpine:3.19
+RUN apk add clang strace
+RSYNC / /
+RUN cc -std=c11 -Wall -Werror -fmax-errors=1 -o mknods mknods.c
+RUN strace ./mknods
+RUN ls -lh /_*
+RUN test $(ls /_* | wc -l) == 2
+RUN test -p /_mknod_fifo
+RUN test -p /_mknodat_fifo

--- a/examples/seccomp/Dockerfile
+++ b/examples/seccomp/Dockerfile
@@ -1,8 +1,8 @@
 # ch-test-builder-include: ch-image
-FROM alpine:3.19
-RUN apk add clang strace
+FROM alpine:3.17
+RUN apk add gcc musl-dev strace
 RSYNC / /
-RUN cc -std=c11 -Wall -Werror -fmax-errors=1 -o mknods mknods.c
+RUN gcc -std=c11 -Wall -Werror -fmax-errors=1 -o mknods mknods.c
 RUN strace ./mknods
 RUN ls -lh /_*
 RUN test $(ls /_* | wc -l) == 2

--- a/examples/seccomp/mknods.c
+++ b/examples/seccomp/mknods.c
@@ -1,0 +1,28 @@
+/* Use mknod(2) and mknodat(2) to create character and block devices (which
+   should be blocked by the seccomp filters) and FIFOs (which should not.) */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+
+#define DEVNULL makedev(1,3)  // character device /dev/null
+#define DEVRAM0 makedev(1,0)  // block device /dev/ram0
+#define Z_(x)  if (x) (fprintf(stderr, "failed: %d: %s (%d)\n", \
+                                       __LINE__, strerror(errno), errno), \
+                       exit(1))
+
+int main(void)
+{
+   Z_ (mknod("/_mknod_chr",  S_IFCHR, DEVNULL));
+   Z_ (mknod("/_mknod_blk",  S_IFBLK, DEVRAM0));
+   Z_ (mknod("/_mknod_fifo", S_IFIFO, 0));
+
+   Z_ (mknodat(AT_FDCWD, "./_mknodat_chr", S_IFCHR, DEVNULL));
+   Z_ (mknodat(AT_FDCWD, "./_mknodat_blk", S_IFBLK, DEVRAM0));
+   Z_ (mknodat(AT_FDCWD, "./_mknodat_fifo", S_IFIFO, 0));
+}

--- a/examples/seccomp/test.bats
+++ b/examples/seccomp/test.bats
@@ -7,6 +7,7 @@ setup () {
 
 @test "${ch_tag}/fifos only" {
     ch-run "$ch_img" -- sh -c 'ls -lh /_*'
+    # shellcheck disable=SC2016
     ch-run "$ch_img" -- sh -c 'test $(ls /_* | wc -l) == 2'
     ch-run "$ch_img" -- test -p /_mknod_fifo
     ch-run "$ch_img" -- test -p /_mknodat_fifo

--- a/examples/seccomp/test.bats
+++ b/examples/seccomp/test.bats
@@ -1,0 +1,13 @@
+CH_TEST_TAG=$ch_test_tag
+load "$CHTEST_DIR"/common.bash
+
+setup () {
+    prerequisites_ok seccomp
+}
+
+@test "${ch_tag}/fifos only" {
+    ch-run "$ch_img" -- sh -c 'ls -lh /_*'
+    ch-run "$ch_img" -- sh -c 'test $(ls /_* | wc -l) == 2'
+    ch-run "$ch_img" -- test -p /_mknod_fifo
+    ch-run "$ch_img" -- test -p /_mknodat_fifo
+}

--- a/examples/spack/Dockerfile
+++ b/examples/spack/Dockerfile
@@ -1,4 +1,3 @@
-# ch-test-scope: skip  # issue #1779
 FROM almalinux:8
 
 # Note: Spack is a bit of an odd duck testing wise. Because it’s a package


### PR DESCRIPTION
Also closes #1779.