### PR TITLE
Fix can’t unlink: part_ no such directory

### DIFF
--- a/lib/filesystem.py
+++ b/lib/filesystem.py
@@ -1144,6 +1144,7 @@ class Storage:
       part_ct = 0
       for path in self.download_cache.glob("part_*"):
          path = Path(path)
+         path = self.download_cache // path.name
          ch.VERBOSE("deleting: %s" % path)
          path.unlink()
          part_ct += 1

--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -557,11 +557,15 @@ EOF
 }
 
 @test 'remove part_ files' {
-    export CH_IMAGE_STORAGE=/var/tmp/albug
+    export CH_IMAGE_STORAGE=/var/tmp/tmpdir
+    ch-image pull alpine
 
-    # create a part_ file 
-    touch /var/tmp/albug/dlcache/part_PROBLEM
-    
+   # create directory
+    mkdir -p /var/tmp/tmpdir/dlcache
+
+    # create a part_ file
+    touch /var/tmp/tmpdir/dlcache/part_PROBLEM
+
     # list images to invoke error
     set +e
     out=$(ch-image list 2>&1)
@@ -571,12 +575,13 @@ EOF
     echo "--- return code: ${retcode}"
     echo '--- output:'
     echo "$out"
- 
+
+    # clean up the directory
+    rm -rf /var/tmp/tmpdir
+
     # check if output errors
     if [[ $retcode -ne 0 ]]; then
         echo "fail: part_ file wasn't cleaned properly."
-        # Clean up the file if the test fails
-        rm /var/tmp/albug/dlcache/part_PROBLEM
         exit 1
     fi
 }

--- a/test/build/40_pull.bats
+++ b/test/build/40_pull.bats
@@ -555,3 +555,28 @@ EOF
     [[ $status -eq 1 ]]
     [[ $output = *'registry-1.docker.io:443/charliecloud/metadata:doesnotexist'* ]]
 }
+
+@test 'remove part_ files' {
+    export CH_IMAGE_STORAGE=/var/tmp/albug
+
+    # create a part_ file 
+    touch /var/tmp/albug/dlcache/part_PROBLEM
+    
+    # list images to invoke error
+    set +e
+    out=$(ch-image list 2>&1)
+    retcode=$?
+    set -e
+
+    echo "--- return code: ${retcode}"
+    echo '--- output:'
+    echo "$out"
+ 
+    # check if output errors
+    if [[ $retcode -ne 0 ]]; then
+        echo "fail: part_ file wasn't cleaned properly."
+        # Clean up the file if the test fails
+        rm /var/tmp/albug/dlcache/part_PROBLEM
+        exit 1
+    fi
+}


### PR DESCRIPTION
Fixes #1925 

* Fix the cleanup function to use the full path to unlink part_ files.
* Write a test called 'remove part_ files' to see if cleanup is correctly removing part_ files during cleanup.