### PR TITLE
tidy tar-related output

### DIFF
--- a/lib/image.py
+++ b/lib/image.py
@@ -561,6 +561,7 @@ class Image:
             # Correct absolute paths.
             if (m.name.is_absolute()):
                m.name = m.name.relative_to("/")
+               abs_ct += 1
             # Record top-level directory.
             if (len(m.name.parts) > 1 or m.isdir()):
                top_dirs.add(m.name.first)


### PR DESCRIPTION
Sometime recently, Red Hat-distributed Pythons have started warning:

> `/usr/lib64/python3.6/tarfile.py:2221`: RuntimeWarning: The default behavior of tarfile extraction has been changed to disallow common exploits (including CVE-2007-4559). By default, absolute/parent paths are disallowed and some mode bits are cleared. See https://access.redhat.com/articles/7004769 for more details. RuntimeWarning)

As a nice touch, that URL is subscriber-only. But, the listed CVE is about path sanitization in tar archives, which we already do. Therefore, suppress the warning.

This PR also makes our warning about fixing absolute member paths actually work.

The specific feature appears to be a backport of a [3.12 feature](https://peps.python.org/pep-0706/). We should keep an eye on things as this may cause further disruption in the future.