### PR TITLE
Adding Experiment Directory

### DIFF
--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -1096,6 +1096,10 @@ class Storage:
    @property
    def build_large(self):
       return self.root // "bularge"
+   
+   @property
+   def experiment_dir(self):
+      return self.root // "build_cache_experiment_LRM"
 
    @property
    def download_cache(self):
@@ -1186,6 +1190,7 @@ class Storage:
          self.download_cache.mkdir()
          self.build_cache.mkdir()
          self.build_large.mkdir()
+         self.experiment_dir.mkdir()
          self.unpack_base.mkdir()
          self.upload_cache.mkdir()
          if (v_found is not None):  # upgrade
@@ -1277,6 +1282,7 @@ class Storage:
       for entry in { i.name for i in (self.build_cache,
                                       self.build_large,
                                       self.download_cache,
+                                      self.experiment_dir,
                                       self.unpack_base,
                                       self.upload_cache,
                                       self.version_file) }:


### PR DESCRIPTION
Updates `lib/filesystem.py` to include an extra directory known as `experiment`, which will contain all of the data gathered from the build cache performance experiment.