### PR TITLE
fix scope handling

### DIFF
--- a/bin/ch-test
+++ b/bin/ch-test
@@ -363,6 +363,7 @@ scope_to_digit () {
             ;;
         *)
             fatal "scope '$scope' invalid"
+            ;;
     esac
 }
 
@@ -516,9 +517,12 @@ test_make_check_image () {
     builder_exclude=$(cat "$img" | grep -F 'ch-test-builder-exclude: ' \
                                  | sed 's/.*: //' | awk '{print $1}')
 
-    img_scope_int=$(scope_to_digit "$(cat "$img" | grep -F 'ch-test-scope' \
-                                                 | sed 's/.*: //' \
-                                                 | awk '{print $1}')")
+    img_scope_str=$(cat "$img" | grep -F 'ch-test-scope' \
+                               | sed 's/.*: //' \
+                               | awk '{print $1}')
+    [[ -n $img_scope_str ]] || fatal "no scope: $img"
+    img_scope_int=$(scope_to_digit "$img_scope_str")
+    [[ -n $img_scope_int ]] || exit 1  # set -e not working, why?
 
     sudo_required=$(cat "$img" | grep -F 'ch-test-need-sudo')
 

--- a/examples/seccomp/Dockerfile
+++ b/examples/seccomp/Dockerfile
@@ -1,3 +1,4 @@
+# ch-test-scope: standard
 # ch-test-builder-include: ch-image
 FROM alpine:3.17
 RUN apk add gcc musl-dev strace

--- a/examples/spack/Dockerfile
+++ b/examples/spack/Dockerfile
@@ -1,3 +1,4 @@
+# ch-test-scope: full
 FROM almalinux:8
 
 # Note: Spack is a bit of an odd duck testing wise. Because it’s a package


### PR DESCRIPTION
This PR fixes a bug where (1) two example Dockerfiles were missing scope and (2) this problem did not fail the tests.

The missing scope was interpreted as "quick". In particular this made CI quite a bit slower because the Spack image takes a long time to build.