### PR TITLE
Spack example: use external `packages.yaml`, add patch

### DIFF
--- a/examples/spack/Dockerfile
+++ b/examples/spack/Dockerfile
@@ -13,20 +13,29 @@ FROM almalinux:8
 # Spack’s m4, and that package is in PowerTools, which we enable using sed(1)
 # to avoid installing the config-manager DNF plugin.
 #
+# autoconf, git, openssl, pkg-config, python3, fuse3-libs, fuse3-devel, are
+# packages that are typically installed on systems. Thus we install them outside
+# of Spack and rely them as externals to speed up the build process.
+#
 # [1]: https://spack.readthedocs.io/en/latest/getting_started.html
 # [2]: https://spack.readthedocs.io/en/latest/workflows.html#using-spack-to-create-docker-images
 RUN sed -Ei 's/enabled=0/enabled=1/' \
         /etc/yum.repos.d/almalinux-powertools.repo
 RUN dnf install -y --setopt=install_weak_deps=false \
+                autoconf \
+                automake \
                 bzip2 \
                 gcc \
                 gcc-c++ \
                 git \
                 gnupg2-smime \
                 file \
+                fuse3-devel \
+                fuse3-libs \
                 make \
                 patch \
-                python3 \
+                pkg-config \
+                python38 \
                 texinfo \
                 unzip \
                 which \
@@ -50,28 +59,44 @@ ARG SPACK_REPO=https://github.com/spack/spack
 RUN git clone $SPACK_REPO && cd spack && git checkout releases/latest  # slow
 RUN cd spack && git status && git rev-parse --short HEAD
 
-# Set up environment to use Spack. (We can’t use setup-env.sh because the
-# Dockerfile shell is sh, not Bash.)
-ENV PATH /spack/bin:$PATH
-RUN spack compiler find --scope system
+# Spack kludge. For some reason Spack has difficulties finding external packages
+# in /usr/lib64; create a symlink in /opt and specify that as the external
+# prefix.
+RUN ln -s /usr/lib64 /opt/lib
 
-# Test: Some basic commands.
-RUN which spack
-RUN spack --version
-RUN spack compiler find
-RUN spack compiler list
-RUN spack compiler list --scope=system
-RUN spack compiler list --scope=user
-RUN spack compilers
-RUN spack spec charliecloud
+# Copy our Spack package file; by relying on external packages already installed
+# by the container we expedite the spack install process. We do this in Spacks
+# system hierarchy, e.g., /etc/spack, however, this could also be done in the
+# user $HOME/.spack directory.
+COPY packages.yaml /etc/spack/
 
-# Test: Install Charliecloud.
+# Apply a patch that resolves issues with Charliecloud 0.35 finding the
+# Squashfuse ll.h header. Remove after https://github.com/spack/spack/pull/43374
+# is merged and included in the latest spack release.
+COPY libfuse.patch /
+RUN patch -p 0 < libfuse.patch
+
+# Test some basic commands and install Charliecloud.
 # Kludge: here we specify an older python sphinx rtd_theme version because
 # newer default version, 0.5.0, introduces a dependency on node-js which doesn’t
 # appear to build on gcc 4.8 or gcc 8.3
 # (see: https://github.com/spack/spack/issues/19310).
-RUN spack spec charliecloud+docs^py-sphinx-rtd-theme@0.4.3
-RUN spack install charliecloud+docs^py-sphinx-rtd-theme@0.4.3
+
+RUN source /spack/share/spack/setup-env.sh \
+    && spack --version \
+    && spack env create ch \
+    && spack env activate ch \
+    && spack compiler find \
+    && spack compiler list --scope=system \
+    && spack compiler list --scope=user \
+    && spack compilers \
+    && spack add charliecloud +docs +squashfuse ^py-sphinx-rtd-theme@0.4.3 \
+    && spack concretize --fresh --force \
+    && spack env depfile -o Makefile \
+    && make -j $(nproc) SPACK_COLOR=always \
+    && spack load charliecloud \
+    && ch-run --version \
+    && ldd $(which ch-run)
 
 # Clean up.
-RUN spack clean --all
+RUN /spack/bin/spack clean --all

--- a/examples/spack/Dockerfile
+++ b/examples/spack/Dockerfile
@@ -59,15 +59,10 @@ ARG SPACK_REPO=https://github.com/spack/spack
 RUN git clone $SPACK_REPO && cd spack && git checkout releases/latest  # slow
 RUN cd spack && git status && git rev-parse --short HEAD
 
