### PR TITLE
fix crash with unlinked worktrees

### DIFF
--- a/lib/build_cache.py
+++ b/lib/build_cache.py
@@ -1324,6 +1324,15 @@ class Enabled_Cache:
                                              // "*" // im.GIT_DIR)) }
       wt_gits =    { fs.Path(i).name
                      for i in glob.iglob("%s/worktrees/*" % self.root) }
+      # Unlink images that think they are in Git but are not. This should not
+      # happen, but it does, and I wasn’t able to figure out how it happened.
+      wt_gits_orphaned = wt_actuals - wt_gits
+      for img_dir in wt_gits_orphaned:
+         link = ch.storage.unpack_base // img_dir // im.GIT_DIR
+         ch.WARNING("image erroneously marked cached, fixing: %s" % link,
+                    ch.BUG_REPORT_PLZ)
+         link.unlink()
+      wt_actuals -= wt_gits_orphaned
       # Delete worktree data for images that no longer exist or aren’t
       # Git-enabled any more.
       wt_gits_deleted = wt_gits - wt_actuals
@@ -1331,7 +1340,12 @@ class Enabled_Cache:
          (ch.storage.build_cache // "worktrees" // wt).rmtree()
       ch.VERBOSE("deleted %d stale worktree metadatas" % len(wt_gits_deleted))
       wt_gits -= wt_gits_deleted
-      assert (wt_gits == wt_actuals)
+      # Validate that the pointers are in sync now.
+      if (wt_gits != wt_actuals):
+         ch.ERROR("found images -> cache links: %s" % " ".join(wt_actuals))
+         ch.ERROR("found cache -> images links: %s" % " ".join(wt_gits))
+         ch.FATAL("build cache is desynchronized, cannot proceed",
+                  ch.BUG_REPORT_PLZ)
       # If storage directory moved, repair all the paths.
       if (len(wt_gits) > 0):
          wt_dir_stored = fs.Path((   ch.storage.build_cache


### PR DESCRIPTION
`ch-image` can get into a state where all commands crash with a traceback similar to:

```
$ ch-image build -t paraview -f ./examples/paraview/Dockerfile ./examples
Traceback (most recent call last):
  File "[...]/bin/ch-image", line 332, in <module>
    main()
  File "[...]/bin/ch-image", line 319, in main
    bu.init(cli)
  File "[...]/lib/build_cache.py", line 184, in init
    cache = Enabled_Cache(cli.cache_large)
  File "[...]/lib/build_cache.py", line 677, in __init__
    self.worktrees_fix()
  File "[...]/lib/build_cache.py", line 1329, in worktrees_fix
    assert (wt_gits == wt_actuals)
AssertionError
```

The crash is because one or more images think they are a Git worktree (i.e., `img/$FOO/ch/git` exists) but Git has no record of the worktree (i.e., `bucache/worktrees/$FOO` does not)

I haven’t been able to reproduce the situation itself. We think it has something to do with mixing `--cache` (usually the default) and `--no-cache`.

This PR converts the crash to a warning and requests help reproducing the underlying bug.