### PR TITLE
ch-run: run SIF files

### DIFF
--- a/bin/ch-run.c
+++ b/bin/ch-run.c
@@ -208,6 +208,10 @@ int main(int argc, char *argv[])
       Tf (!args.c.writable || args.unsafe,
           "--write invalid when running by name");
       break;
+   case IMG_SIF:
+      INFO("SIF file detected!");
+      //args.c.newroot = realpath_(args.c.img_ref, false);
+      break;
    case IMG_SQUASH:
 #ifndef HAVE_LIBSQUASHFUSE
       FATAL(0, "this ch-run does not support internal SquashFS mounts");

--- a/bin/ch_core.h
+++ b/bin/ch_core.h
@@ -22,6 +22,7 @@ struct bind {
 
 enum img_type {
    IMG_DIRECTORY,  // normal directory, perhaps an external mount of some kind
+   IMG_SIF,        // SIF file (squash portion not yet mounted)
    IMG_SQUASH,     // SquashFS archive file (not yet mounted)
    IMG_NAME,       // name of image in storage
    IMG_NONE,       // image type is not set yet
@@ -53,6 +54,7 @@ void containerize(struct container *c);
 enum img_type image_type(const char *ref, const char *images_dir);
 char *img_name2path(const char *name, const char *storage_dir);
 void run_user_command(char *argv[], const char *initial_dir);
+char *to_string(char *c);
 #ifdef HAVE_SECCOMP
 void seccomp_install(void);
 #endif

--- a/bin/ch_fuse.h
+++ b/bin/ch_fuse.h
@@ -5,3 +5,4 @@
 /** Function prototypes **/
 
 void sq_fork(struct container *c);
+int sq_offset(const char *sif_path);


### PR DESCRIPTION
ch-run can now identify, validate, and run SIF files (see: https://github.com/sylabs/sif/tree/main).
```ch-run [OPTION...] IMAGE -- COMMAND [ARG...]```
When given an image, we will identify and validate the file by looking through the SIF header and obtaining the ```SIF_MAGIC``` constant. This constant confirms it is a SIF file.

Since a SIF file is a squash image with some extra metadata (header and signatures at end of file), we need to find the byte offset of the squash portion to feed to ```ch_fuse.c``` and continue the usual squash mount/run.

Comparison example:
```
kchilleri@dev:/usr/local/src/charliecloud$ ch-run --verbose /home/kchilleri/charliecloud_dev/sif_files/alpine.sqfs -- true
ch-run[49244]: squash image file magic expected: 6873 7173; actual: 6873 7173 (ch_core.c:413)
ch-run[49244]: verbosity: 1 (ch-run.c:239)
ch-run[49244]: image: /home/kchilleri/charliecloud_dev/sif_files/alpine.sqfs (ch-run.c:240)
ch-run[49244]: storage: /var/tmp/kchilleri.ch (ch-run.c:241)
ch-run[49244]: newroot: (null) (ch-run.c:242)
ch-run[49244]: container uid: 1000 (ch-run.c:243)
ch-run[49244]: container gid: 1000 (ch-run.c:244)
ch-run[49244]: join: 0 0 (null) 0 (ch-run.c:245)
ch-run[49244]: private /tmp: 0 (ch-run.c:247)
ch-run[49244]: seccomp: 0 (ch-run.c:249)
ch-run[49244]: unsafe: 0 (ch-run.c:251)
ch-run[49244]: using default mount point: /var/tmp/kchilleri.ch/mnt (ch_fuse.c:127)
ch-run[49244]: Squash byte offset: 0
 (ch_fuse.c:240)
ch-run[49244]: Magic number at this position: 6873 7173
 (ch_fuse.c:241)
ch-run[49245]: executing: true (ch_core.c:586)
ch-run[49244]: FUSE loop terminated successfully (ch_fuse.c:187)
ch-run[49244]: child terminated normally with exit code 0 (ch_fuse.c:196)
ch-run[49244]: unmounting: /var/tmp/kchilleri.ch/mnt (ch_fuse.c:212)
ch-run[49244]: FUSE loop done (ch_fuse.c:216)
```
```
kchilleri@dev:/usr/local/src/charliecloud$ ch-run --verbose /home/kchilleri/charliecloud_dev/sif_files/alpine.sif -- true
ch-run[49261]: squash image file magic expected: 6873 7173; actual: 2321 2f75 (ch_core.c:413)
ch-run[49261]: sif file magic expected: SIF_MAGIC: actual: SIF_MAGIC (ch_core.c:430)
ch-run[49261]: SIF file detected! (ch-run.c:212)
ch-run[49261]: verbosity: 1 (ch-run.c:239)
ch-run[49261]: image: /home/kchilleri/charliecloud_dev/sif_files/alpine.sif (ch-run.c:240)
ch-run[49261]: storage: /var/tmp/kchilleri.ch (ch-run.c:241)
ch-run[49261]: newroot: (null) (ch-run.c:242)
ch-run[49261]: container uid: 1000 (ch-run.c:243)
ch-run[49261]: container gid: 1000 (ch-run.c:244)
ch-run[49261]: join: 0 0 (null) 0 (ch-run.c:245)
ch-run[49261]: private /tmp: 0 (ch-run.c:247)
ch-run[49261]: seccomp: 0 (ch-run.c:249)
ch-run[49261]: unsafe: 0 (ch-run.c:251)
ch-run[49261]: using default mount point: /var/tmp/kchilleri.ch/mnt (ch_fuse.c:127)
ch-run[49261]: Squash byte offset: 262144
 (ch_fuse.c:240)
ch-run[49261]: Magic number at this position: 6873 7173
 (ch_fuse.c:241)
ch-run[49262]: executing: true (ch_core.c:586)
ch-run[49261]: FUSE loop terminated successfully (ch_fuse.c:187)
ch-run[49261]: child terminated normally with exit code 0 (ch_fuse.c:196)
ch-run[49261]: unmounting: /var/tmp/kchilleri.ch/mnt (ch_fuse.c:212)
ch-run[49261]: FUSE loop done (ch_fuse.c:216)
```
closes #1749