### PR TITLE
Mksquashfs quiet using '-quiet' flag

### DIFF
--- a/bin/ch-convert
+++ b/bin/ch-convert
@@ -116,8 +116,13 @@ cv_dir_squash () {
     # Exclude build cache metadata. 64kiB block size based on Shane’s
     # experiments.
     # shellcheck disable=SC2086
-    quiet mksquashfs "$1" "$2" $squash_xattr_arg -b 65536 -noappend -all-root \
+    if mksquashfs --help 2>&1 | grep "quieti"; then 
+       mksquashfs "$1" "$2" $squash_xattr_arg -b 65536 -noappend -all-root \
+                         -pf "$pflist" -e "$1"/ch/git -e "$1"/ch/git.pickle -quiet
+    else
+       quiet mksquashfs "$1" "$2" $squash_xattr_arg -b 65536 -noappend -all-root \
                          -pf "$pflist" -e "$1"/ch/git -e "$1"/ch/git.pickle
+    fi
     # Zero the archive’s internal modification time at bytes 8–11, 0-indexed
     # [1]. Newer SquashFS-Tools ≥4.3 have option “-fstime 0” to do this, but
     # CentOS 7 comes with 4.2.  [1]: https://dr-emann.github.io/squashfs/


### PR DESCRIPTION
Fixes issue #1210 
Uses the '-quiet' flag on mksquashfs. 
If the grep cmd is able to find the '-quiet' flag in the mksquashfs help menu, then we use the '-quiet' flag because this flag is only available on mksquashf version 4.4 or higher.