-# Spack kludge. For some reason Spack has difficulties finding external packages
-# in /usr/lib64; create a symlink in /opt and specify that as the external
-# prefix.
-RUN ln -s /usr/lib64 /opt/lib
-
 # Copy our Spack package file; by relying on external packages already installed
-# by the container we expedite the spack install process. We do this in Spacks
-# system hierarchy, e.g., /etc/spack, however, this could also be done in the
-# user $HOME/.spack directory.
+# by the container we expedite the spack install process. We do this using
+# Spacks config hierarchy, e.g., /etc/spack; however, this file could also be
+# placed in the user $HOME/.spack directory.
 COPY packages.yaml /etc/spack/
 
 # Apply a patch that resolves issues with Charliecloud 0.35 finding the
@@ -81,7 +76,6 @@ RUN patch -p 0 < libfuse.patch
 # newer default version, 0.5.0, introduces a dependency on node-js which doesn’t
 # appear to build on gcc 4.8 or gcc 8.3
 # (see: https://github.com/spack/spack/issues/19310).
-
 RUN source /spack/share/spack/setup-env.sh \
     && spack --version \
     && spack env create ch \

--- a/examples/spack/libfuse.patch
+++ b/examples/spack/libfuse.patch
@@ -1,0 +1,9 @@
+index 0e8f983545..b85ef9958a 100644
+--- spack/var/spack/repos/builtin/packages/charliecloud/package.py
++++ spack/var/spack/repos/builtin/packages/charliecloud/package.py
+@@ -152,5 +152,7 @@ def configure_args(self):
+         if "+squashfuse" in self.spec:
+             squashfuse_prefix = "{0}".format(self.spec["squashfuse"].prefix)
+             args.append("--with-libsquashfuse={0}".format(squashfuse_prefix))
++            fuse_include = self.spec["fuse"].prefix.include.fuse3
++            args.append("CFLAGS=-I{0}".format(fuse_include))

--- a/examples/spack/packages.yaml
+++ b/examples/spack/packages.yaml
@@ -1,0 +1,47 @@
+packages:
+  # The following packages are built externally to speed up the spack build
+  # process; they can be built from spack without issue, e.g., you can remove
+  # them from here without issue.
+  autoconf:
+    buildable: false
+    externals:
+      - spec: autoconf@2.69
+        prefix: /usr
+  automake:
+    buildable: false
+    externals:
+      - spec: automake@1.16.1
+        prefix: /usr
+  git:
+    buildable: false
+    externals:
+      - spec: git@2.39.3
+        prefix: /usr
+  perl:
+    buildable: false
+    externals:
+      - spec: perl@5.26.3
+        prefix: /usr
+  pkgconf:
+    buildable: false
+    externals:
+      - spec: pkgconf@1.4.2
+        prefix: /usr
+  python:
+    buildable: false
+    externals:
+      - spec: python@3.8.17
+        prefix: /usr
+  openssl:
+    buildable: false
+    externals:
+      - spec: openssl@1.1.1
+        prefix: /usr
+
+# Unlike the above, the following packages require a sysadmin. Removing these
+# will likely cause issues.
+  libfuse:
+    buildable: false
+    externals:
+      - spec: libfuse@3.3.0
+        prefix: /usr

--- a/misc/loc
+++ b/misc/loc
@@ -243,6 +243,8 @@ find ./.github ./examples ./test -type f -a \( \
      -o -path ./test/fixtures/README \
      -o -path ./.github/PERUSEME \
      -o -path ./examples/chtest/printns \
+     -o -path ./examples/spack/packages.yaml \
+     -o -path ./examples/spack/libfuse.patch \
      -o -path ./test/approved-trailing-whitespace \
      -o -path ./test/common.bash \
      -o -path ./test/doctest-auto \


### PR DESCRIPTION
This PR adds a number of changes.

1. add `packages.yaml`; tell spack to make use of external (container supplied) packages, including libfuse for `+squashfuse1` variant.
2. use spack envrionments to make use of the parallel building feature.
3. add `libfuse.patch`, see https://github.com/spack/spack/pull/43374. This effectively resolves https://github.com/hpc/charliecloud/issues/1847.

This makes the Spack example take 4 minutes and 40 seconds from start to finish, with `--no-cache`.