### PR TITLE
fix bad escape sequences

### DIFF
--- a/lib/build_cache.py
+++ b/lib/build_cache.py
@@ -907,7 +907,7 @@ class Enabled_Cache:
             i += 1
          text = "\n".join(lines)
          text = re.sub(r"^(D|M [0-7]+ [0-9a-f]+) \.(git|weirdal_)ignore$",
-                       "#\g<0>", text, flags=re.MULTILINE)
+                       r"#\g<0>", text, flags=re.MULTILINE)
          #fs.Path("/tmp/new").file_write(text)
          self.git(["fast-import", "--force"], input=text)
          self.git(["reflog", "expire", "--all", "--expire=now"])

--- a/lib/force.py
+++ b/lib/force.py
@@ -184,7 +184,7 @@ FAKEROOT_DEFAULT_CONFIGS = {
      "match": ("/etc/redhat-release", r"release 7\."),
      "init": [ ("command -v fakeroot > /dev/null",
                 "set -e; "
-                "if ! grep -Eq '\[epel\]' /etc/yum.conf /etc/yum.repos.d/*; then "
+                r"if ! grep -Eq '\[epel\]' /etc/yum.conf /etc/yum.repos.d/*; then "
                 "yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm; "
                 "yum install -y fakeroot; "
                 "yum remove -y epel-release; "
@@ -199,7 +199,7 @@ FAKEROOT_DEFAULT_CONFIGS = {
      "match":  ("/etc/redhat-release", r"release (?![0-7]\.)"),
      "init": [ ("command -v fakeroot > /dev/null",
                 "set -e; "
-                "if ! grep -Eq '\[epel\]' /etc/yum.conf /etc/yum.repos.d/*; then "
+                r"if ! grep -Eq '\[epel\]' /etc/yum.conf /etc/yum.repos.d/*; then "
                 # Macro %rhel from *-release* RPM, e.g. redhat-release-server
                 # or centos-linux-release; thus reliable.
                 "dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-$(rpm -E %rhel).noarch.rpm; "


### PR DESCRIPTION
We were depending on unknown escape sequences passing through unchanged, which has been deprecated behavior since 3.6. In 3.12, it generates a `SyntaxWarning`, which causes some distro test suites to fail.

Closes #1834.