### PR TITLE
`configure.ac`: add missed `fnctl.h`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -343,6 +343,7 @@ AC_MSG_RESULT($have_userns)
 AC_DEFUN([CH_OVERLAY_C], [[
   #define _GNU_SOURCE
   #include <errno.h>
+  #include <fcntl.h>
   #include <sched.h>
   #include <stdio.h>
   #include <stdlib.h>


### PR DESCRIPTION
`open(2)` is [documented](https://man7.org/linux/man-pages/man2/open.2.html) to require `fnctl.h`. We weren’t including it explicitly, but it worked, I assume because we got `fnctl.h` indirectly. However this is apparently not true on Ubuntu 22.04, and regardless we should include the documented file.