### PR TITLE
fix `$CFLAGS` duplication that we’ve had since 2019

### DIFF
--- a/bin/Makefile.am
+++ b/bin/Makefile.am
@@ -13,7 +13,8 @@ if HAVE_LIBSQUASHFUSE
 ch_run_SOURCES += ch_fuse.h ch_fuse.c
 endif
 
-ch_run_CFLAGS = $(CFLAGS) $(PTHREAD_CFLAGS)
+# additional build flags for ch-run
+ch_run_CFLAGS = $(PTHREAD_CFLAGS)
 ch_run_LDADD = $(CH_RUN_LIBS)
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -941,7 +941,7 @@ Building Charliecloud
     test suite ... ${enable_test}
 
   required:
-    C99 compiler ... ${CC} ${CC_VERSION}
+    C99 compiler ... ${CC} ${CFLAGS}
 
   optional:
     extended glob patterns in --unset-env ... ${have_fnm_extmatch}


### PR DESCRIPTION
We’ve had duplicate flags in `$CC` invocations for a long time, I *think* since the introduction of Autotools in PR 589.

This is because `ch_run_CFLAGS` is *additional* flags, which I didn’t realize. This PR removes the duplication.

We also state `$CFLAGS` in `configure` and remove an unused variable there.